### PR TITLE
Add symlink resolver so we can figure out paths properly

### DIFF
--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -145,7 +145,7 @@ namespace GitHub.Unity
             if (path == null)
                 path = await new FindExecTask("git", taskManager.Token).StartAwait();
 
-            return path.Resolve();
+            return path;
         }
 
         public bool ValidateGitInstall(NPath path)

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -134,13 +134,18 @@ namespace GitHub.Unity
 
         private async Task<NPath> LookForSystemGit()
         {
-            if (environment.IsMac)
+            NPath path = null;
+            if (!environment.IsWindows)
             {
-                var path = "/usr/local/bin/git".ToNPath();
-                if (path.FileExists())
-                    return path;
+                var p = new NPath("/usr/local/bin/git");
+                if (p.FileExists())
+                    path = p;
             }
-            return await new FindExecTask("git", taskManager.Token).StartAwait();
+
+            if (path == null)
+                path = await new FindExecTask("git", taskManager.Token).StartAwait();
+
+            return path.Resolve();
         }
 
         public bool ValidateGitInstall(NPath path)

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -69,6 +69,9 @@
     <Reference Include="Mono.Security">
       <HintPath>$(SolutionDir)lib\Mono.Security.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Posix">
+      <HintPath>$(SolutionDir)lib\Mono.Posix.dll</HintPath>
+    </Reference>
     <Reference Include="Rackspace.Threading, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bb62785d398726f0, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\TunnelVisionLabs.Threading.2.0.0-unity\lib\net35-client\Rackspace.Threading.dll</HintPath>
       <Private>True</Private>

--- a/src/GitHub.Api/IO/NiceIO.cs
+++ b/src/GitHub.Api/IO/NiceIO.cs
@@ -283,6 +283,8 @@ GitHub.Unity
 
         public bool DirectoryExists(NPath append)
         {
+            if (append == null)
+                return FileSystem.DirectoryExists(ToString());
             return FileSystem.DirectoryExists(Combine(append).ToString());
         }
 
@@ -295,6 +297,8 @@ GitHub.Unity
 
         public bool FileExists(NPath append)
         {
+            if (append == null)
+                return FileSystem.FileExists(ToString());
             return FileSystem.FileExists(Combine(append).ToString());
         }
 
@@ -1017,6 +1021,14 @@ GitHub.Unity
             if (path == null)
                 return null;
             return new NPath(path);
+        }
+
+        public static NPath Resolve(this NPath path)
+        {
+            if (path == null || DefaultEnvironment.OnWindows || path.IsRelative || !path.FileExists())
+                return path;
+
+            return new NPath(Mono.Unix.UnixPath.GetCompleteRealPath(path.ToString()));
         }
     }
 

--- a/src/GitHub.Api/IO/NiceIO.cs
+++ b/src/GitHub.Api/IO/NiceIO.cs
@@ -753,11 +753,14 @@ GitHub.Unity
             }
         }
 
+        private static NPath systemTemp;
         public static NPath SystemTemp
         {
             get
             {
-                return new NPath(FileSystem.GetTempPath());
+                if (systemTemp == null)
+                    systemTemp = new NPath(FileSystem.GetTempPath());
+                return systemTemp;
             }
         }
 

--- a/src/GitHub.Api/OutputProcessors/ProcessManager.cs
+++ b/src/GitHub.Api/OutputProcessors/ProcessManager.cs
@@ -74,8 +74,13 @@ namespace GitHub.Unity
             }
             else if (environment.IsMac)
             {
+                // we need to create a temp bash script to set up the environment properly, because
+                // osx terminal app doesn't inherit the PATH env var and there's no way to pass it in
+                var envVarFile = environment.FileSystem.GetRandomFileName();
+                environment.FileSystem.WriteAllLines(envVarFile, new string[] { "cd $GHU_WORKINGDIR", "PATH=$GHU_FULLPATH:$PATH /bin/bash" });
+                Mono.Unix.Native.Syscall.chmod(envVarFile, (Mono.Unix.Native.FilePermissions)493); // -rwxr-xr-x mode (0755)
                 startInfo.FileName = "open";
-                startInfo.Arguments = $"-a Terminal {workingDirectory}";
+                startInfo.Arguments = $"-a Terminal {envVarFile}";
             }
             else
             {

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -117,35 +117,14 @@ namespace GitHub.Unity
             set
             {
                 gitExecutablePath = value;
-                gitInstallPath = null;
+                if (String.IsNullOrEmpty(gitExecutablePath))
+                    GitInstallPath = null;
+                else
+                    GitInstallPath = GitExecutablePath.Parent.Parent;
             }
         }
 
