### PR TITLE
Fix for FindCommonPath to checking for empty paths as well as null

### DIFF
--- a/src/GitHub.Api/IO/FileSystemHelpers.cs
+++ b/src/GitHub.Api/IO/FileSystemHelpers.cs
@@ -7,12 +7,16 @@ namespace GitHub.Unity
     {
         public static string FindCommonPath(IEnumerable<string> paths)
         {
-            var pathsArray = paths.Where(s => s != null).Select(s => s.ToNPath().Parent).ToArray();
-            var maxDepth = pathsArray.Max(path => path.Depth);
-            var deepestPath = pathsArray.First(path => path.Depth == maxDepth);
+            var parentPaths = paths.Where(s => !string.IsNullOrEmpty(s)).Select(s => s.ToNPath().Parent);
+            if (!parentPaths.Any())
+                return null;
+
+            var parentsArray = parentPaths.ToArray();
+            var maxDepth = parentsArray.Max(path => path.Depth);
+            var deepestPath = parentsArray.First(path => path.Depth == maxDepth);
 
             var commonParent = deepestPath;
-            foreach (var path in pathsArray)
+            foreach (var path in parentsArray)
             {
                 var cp = path.Elements.Any() ? commonParent.GetCommonParent(path) : null;
                 if (cp != null)

--- a/src/tests/UnitTests/IO/FileSystemHelperTests.cs
+++ b/src/tests/UnitTests/IO/FileSystemHelperTests.cs
@@ -27,18 +27,18 @@ namespace UnitTests
         }
 
         [Test]
-        public void ShouldErrorIfEmpty()
+        public void ShouldNotErrorIfEmpty()
         {
             Action item;
 
             item = () => { FileSystemHelpers.FindCommonPath(new List<string>()); };
-            item.ShouldThrow<InvalidOperationException>();
+            item.ShouldNotThrow<InvalidOperationException>();
 
             item = () => { FileSystemHelpers.FindCommonPath(new List<string> { null }); };
-            item.ShouldThrow<InvalidOperationException>();
+            item.ShouldNotThrow<InvalidOperationException>();
 
             item = () => { FileSystemHelpers.FindCommonPath(new List<string> { "" }); };
-            item.ShouldThrow<InvalidOperationException>();
+            item.ShouldNotThrow<InvalidOperationException>();
         }
 
         [Test]


### PR DESCRIPTION
Splitting up #91