### PR TITLE
Refactor repository manager

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -420,7 +420,7 @@ namespace GitHub.Unity
 
         private void OnLocalBranchChanged(string name)
         {
-            if (name == this.Repository.CurrentBranch)
+            if (name == ActiveBranch?.Name)
             {
                 OnActiveBranchChanged?.Invoke();
                 OnRepositoryUpdatedHandler();


### PR DESCRIPTION
`RepositoryManager`  calls `Repository.CurrentBranch`
`Repository.CurrentBranch` returns `RepositoryManager.ActiveBranch?.Name`

I'm changing `RepositoryManager` to reduce a hop in the returned data.