### PR TITLE
Accept Enter/Return as confirm keys in authentication flow.

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using UnityEditor;
 
@@ -26,6 +26,7 @@ namespace GitHub.Unity
         [NonSerialized] private bool need2fa;
         [NonSerialized] private bool busy;
         [NonSerialized] private string message;
+        [NonSerialized] private bool enterPressed;
 
         [NonSerialized] private AuthenticationService authenticationService;
         private AuthenticationService AuthenticationService
@@ -73,6 +74,8 @@ namespace GitHub.Unity
 
         public override void OnGUI()
         {
+            HandleEnterPressed();
+
             scroll = GUILayout.BeginScrollView(scroll);
             {
                 Rect authHeader = EditorGUILayout.BeginHorizontal(Styles.AuthHeaderBoxStyle);
@@ -116,6 +119,16 @@ namespace GitHub.Unity
             GUILayout.EndScrollView();
         }
 
+        private void HandleEnterPressed()
+        {
+            if (Event.current.type != EventType.KeyDown)
+                return;
+
+            enterPressed = Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter;
+            if (enterPressed)
+                Event.current.Use();
+        }
+
         private void OnGUILogin()
         {
             GUILayout.Space(3);
@@ -142,7 +155,7 @@ namespace GitHub.Unity
             if (busy) GUI.enabled = false;
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
-            if (GUILayout.Button(loginButton))
+            if (GUILayout.Button(loginButton) || (GUI.enabled && enterPressed))
             {
                 GUI.FocusControl(null);
                 busy = true;
@@ -185,7 +198,7 @@ namespace GitHub.Unity
 
             GUILayout.Space(Styles.BaseSpacing);
 
-            if (GUILayout.Button(twofaButton))
+            if (GUILayout.Button(twofaButton) || (GUI.enabled && enterPressed))
             {
                 GUI.FocusControl(null);
                 busy = true;


### PR DESCRIPTION
### Description of the Change

Change to make Enter/Return be used as confirmation keys in the authentication window flow. Enter/Return will have the same behavior as the "Sign In" button in Username/Password state, and "Verify" button in 2FA state.

### Alternate Designs

None

### Benefits

UX expectation when working with form-like interfaces.

### Possible Drawbacks

Possible future consideration. The way this is being handled is checking for enter/return at the beginning of OnGUI, which consumes the event before the rest of the window can process it. We do this because we want to intercept the event before the textfields do. With the current flow it's not a problem, but if the flow changed in a way where a control would want to receive enter/return, then we'd need to change how this works.

### Applicable Issues

N/A