-        private NPath gitInstallPath;
-        public NPath GitInstallPath
-        {
-            get
-            {
-                if (gitInstallPath == null)
-                {
-
-                    if (!String.IsNullOrEmpty(GitExecutablePath))
-                    {
-                        if (IsWindows)
-                        {
-                            gitInstallPath = GitExecutablePath.Parent.Parent;
-                        }
-                        else
-                        {
-                            gitInstallPath = GitExecutablePath.Parent;
-                        }
-                    }
-                    else
-                        gitInstallPath = GitExecutablePath;
-                }
-                return gitInstallPath;
-            }
-        }
+        public NPath GitInstallPath { get; private set; }
 
         public NPath RepositoryPath { get; private set; }
         public IRepository Repository { get; set; }

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -120,7 +120,7 @@ namespace GitHub.Unity
                 if (String.IsNullOrEmpty(gitExecutablePath))
                     GitInstallPath = null;
                 else
-                    GitInstallPath = GitExecutablePath.Parent.Parent;
+                    GitInstallPath = GitExecutablePath.Resolve().Parent.Parent;
             }
         }
 

--- a/src/GitHub.Api/Platform/ProcessEnvironment.cs
+++ b/src/GitHub.Api/Platform/ProcessEnvironment.cs
@@ -54,6 +54,7 @@ namespace GitHub.Unity
 
             var gitPathRoot = Environment.GitInstallPath;
             var gitLfsPath = Environment.GitInstallPath;
+            var gitExecutableDir = Environment.GitExecutablePath.Parent; // original path to git (might be different from install path if it's a symlink)
 
             // Paths to developer tools such as msbuild.exe
             //var developerPaths = StringExtensions.JoinForAppending(";", developerEnvironment.GetPaths());
@@ -78,19 +79,17 @@ namespace GitHub.Unity
             if (Environment.IsWindows)
             {
                 var userPath = @"C:\windows\system32;C:\windows";
-                path = String.Format(CultureInfo.InvariantCulture, @"{0}\cmd;{0}\usr\bin;{1};{2};{0}\usr\share\git-tfs;{3};{4}{5}",
-                    gitPathRoot, execPath, binPath,
-                    gitLfsPath, userPath, developerPaths);
+                path = $"{gitPathRoot}\\cmd;{gitPathRoot}\\usr\\bin;{execPath};{binPath};{gitLfsPath};{userPath}{developerPaths}";
             }
             else
             {
-                var userPath = Environment.Path;
-                path = String.Format(CultureInfo.InvariantCulture, @"{0}:{1}:{2}:{3}{4}",
-                    binPath, execPath, gitLfsPath, userPath, developerPaths);
+                path = $"{gitExecutableDir}:{binPath}:{execPath}:{gitLfsPath}:{Environment.Path}:{developerPaths}";
             }
             psi.EnvironmentVariables["GIT_EXEC_PATH"] = execPath.ToString();
 
             psi.EnvironmentVariables["PATH"] = path;
+            psi.EnvironmentVariables["GHU_FULLPATH"] = path;
+            psi.EnvironmentVariables["GHU_WORKINGDIR"] = workingDirectory;
 
             psi.EnvironmentVariables["PLINK_PROTOCOL"] = "ssh";
             psi.EnvironmentVariables["TERM"] = "msys";

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PUblishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PUblishView.cs
@@ -222,9 +222,7 @@ namespace GitHub.Unity
                             return;
                         }
 
-                        var repositoryCloneUrl = Environment.IsWindows ? repository.CloneUrl : repository.SshUrl;
-
-                        GitClient.RemoteAdd("origin", repositoryCloneUrl)
+                        GitClient.RemoteAdd("origin", repository.CloneUrl)
                                  .Then(GitClient.Push("origin", Repository.CurrentBranch.Value.Name))
                                  .ThenInUI(Parent.Finish)
                                  .Start();


### PR DESCRIPTION
Fixes #192

On non-windows, git and other files might be symlinks, so when we're using them as a base for determining parent directories, we may need to resolve the symlink first. The rules for automatically
doing symlink resolution are tricky, so for now just do it manually.

Still not happy with how we're finding git on the system, but this should at least make the command line work across all systems. 

~~An existing problem right now is that OSX overwrites values set to the PATH env variable when it loads `/etc/profile` in preparation to run bash, which is seriously screwed up on their part. That means that the opened command line won't have our path variable value (but it will have all the other env vars). I'm still investigating how to fix that...~~ This is fixed now by creating a little shell script that in turn invokes bash with a proper environment.

FYI, we want the GitExecutablePath to reflect where the binary was found, and the GitInstallPath to reflect where it is installed. When the binary is a symlink (like /usr/local/bin/git -> ../Cellar/git/2.12.2/bin/git), this means GitExecutablePath will have /usr/local/bin/git and GitInstallPath will have /usr/local/Cellar/git/2.12.2/bin