### PR TITLE
Fixes to populate remote url text field after publish

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -67,7 +67,6 @@ namespace GitHub.Unity
         private const string DefaultRepositoryRemoteName = "origin";
 
         [NonSerialized] private int newGitIgnoreRulesSelection = -1;
-        [NonSerialized] private ConfigRemote? activeRemote;
 
         [SerializeField] private string gitName;
         [SerializeField] private string gitEmail;
@@ -94,6 +93,8 @@ namespace GitHub.Unity
         {
             base.OnEnable();
             AttachHandlers(Repository);
+
+            remoteHasChanged = true;
         }
 
         public override void OnDisable()
@@ -114,8 +115,9 @@ namespace GitHub.Unity
 
             DetachHandlers(oldRepository);
             AttachHandlers(Repository);
-            activeRemote = Repository.CurrentRemote;
+
             remoteHasChanged = true;
+
             Refresh();
         }
 
@@ -178,7 +180,7 @@ namespace GitHub.Unity
 
             if (Repository == null)
             {
-                if (cachedUser == null || String.IsNullOrEmpty(cachedUser.Name))
+                if ((cachedUser == null || String.IsNullOrEmpty(cachedUser.Name)) && GitClient != null)
                 {
                     var user = new User();
                     GitClient.GetConfig("user.name", GitConfigSource.User)
@@ -221,6 +223,7 @@ namespace GitHub.Unity
             if (remoteHasChanged)
             {
                 remoteHasChanged = false;
+                var activeRemote = Repository.CurrentRemote;
                 hasRemote = activeRemote.HasValue && !String.IsNullOrEmpty(activeRemote.Value.Url);
                 if (!hasRemote)
                 {
@@ -245,7 +248,6 @@ namespace GitHub.Unity
 
         private void Repository_OnActiveRemoteChanged(string remote)
         {
-            activeRemote = Repository.CurrentRemote;
             remoteHasChanged = true;
         }
 


### PR DESCRIPTION
Fixes #185 

The problem here was due to the use of `activeRemote` in `SettingsView`.

When a user is publishing, they are looking at the `HistoryView`. Which means the `SettingsView` is disabled, and when a remote is added the event handler `SettingsView.OnRepositoryChanged` will not run and won't update `activeRemote` with the new value.

I removed `activeRemote` and switched it to `Repository.CurrentRemote`.

I also fixed two errors in the `SettingsView` that would appear in the user log.