### PR TITLE
Repository Refactor

### DIFF
--- a/src/GitHub.Api/Git/GitConfig.cs
+++ b/src/GitHub.Api/Git/GitConfig.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -41,16 +41,17 @@ namespace GitHub.Unity
         /// <summary>
         /// Gets the current remote of the repository.
         /// </summary>
-        ConfigRemote? CurrentRemote { get; }
+        ConfigRemote? CurrentRemote { get; set; }
         /// <summary>
         /// Gets the current branch of the repository.
         /// </summary>
-        string CurrentBranch { get; }
-        GitStatus CurrentStatus { get; }
+        ConfigBranch? CurrentBranch { get; set; }
+        GitStatus CurrentStatus { get; set; }
         IEnumerable<GitBranch> LocalBranches { get; }
         IEnumerable<GitBranch> RemoteBranches { get; }
         IUser User { get; set; }
         IEnumerable<GitLock> CurrentLocks { get; }
+        string CurrentBranchName { get; }
 
         event Action<GitStatus> OnStatusUpdated;
         event Action<string> OnActiveBranchChanged;

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -124,7 +124,6 @@ namespace GitHub.Unity
 
         private void RepositoryManager_OnStatusUpdated(GitStatus status)
         {
-            CurrentStatus = status;
             OnStatusUpdated?.Invoke(CurrentStatus);
         }
 
@@ -209,7 +208,8 @@ namespace GitHub.Unity
             LocalPath,
             GetHashCode());
 
-        public GitStatus CurrentStatus { get; private set; }
+        public GitStatus CurrentStatus => repositoryManager.CurrentStatus;
+
         public IUser User { get; set; }
         public IEnumerable<GitLock> CurrentLocks { get; private set; }
         protected static ILogging Logger { get; } = Logging.GetLogger<Repository>();

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -10,7 +10,6 @@ namespace GitHub.Unity
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     class Repository : IRepository, IEquatable<Repository>
     {
-        private readonly IGitClient gitClient;
         private readonly IRepositoryManager repositoryManager;
 
         public event Action<GitStatus> OnRepositoryChanged;
@@ -29,18 +28,15 @@ namespace GitHub.Unity
         /// <summary>
         /// Initializes a new instance of the <see cref="Repository"/> class.
         /// </summary>
-        /// <param name="gitClient"></param>
         /// <param name="repositoryManager"></param>
         /// <param name="name">The repository name.</param>
         /// <param name="cloneUrl">The repository's clone URL.</param>
         /// <param name="localPath"></param>
-        public Repository(IGitClient gitClient, IRepositoryManager repositoryManager, string name, UriString cloneUrl, NPath localPath)
+        public Repository(IRepositoryManager repositoryManager, string name, UriString cloneUrl, NPath localPath)
         {
             Guard.ArgumentNotNull(repositoryManager, nameof(repositoryManager));
             Guard.ArgumentNotNullOrWhiteSpace(name, nameof(name));
-            Guard.ArgumentNotNull(cloneUrl, nameof(cloneUrl));
 
-            this.gitClient = gitClient;
             this.repositoryManager = repositoryManager;
             Name = name;
             CloneUrl = cloneUrl;

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -30,16 +30,14 @@ namespace GitHub.Unity
         /// </summary>
         /// <param name="repositoryManager"></param>
         /// <param name="name">The repository name.</param>
-        /// <param name="cloneUrl">The repository's clone URL.</param>
         /// <param name="localPath"></param>
-        public Repository(IRepositoryManager repositoryManager, string name, UriString cloneUrl, NPath localPath)
+        public Repository(IRepositoryManager repositoryManager, string name, NPath localPath)
         {
             Guard.ArgumentNotNull(repositoryManager, nameof(repositoryManager));
             Guard.ArgumentNotNullOrWhiteSpace(name, nameof(name));
 
             this.repositoryManager = repositoryManager;
             Name = name;
-            CloneUrl = cloneUrl;
             LocalPath = localPath;
 
             repositoryManager.OnRepositoryChanged += RepositoryManager_OnRepositoryChanged;
@@ -48,11 +46,6 @@ namespace GitHub.Unity
             repositoryManager.OnLocalBranchListChanged += RepositoryManager_OnLocalBranchListChanged;
             repositoryManager.OnHeadChanged += RepositoryManager_OnHeadChanged;
             repositoryManager.OnLocksUpdated += RepositoryManager_OnLocksUpdated;
-
-            if (String.IsNullOrEmpty(CloneUrl))
-            {
-                repositoryManager.OnRemoteOrTrackingChanged += RepositoryManager_OnRemoteOrTrackingChanged; ;
-            }
         }
 
         public void Refresh()
@@ -107,16 +100,6 @@ namespace GitHub.Unity
         public ITask ReleaseLock(string file, bool force)
         {
             return repositoryManager.UnlockFile(file, force);
-        }
-
-        private void RepositoryManager_OnRemoteOrTrackingChanged()
-        {
-            var remote = repositoryManager.Config.GetRemotes()
-                            .Where(x => HostAddress.Create(new UriString(x.Url).ToRepositoryUri()).IsGitHubDotCom())
-                            .FirstOrDefault();
-
-            if (remote.Url != null)
-                CloneUrl = new UriString(remote.Url).ToRepositoryUrl();
         }
 
         private void RepositoryManager_OnHeadChanged()
@@ -208,8 +191,12 @@ namespace GitHub.Unity
             }
         }
 
