### PR TITLE
Fix to prevent a view from being initialized twice

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -70,7 +70,6 @@ namespace GitHub.Unity
             ChangesTab.InitializeView(this);
             BranchesTab.InitializeView(this);
             SettingsTab.InitializeView(this);
-            ActiveTab.InitializeView(this);
         }
 
         public override void OnEnable()


### PR DESCRIPTION
I'm tracing logs and noticing some things are getting called twice.