### PR TITLE
Fix to improve performance of ChangesTreeView

### DIFF
--- a/src/GitHub.Api/UI/TreeBuilder.cs
+++ b/src/GitHub.Api/UI/TreeBuilder.cs
@@ -77,6 +77,7 @@ namespace GitHub.Unity
             Guard.ArgumentNotNullOrEmpty(newEntries, "newEntries");
 
             var newEntriesSetByPath = new HashSet<string>(newEntries.Select(entry => entry.Path));
+            var gitStatusEntriesSetByPath = new HashSet<string>(gitStatusEntries.Select(entry => entry.Path));
 
             // Remove what got nuked
             for (var index = 0; index < gitStatusEntries.Count;)
@@ -95,7 +96,7 @@ namespace GitHub.Unity
             // Remove folding state of nuked items
             for (var index = 0; index < foldedTreeEntries.Count;)
             {
-                if (!newEntries.Any(e => e.Path.IndexOf(foldedTreeEntries[index]) == 0))
+                if (newEntries.All(e => e.Path.IndexOf(foldedTreeEntries[index], StringComparison.CurrentCulture) != 0))
                 {
                     foldedTreeEntries.RemoveAt(index);
                 }
@@ -109,7 +110,7 @@ namespace GitHub.Unity
             for (var index = 0; index < newEntries.Count; ++index)
             {
                 var entry = newEntries[index];
-                if (!gitStatusEntries.Contains(entry))
+                if (!gitStatusEntriesSetByPath.Contains(entry.Path))
                 {
                     gitStatusEntries.Add(entry);
                     gitCommitTargets.Add(new GitCommitTarget());

--- a/src/GitHub.Api/UI/TreeBuilder.cs
+++ b/src/GitHub.Api/UI/TreeBuilder.cs
@@ -49,10 +49,11 @@ namespace GitHub.Unity
             {
                 // Look for a branch matching our root in the existing children
                 var found = false;
+                var searchLabel = nodePath.Parent.Combine(nodePath.FileNameWithoutExtension);
                 foreach (var child in parent.Children)
                 {
                     // If we found the branch, continue building from that branch
-                    if (child.Label.Equals(nodePath.Parent.Combine(nodePath.FileNameWithoutExtension)))
+                    if (child.Label.Equals(searchLabel))
                     {
                         found = true;
                         BuildChildNode(child, node, foldedTreeEntries1, stateChangeCallback1);

--- a/src/GitHub.Api/UI/TreeBuilder.cs
+++ b/src/GitHub.Api/UI/TreeBuilder.cs
@@ -76,10 +76,12 @@ namespace GitHub.Unity
         {
             Guard.ArgumentNotNullOrEmpty(newEntries, "newEntries");
 
+            var newEntriesSetByPath = new HashSet<string>(newEntries.Select(entry => entry.Path));
+
             // Remove what got nuked
             for (var index = 0; index < gitStatusEntries.Count;)
             {
-                if (!newEntries.Contains(gitStatusEntries[index]))
+                if (!newEntriesSetByPath.Contains(gitStatusEntries[index].Path))
                 {
                     gitStatusEntries.RemoveAt(index);
                     gitCommitTargets.RemoveAt(index);

--- a/src/GitHub.Api/UI/TreeBuilder.cs
+++ b/src/GitHub.Api/UI/TreeBuilder.cs
@@ -6,7 +6,7 @@ namespace GitHub.Unity
 {
     static class TreeBuilder
     {
-        internal static void BuildChildNode(FileTreeNode parent, FileTreeNode node, List<string> foldedTreeEntries1, Action<FileTreeNode> stateChangeCallback1)
+        internal static void BuildChildNode(FileTreeNode parent, FileTreeNode node, HashSet<string> foldedTreeSet, Action<FileTreeNode> stateChangeCallback)
         {
             if (String.IsNullOrEmpty(node.Label))
             {
@@ -15,7 +15,7 @@ namespace GitHub.Unity
             }
 
             node.RepositoryPath = parent.RepositoryPath.ToNPath().Combine(node.Label);
-            parent.Open = !foldedTreeEntries1.Contains(parent.RepositoryPath);
+            parent.Open = !foldedTreeSet.Contains(parent.RepositoryPath);
 
             // Is this node inside a folder?
             var nodePath = node.Label.ToNPath();
@@ -33,7 +33,7 @@ namespace GitHub.Unity
                     if (child.Label.Equals(root))
                     {
                         found = true;
-                        BuildChildNode(child, node, foldedTreeEntries1, stateChangeCallback1);
+                        BuildChildNode(child, node, foldedTreeSet, stateChangeCallback);
                         break;
                     }
                 }
@@ -42,7 +42,7 @@ namespace GitHub.Unity
                 if (!found)
                 {
                     var p = parent.RepositoryPath.ToNPath().Combine(root);
-                    BuildChildNode(parent.Add(new FileTreeNode(root, stateChangeCallback1) { RepositoryPath = p }), node, foldedTreeEntries1, stateChangeCallback1);
+                    BuildChildNode(parent.Add(new FileTreeNode(root, stateChangeCallback) { RepositoryPath = p }), node, foldedTreeSet, stateChangeCallback);
                 }
             }
             else if (nodePath.ExtensionWithDot == ".meta")
@@ -56,7 +56,7 @@ namespace GitHub.Unity
                     if (child.Label.Equals(searchLabel))
                     {
                         found = true;
-                        BuildChildNode(child, node, foldedTreeEntries1, stateChangeCallback1);
+                        BuildChildNode(child, node, foldedTreeSet, stateChangeCallback);
                         break;
                     }
                 }
@@ -106,6 +106,8 @@ namespace GitHub.Unity
                 }
             }
 
+            var foldedTreeSet = new HashSet<string>(foldedTreeEntries);
+
             // Add new stuff
             for (var index = 0; index < newEntries.Count; ++index)
             {
@@ -136,7 +138,7 @@ namespace GitHub.Unity
                     node.Icon = iconLoaderFunc?.Invoke(gitStatusEntry.ProjectPath);
                 }
 
-                BuildChildNode(tree, node, foldedTreeEntries, stateChangeCallback);
+                BuildChildNode(tree, node, foldedTreeSet, stateChangeCallback);
             }
 
             return tree;


### PR DESCRIPTION
Attempted #23 

performance test used pumps two sequences into `TreeBuilder.BuildTreeRoot()`:
1. Simple Test
  a. The first sequence contains 200 `GitStatusEntry` objects.
    1. There are 10 folders, with 10 files and 10 meta files.
  a. The second sequence contains 300 `GitStatusEntry` objects.
    1. Out of the original dataset every other file is retained.
      a. There are 10 folders, with 5 files and 5 meta files.
      a. Half of the original files can be considered "removed".
      a. An additional 10 folders, with 10 files and 10 meta files.
1. Advanced Test
  a. The first sequence contains 800 `GitStatusEntry` objects.
    1. There are 20 folders, with 20 files and 20 meta files.
  a. The second sequence contains 1200 `GitStatusEntry` objects.
    1. Out of the original dataset every other file is retained.
      a. There are 10 folders, with 10 files and 10 meta files.
      a. Half of the original files can be considered "removed".
      a. An additional 20 folders, with 20 files and 20 meta files.

|                       Method |     Mean |    Error |   StdDev |
|----------------------------- |---------|---------|---------|
 |Basic Test - Currently| 70.71 ms | 1.3993 ms | 1.3743 ms |
 |Basic Test - PR|   26.77 ms | 0.6483 ms | 0.6657 ms |
 |Heavy Test - Currently|754.46 ms | 6.6629 ms | 5.9064 ms |
 |Heavy Test - PR| 110.11 ms | 2.1563 ms | 2.2143 ms |

This branch will let you reproduce the performance test framework:
https://github.com/github-for-unity/Unity/tree/fixes/changes-view-performance-proof
Run the PerformanceTest project un-attached in Release mode.
It will take approx 8-9 minutes to complete.

Overall the PR starts at a third of the time of the current code base, and the amount of time it takes to execute grows bu half of the current code base.

Depends on:
- [x] #120 
- [x] #121
- [x] #133 