+        public UriString CloneUrl
+        {
+            get { return repositoryManager.CloneUrl; }
+        }
+
         public string Name { get; private set; }
-        public UriString CloneUrl { get; private set; }
         public NPath LocalPath { get; private set; }
         public string Owner => CloneUrl?.Owner ?? string.Empty;
         public bool IsGitHub { get { return CloneUrl != ""; } }

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -179,7 +179,7 @@ namespace GitHub.Unity
                 cloneUrl = new UriString(remote.Value.Url).ToRepositoryUrl();
             }
 
-            repository = new Repository(gitClient, this, repositoryPaths.RepositoryPath.FileName, cloneUrl,
+            repository = new Repository(this, repositoryPaths.RepositoryPath.FileName, cloneUrl,
                 repositoryPaths.RepositoryPath);
         }
 

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -44,6 +44,7 @@ namespace GitHub.Unity
         ITask ListLocks(bool local);
         ITask LockFile(string file);
         ITask UnlockFile(string file, bool force);
+        GitStatus CurrentStatus { get; }
     }
 
     interface IRepositoryPathConfiguration
@@ -118,6 +119,7 @@ namespace GitHub.Unity
         private readonly IGitClient gitClient;
         private readonly IRepositoryWatcher watcher;
 
+        private GitStatus currentStatus;
         private ConfigBranch? activeBranch;
         private ConfigRemote? activeRemote;
         private string head;
@@ -356,7 +358,7 @@ namespace GitHub.Unity
                 {
                     if (success && data.HasValue)
                     {
-                        OnStatusUpdated?.Invoke(data.Value);
+                        CurrentStatus = data.Value;
                     }
                     Logger.Trace("Updated Git Status");
                 });
@@ -639,6 +641,15 @@ namespace GitHub.Unity
             }
         }
 
+        public GitStatus CurrentStatus
+        {
+            get { return currentStatus; }
+            set
+            {
+                currentStatus = value;
+                OnStatusUpdated?.Invoke(value);
+            }
+        }
 
         public UriString CloneUrl
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -113,6 +113,7 @@ namespace GitHub.Unity
 
         private void UpdateStatus(GitStatus status)
         {
+            // TODO: this shouldn't be updated here, it should be updated whenever the active remote changes
             currentRemote = Repository.CurrentRemote.HasValue ? Repository.CurrentRemote.Value.Name : null;
             statusAhead = status.Ahead;
             statusBehind = status.Behind;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 
@@ -170,7 +169,7 @@ namespace GitHub.Unity
 
                     GUILayout.Label(headerRepoLabelText, Styles.HeaderRepoLabelStyle);
                     GUILayout.Space(-2);
-                    GUILayout.Label(Repository.CurrentBranch, Styles.HeaderBranchLabelStyle);
+                    GUILayout.Label(Repository.CurrentBranchName, Styles.HeaderBranchLabelStyle);
                 }
                 GUILayout.EndVertical();
             }

