### PR TITLE
Reducing noise in UsageTracker error

### DIFF
--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -145,7 +145,7 @@ namespace GitHub.Unity
                     }
                     catch (Exception ex)
                     {
-                        Logger.Warning(ex, "Error Sending Usage");
+                        Logger.Warning("Error Sending Usage Exception Type:{0} Message:{1}", ex.GetType().ToString(), ex.Message);
                     }
                 }
 

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -145,7 +145,7 @@ namespace GitHub.Unity
                     }
                     catch (Exception ex)
                     {
-                        Logger.Warning("Error Sending Usage Exception Type:{0} Message:{1}", ex.GetType().ToString(), ex.Message);
+                        Logger.Warning(@"Error Sending Usage Exception Type:""{0}"" Message:""{1}""", ex.GetType().ToString(), ex.Message);
                     }
                 }
 


### PR DESCRIPTION
`UsageTracker` regularly throws an error in debug mode when developing.
I'd just like to limit the output for those errors.