### PR TITLE
Fix appveyor build now that the project is public

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ environment:
 clone_script:
 - ps: >-
     if(-not $env:appveyor_pull_request_number) {
-      git lfs clone -q -n --branch=$env:appveyor_repo_branch git@github.com:$env:appveyor_repo_name.git $env:appveyor_build_folder
+      git lfs clone -q -n --branch=$env:appveyor_repo_branch https://github.com/$env:appveyor_repo_name.git $env:appveyor_build_folder
       git checkout -qf $env:appveyor_repo_commit
     } else {
-      git lfs clone -q -n git@github.com:$env:appveyor_repo_name.git $env:appveyor_build_folder
+      git lfs clone -q -n https://github.com/$env:appveyor_repo_name.git $env:appveyor_build_folder
       git fetch -q origin +refs/pull/$env:appveyor_pull_request_number/merge:
       git lfs fetch origin FETCH_HEAD
       git checkout -qf FETCH_HEAD


### PR DESCRIPTION
Need some new urls for cloning things, looks like appveyor only uses ssh if the project is private