--- a/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace IntegrationTests
 {
-    [TestFixture, Category("TimeSensitive")]
+    [TestFixture/*, Category("TimeSensitive")*/]
     class RepositoryManagerTests : BaseGitEnvironmentTest
     {
         [Test]
@@ -35,7 +35,7 @@ namespace IntegrationTests
             };
 
             var result = new GitStatus();
-            RepositoryManager.OnStatusUpdated += status => { result = status; };
+            Environment.Repository.OnStatusUpdated += status => { result = status; };
 
             Logger.Trace("Issuing Changes");
 
@@ -47,11 +47,11 @@ namespace IntegrationTests
             await TaskEx.Delay(200);
             await TaskManager.Wait();
 
-            managerAutoResetEvent.OnRepositoryChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
+            managerAutoResetEvent.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.Received().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             result.AssertEqual(expected);
 
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -60,7 +60,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -97,7 +96,7 @@ namespace IntegrationTests
             };
 
             var result = new GitStatus();
-            RepositoryManager.OnStatusUpdated += status => {
+            RepositoryManager.Repository.OnStatusUpdated += status => {
                 result = status;
             };
 
@@ -110,11 +109,11 @@ namespace IntegrationTests
             testDocumentTxt.WriteAllText("foobar");
             await TaskManager.Wait();
 
-            managerAutoResetEvent.OnRepositoryChanged.WaitOne(TimeSpan.FromSeconds(200)).Should().BeTrue();
+            managerAutoResetEvent.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(200)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.Received().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             result.AssertEqual(expectedAfterChanges);
 
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -123,7 +122,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             repositoryManagerListener.ClearReceivedCalls();
@@ -136,16 +134,15 @@ namespace IntegrationTests
 
             await TaskManager.Wait();
 
-            managerAutoResetEvent.OnActiveBranchChanged.WaitOne(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            managerAutoResetEvent.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(5)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.Received(1).OnActiveBranchChanged();
+            repositoryManagerListener.Received(1).OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -166,7 +163,7 @@ namespace IntegrationTests
             };
 
             var result = new GitStatus();
-            RepositoryManager.OnStatusUpdated += status => { result = status; };
+            RepositoryManager.Repository.OnStatusUpdated += status => { result = status; };
 
             Logger.Trace("Issuing Command");
 
@@ -178,12 +175,12 @@ namespace IntegrationTests
             await TaskManager.Wait();
 
             managerAutoResetEvent.OnActiveBranchChanged.WaitOne(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            managerAutoResetEvent.OnRepositoryChanged.WaitOne(TimeSpan.FromSeconds(3)).Should().BeTrue();
+            managerAutoResetEvent.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(3)).Should().BeTrue();
             managerAutoResetEvent.OnHeadChanged.WaitOne(TimeSpan.FromSeconds(3)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.Received().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             result.AssertEqual(expected);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received(1).OnActiveBranchChanged();
@@ -191,7 +188,6 @@ namespace IntegrationTests
             repositoryManagerListener.Received(1).OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -211,18 +207,16 @@ namespace IntegrationTests
             await TaskManager.Wait();
 
             managerAutoResetEvent.OnLocalBranchListChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
-            managerAutoResetEvent.OnRemoteOrTrackingChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.Received().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -245,14 +239,13 @@ namespace IntegrationTests
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             repositoryManagerListener.ClearReceivedCalls();
@@ -266,13 +259,12 @@ namespace IntegrationTests
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             repositoryManagerListener.ClearReceivedCalls();
@@ -295,18 +287,16 @@ namespace IntegrationTests
 
             managerAutoResetEvent.OnActiveBranchChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
             managerAutoResetEvent.OnActiveRemoteChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
-            managerAutoResetEvent.OnRemoteOrTrackingChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received().OnActiveBranchChanged();
             repositoryManagerListener.Received().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.Received().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             repositoryManagerListener.ClearReceivedCalls();
@@ -317,18 +307,16 @@ namespace IntegrationTests
             await TaskManager.Wait();
 
             managerAutoResetEvent.OnActiveRemoteChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
-            managerAutoResetEvent.OnRemoteOrTrackingChanged.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.Received().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.Received().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -349,15 +337,15 @@ namespace IntegrationTests
             };
 
             var result = new GitStatus();
-            RepositoryManager.OnStatusUpdated += status => { result = status; };
+            RepositoryManager.Repository.OnStatusUpdated += status => { result = status; };
 
             Logger.Trace("Issuing Command");
 
             await RepositoryManager.Pull("origin", "master").StartAsAsync();
             await TaskManager.Wait();
 
-            managerAutoResetEvent.OnRepositoryChanged.WaitOne(TimeSpan.FromSeconds(7)).Should().BeTrue();
-            managerAutoResetEvent.OnActiveBranchChanged.WaitOne(TimeSpan.FromSeconds(7)).Should().BeTrue();
+            managerAutoResetEvent.OnHeadChanged.WaitOne(TimeSpan.FromSeconds(7)).Should().BeTrue();
+            managerAutoResetEvent.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(7)).Should().BeTrue();
 
             WaitForNotBusy(managerAutoResetEvent, 3);
             WaitForNotBusy(managerAutoResetEvent, 3);
