### PR TITLE
Fixing package.sh to run correctly on bash in windows

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -23,7 +23,7 @@ git clean -xdf
 popd
 
 OS="Mac"
-if [ -e "/c/" ]; then
+if [ -e "c:\\" ]; then
 	OS="Windows"
 fi
 
@@ -37,7 +37,7 @@ if [ x"$OS" == x"Windows" ]; then
 else
 	if [ -f "$1/Unity.app/Contents/MacOS/Unity" ]; then
 		Unity="$1/Unity.app/Contents/MacOS/Unity"
-	elif [ -f $1/Unity ]; then
+	elif [ -f "$1/Unity" ]; then
 		Unity="$1/Unity"
 	else
 		echo "Can't find Unity in $1"

--- a/package.sh
+++ b/package.sh
@@ -22,18 +22,27 @@ pushd src
 git clean -xdf
 popd
 
-if [ -f "$1/Unity.app/Contents/MacOS/Unity" ]; then
-	Unity="$1/Unity.app/Contents/MacOS/Unity"
-elif [ -f $1/Unity ]; then
-	Unity="$1/Unity"
-else
-	echo "Can't find Unity in $1"
-	exit 1
-fi
-
 OS="Mac"
 if [ -e "/c/" ]; then
 	OS="Windows"
+fi
+
+if [ x"$OS" == x"Windows" ]; then
+	if [ -f "$1/Editor/Unity.exe" ]; then
+		Unity="$1/Editor/Unity.exe"
+	else
+		echo "Can't find Unity in $1"
+		exit 1
+	fi
+else
+	if [ -f "$1/Unity.app/Contents/MacOS/Unity" ]; then
+		Unity="$1/Unity.app/Contents/MacOS/Unity"
+	elif [ -f $1/Unity ]; then
+		Unity="$1/Unity"
+	else
+		echo "Can't find Unity in $1"
+		exit 1
+	fi
 fi
 
 if [ x"$OS" == x"Windows" ]; then


### PR DESCRIPTION
Fixes #97 

`./package.sh "/c/Program\ Files/Unity\ 5.5/"`