### PR TITLE
Handle exceptions properly on startup

### DIFF
--- a/src/GitHub.Api/Application/IApplicationManager.cs
+++ b/src/GitHub.Api/Application/IApplicationManager.cs
@@ -17,6 +17,8 @@ namespace GitHub.Unity
         ITaskManager TaskManager { get; }
         IGitClient GitClient { get; }
         IUsageTracker UsageTracker { get; }
+
+        void Run(bool firstRun);
         void RestartRepository();
         ITask InitializeRepository();
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
@@ -58,7 +58,7 @@ namespace GitHub.Unity
             Logging.LogAdapter = new FileLogAdapter(logPath);
             Logging.Info("Initializing GitHub for Unity version " + ApplicationInfo.Version);
 
-            ((ApplicationManager)ApplicationManager).Run(ApplicationCache.Instance.FirstRun).Forget();
+            ApplicationManager.Run(ApplicationCache.Instance.FirstRun);
         }
 
         private static bool ServerCertificateValidationCallback(object sender, X509Certificate certificate,


### PR DESCRIPTION
Fixes #227

While debugging the mac sfw support I got exceptions getting thrown from `RestartRepository` that were totally getting swallowed, 'cause threads. This changes the implementation to use our new task system so hopefully no more swallowing of things.

Also I'm not sure why the `GitClient` was being created on initialize if there was an `GitExecutablePath` and then immediately after, on `Run`, being created if there *wasn't* a path. Feels like there was some weird reason for this, but I can't think of one and literally it will get created regardless, so meh, creating it on top. We should test our assumptions on this one.