### PR TITLE
Support paths with spaces in the package.sh script

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -24,8 +24,8 @@ popd
 
 if [ -f "$1/Unity.app/Contents/MacOS/Unity" ]; then
 	Unity="$1/Unity.app/Contents/MacOS/Unity"
-elif [ -f $1/Unity ]; then
-	Unity="$1/Unity"
+elif [ -f "$1/Editor/Unity" ]; then
+	Unity="$1/Editor/Unity"
 else
 	echo "Can't find Unity in $1"
 	exit 1

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -eux
 
 Configuration="Release"
 if [ $# -lt 1 ]; then


### PR DESCRIPTION
This is what I get for installing Unity in paths without spaces in them...

This PR also changes the path you need to give to package.sh to build the package on Windows, so it matches the logic on the mac