### PR TITLE
Cleaning unused fields left over from PR #74

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -33,10 +33,6 @@ namespace GitHub.Unity
         private const string FetchActionTitle = "Fetch Changes";
         private const string FetchButtonText = "Fetch";
         private const string FetchFailureDescription = "Could not fetch changes";
-        private const string FetchConfirmTitle = "Fetch Changes?";
-        private const string FetchConfirmDescription = "Would you like to fetch changes from remote '{0}'?";
-        private const string FetchConfirmYes = "Fetch";
-        private const string FetchConfirmCancel = "Cancel";
         private const int HistoryExtraItemCount = 10;
         private const float MaxChangelistHeightRatio = .2f;
 


### PR DESCRIPTION
There was some leftover unused fields from https://github.com/github-for-unity/Unity/pull/74 that don't need to be here.