### PR TITLE
Fix to include the OwnersDefaultText after user and organizations load

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PUblishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PUblishView.cs
@@ -91,7 +91,7 @@ namespace GitHub.Unity
                                 .OrderBy(organization => organization.Login)
                                 .Select(organization => organization.Login);
 
-                            owners = new[] { username }.Union(organizationLogins).ToArray();
+                            owners = new[] { OwnersDefaultText, username }.Union(organizationLogins).ToArray();
 
                             isBusy = false;
                         });


### PR DESCRIPTION
A fix in #213 was unfixed in #197