@@ -367,15 +355,14 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             RepositoryManager.IsBusy.Should().BeFalse();
 
-            repositoryManagerListener.Received().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             result.AssertEqual(expected);
 
-            repositoryManagerListener.Received(1).OnActiveBranchChanged();
+            repositoryManagerListener.Received(1).OnHeadChanged();
+            repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
@@ -399,14 +386,13 @@ namespace IntegrationTests
 
             Logger.Trace("Continue test");
 
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.Received(2).OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -8,13 +8,12 @@ namespace TestUtils.Events
 {
     interface IRepositoryManagerListener
     {
-        void OnRepositoryChanged(GitStatus obj);
+        void OnStatusUpdate(GitStatus obj);
         void OnActiveBranchChanged();
         void OnActiveRemoteChanged();
         void OnHeadChanged();
         void OnLocalBranchListChanged();
         void OnRemoteBranchListChanged();
-        void OnRemoteOrTrackingChanged();
         void OnIsBusyChanged(bool obj);
         void OnLocksUpdated(IEnumerable<GitLock> locks);
     }
@@ -22,13 +21,12 @@ namespace TestUtils.Events
     class RepositoryManagerAutoResetEvent
     {
         public AutoResetEvent OnIsBusyChanged { get; } = new AutoResetEvent(false);
-        public AutoResetEvent OnRepositoryChanged { get; } = new AutoResetEvent(false);
+        public AutoResetEvent OnStatusUpdate { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnActiveBranchChanged { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnActiveRemoteChanged { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnHeadChanged { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnLocalBranchListChanged { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnRemoteBranchListChanged { get; } = new AutoResetEvent(false);
-        public AutoResetEvent OnRemoteOrTrackingChanged { get; } = new AutoResetEvent(false);
         public AutoResetEvent OnLocksUpdated { get; } = new AutoResetEvent(false);
     }
 
@@ -45,19 +43,19 @@ namespace TestUtils.Events
                 managerAutoResetEvent?.OnIsBusyChanged.Set();
             };
 
-            repositoryManager.OnStatusUpdated += status => {
+            repositoryManager.Repository.OnStatusUpdated += status => {
                 logger?.Debug("OnStatusUpdated: {0}", status);
-                listener.OnRepositoryChanged(status);
-                managerAutoResetEvent?.OnRepositoryChanged.Set();
+                listener.OnStatusUpdate(status);
+                managerAutoResetEvent?.OnStatusUpdate.Set();
             };
 
-            repositoryManager.OnActiveBranchChanged += () => {
+            repositoryManager.Repository.OnActiveBranchChanged += branch => {
                 logger?.Trace("OnActiveBranchChanged");
                 listener.OnActiveBranchChanged();
                 managerAutoResetEvent?.OnActiveBranchChanged.Set();
             };
 
-            repositoryManager.OnActiveRemoteChanged += () => {
+            repositoryManager.Repository.OnActiveRemoteChanged += remote => {
                 logger?.Trace("OnActiveRemoteChanged");
                 listener.OnActiveRemoteChanged();
                 managerAutoResetEvent?.OnActiveRemoteChanged.Set();
@@ -91,13 +89,12 @@ namespace TestUtils.Events
 
         public static void AssertDidNotReceiveAnyCalls(this IRepositoryManagerListener repositoryManagerListener)
         {
-            repositoryManagerListener.DidNotReceive().OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged();
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged();
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
     }

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -81,12 +81,6 @@ namespace TestUtils.Events
                 managerAutoResetEvent?.OnRemoteBranchListChanged.Set();
             };
 
-            repositoryManager.OnRemoteOrTrackingChanged += () => {
-                logger?.Trace("OnRemoteOrTrackingChanged");
-                listener.OnRemoteOrTrackingChanged();
-                managerAutoResetEvent?.OnRemoteOrTrackingChanged.Set();
-            };
-
             repositoryManager.OnLocksUpdated += locks => {
                 var lockArray = locks.ToArray();
                 logger?.Trace("OnLocksUpdated Count:{0}", lockArray.Length);

--- a/src/tests/UnitTests/Authentication/KeychainTests.cs
+++ b/src/tests/UnitTests/Authentication/KeychainTests.cs
@@ -416,7 +416,7 @@ namespace UnitTests
 
             const string username = "SomeUser";
             const string password = "SomePassword";
-            const string token = "SomeToken";
+            //const string token = "SomeToken";
 
             var hostUri = new UriString("https://github.com/");
 

--- a/src/tests/UnitTests/Repository/RepositoryManagerTests.cs
+++ b/src/tests/UnitTests/Repository/RepositoryManagerTests.cs
@@ -169,13 +169,13 @@ namespace UnitTests
             repositoryManagerListener.AttachListener(repositoryManager);
 
             GitStatus? result = null;
-            repositoryManager.OnStatusUpdated += s => { result = s; };
+            repositoryManager.Repository.OnStatusUpdated += s => { result = s; };
 
             repositoryManager.Refresh();
 
             await TaskEx.Delay(1000);
 
-            repositoryManagerListener.Received(1).OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received(1).OnStatusUpdate(Args.GitStatus);
 
             result.HasValue.Should().BeTrue();
             result.Value.AssertEqual(expectedGitStatus);
@@ -185,7 +185,6 @@ namespace UnitTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
         }
 
         [Test]
@@ -232,13 +231,13 @@ namespace UnitTests
             repositoryManagerListener.AttachListener(repositoryManager);
 
             GitStatus? result = null;
-            repositoryManager.OnStatusUpdated += s => { result = s; };
+            repositoryManager.Repository.OnStatusUpdated += s => { result = s; };
 
             repositoryManager.Refresh();
 
             Thread.Sleep(1000);
 
-            repositoryManagerListener.Received(1).OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received(1).OnStatusUpdate(Args.GitStatus);
 
             result.HasValue.Should().BeTrue();
             result.Value.AssertNotEqual(expectedGitStatus);
@@ -248,7 +247,6 @@ namespace UnitTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
         }
 
         [Test]
@@ -272,13 +270,13 @@ namespace UnitTests
             repositoryManagerListener.AttachListener(repositoryManager);
 
             GitStatus? result = null;
-            repositoryManager.OnStatusUpdated += s => { result = s; };
+            repositoryManager.Repository.OnStatusUpdated += s => { result = s; };
 
             repositoryManager.Refresh();
 
             Thread.Sleep(1000);
 
-            repositoryManagerListener.Received(1).OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received(1).OnStatusUpdate(Args.GitStatus);
 
             result.HasValue.Should().BeTrue();
             result.Value.AssertEqual(responseGitStatus);
@@ -288,7 +286,6 @@ namespace UnitTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
         }
 
         [Test]
@@ -312,13 +309,13 @@ namespace UnitTests
             repositoryManagerListener.AttachListener(repositoryManager);
 
             GitStatus? result = null;
-            repositoryManager.OnStatusUpdated += s => { result = s; };
+            repositoryManager.Repository.OnStatusUpdated += s => { result = s; };
 
             repositoryManager.Refresh();
 
             Thread.Sleep(1000);
 
-            repositoryManagerListener.Received(1).OnRepositoryChanged(Args.GitStatus);
+            repositoryManagerListener.Received(1).OnStatusUpdate(Args.GitStatus);
 
             result.HasValue.Should().BeTrue();
             result.Value.AssertEqual(responseGitStatus);
@@ -328,7 +325,6 @@ namespace UnitTests
             repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteOrTrackingChanged();
         }
     }
 }


### PR DESCRIPTION
I'm trying to clean up the `Repository` class.
It has a `IGitClient` that it doesn't need, I removed that from the constructor.

I also changed `CloneUrl` to be driven from a field in the `RepositoryManager`.
Currently, the value is figured out in the `RepositoryManager` and set in the constructor of the `Repository`.
On a config change event the `RepositoryManager` raises `OnRemoteOrTrackingChanged`, and the `Repository` has a duplicate of the logic to set it's own `CloneUrl`.

Depends on:
- [x] #139 