### PR TITLE
Fixes to better control when the branch delete button is enabled

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -61,7 +61,6 @@ namespace GitHub.Unity
         {
             base.OnDisable();
             DetachHandlers(Repository);
-            selectedNode = null;
         }
 
         public override void OnRepositoryChanged(IRepository oldRepository)
@@ -313,6 +312,9 @@ namespace GitHub.Unity
 
         private void BuildTree(IEnumerable<GitBranch> local, IEnumerable<GitBranch> remote)
         {
+            //Clear the selected node
+            selectedNode = null;
+ 
             // Sort
             var localBranches = new List<GitBranch>(local);
             var remoteBranches = new List<GitBranch>(remote);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -14,7 +14,7 @@ namespace GitHub.Unity
         private const string ConfirmSwitchTitle = "Confirm branch switch";
         private const string ConfirmSwitchMessage = "Switch branch to {0}?";
         private const string ConfirmSwitchOK = "Switch";
-        private const string ConfirmSwitchCancel = CancelButtonLabel;
+        private const string ConfirmSwitchCancel = "Cancel";
         private const string NewBranchCancelButton = "x";
         private const string NewBranchConfirmButton = "Create";
         private const string FavoritesSetting = "Favorites";

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -464,7 +464,7 @@ namespace GitHub.Unity
             {
                 // Delete button
                 // If the current branch is selected, then do not enable the Delete button
-                var disableDelete = selectedNode == null || activeBranchNode == selectedNode;
+                var disableDelete = selectedNode == null || selectedNode.Type == NodeType.Folder || activeBranchNode == selectedNode;
                 EditorGUI.BeginDisabledGroup(disableDelete);
                 {
                     if (GUILayout.Button(DeleteBranchButton, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -14,7 +14,7 @@ namespace GitHub.Unity
         private const string ConfirmSwitchTitle = "Confirm branch switch";
         private const string ConfirmSwitchMessage = "Switch branch to {0}?";
         private const string ConfirmSwitchOK = "Switch";
-        private const string ConfirmSwitchCancel = "Cancel";
+        private const string ConfirmSwitchCancel = CancelButtonLabel;
         private const string NewBranchCancelButton = "x";
         private const string NewBranchConfirmButton = "Create";
         private const string FavoritesSetting = "Favorites";
@@ -23,6 +23,10 @@ namespace GitHub.Unity
         private const string LocalTitle = "Local branches";
         private const string RemoteTitle = "Remote branches";
         private const string CreateBranchButton = "New Branch";
+        private const string DeleteBranchMessageFormatString = "Are you sure you want to delete the branch: {0}?";
+        private const string DeleteBranchTitle = "Delete Branch?";
+        private const string DeleteBranchButton = "Delete";
+        private const string CancelButtonLabel = "Cancel";
 
         private bool showLocalBranches = true;
         private bool showRemoteBranches = true;
@@ -460,12 +464,11 @@ namespace GitHub.Unity
                 var disableDelete = activeBranchNode == selectedNode;
                 EditorGUI.BeginDisabledGroup(disableDelete);
                 {
-                    if (GUILayout.Button("Delete", EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
+                    if (GUILayout.Button(DeleteBranchButton, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
                     {
                         var selectedBranchName = selectedNode.Name;
-                        var dialogTitle = "Delete Branch: " + selectedBranchName;
-                        var dialogMessage = "Are you sure you want to delete the branch: " + selectedBranchName + "?";
-                        if (EditorUtility.DisplayDialog("Delete Branch?", dialogMessage, "Delete", "Cancel"))
+                        var dialogMessage = string.Format(DeleteBranchMessageFormatString, selectedBranchName);
+                        if (EditorUtility.DisplayDialog(DeleteBranchTitle, dialogMessage, DeleteBranchButton, CancelButtonLabel))
                         {
                             GitClient.DeleteBranch(selectedBranchName, true).Start();
                         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -61,6 +61,7 @@ namespace GitHub.Unity
         {
             base.OnDisable();
             DetachHandlers(Repository);
+            selectedNode = null;
         }
 
         public override void OnRepositoryChanged(IRepository oldRepository)
@@ -461,7 +462,7 @@ namespace GitHub.Unity
             {
                 // Delete button
                 // If the current branch is selected, then do not enable the Delete button
-                var disableDelete = activeBranchNode == selectedNode;
+                var disableDelete = selectedNode == null || activeBranchNode == selectedNode;
                 EditorGUI.BeginDisabledGroup(disableDelete);
                 {
                     if (GUILayout.Button(DeleteBranchButton, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -147,7 +147,7 @@ namespace GitHub.Unity
 
                 GUILayout.BeginHorizontal();
                 {
-                    OnCreateGUI();
+                    OnButtonBarGUI();
                 }
                 GUILayout.EndHorizontal();
 
@@ -451,11 +451,11 @@ namespace GitHub.Unity
             }
         }
 
-        private void OnCreateGUI()
+        private void OnButtonBarGUI()
         {
-            // Create button
             if (mode == BranchesMode.Default)
             {
+                // Delete button
                 // If the current branch is selected, then do not enable the Delete button
                 var disableDelete = activeBranchNode == selectedNode;
                 EditorGUI.BeginDisabledGroup(disableDelete);
@@ -473,6 +473,7 @@ namespace GitHub.Unity
                 }
                 EditorGUI.EndDisabledGroup();
 
+                // Create button
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button(CreateBranchButton, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
                 {


### PR DESCRIPTION
Fixes #237 
Fixes #238 

- Adding to the logic that controls when the delete button is diabled
- Refactored the name of the method `OnCreateGUI` to `OnButtonBarGUI`
- Refactored the strings in `BranchesView` to `const`