### PR TITLE
Split the commit message into the subject line and the body

### DIFF
--- a/src/GitHub.Api/Git/Tasks/GitCommitTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitCommitTask.cs
@@ -16,10 +16,9 @@ namespace GitHub.Unity
 
             Name = TaskName;
             arguments = "commit ";
-            arguments += String.Format(" -m \"{0}", message);
+            arguments += String.Format(" -m \"{0}\"", message);
             if (!String.IsNullOrEmpty(body))
-                arguments += String.Format("{0}{1}", Environment.NewLine, body);
-            arguments += "\"";
+                arguments += String.Format(" -m \"{0}\"", body);
         }
 
         public override string ProcessArguments { get { return arguments; } }


### PR DESCRIPTION
### Description of the Change

fixes #206 

Change commit message to recommended style.

**current commit message**
```
summary
1st line of description
2nd line of description
3rd line of description
...
```

**changed commit message**
```
summary

1st line of description
2nd line of description
3rd line of description
...
```

refs
* https://chris.beams.io/posts/git-commit/#separate
* https://stackoverflow.com/questions/16122234/how-to-commit-a-change-with-both-message-and-description-from-the-command-li

### Alternate Designs

None

### Benefits

`git log --online` and `git shortlog` etc will print only the summary.

### Possible Drawbacks

None

### Applicable Issues

N/A
