### PR TITLE
Fix build on mac

### DIFF
--- a/common/nativelibraries.props
+++ b/common/nativelibraries.props
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(SolutionDir)\lib\sfw\linux\libsfw.so">
+    <None Include="$(SolutionDir)\lib\sfw\linux\libsfw.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\linux\libsfw.so.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\linux\libsfw.so.meta">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\mac\libsfw.bundle">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\mac\libsfw.bundle">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\mac\libsfw.bundle.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\mac\libsfw.bundle.meta">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll">
       <Link>x64\sfw_x64.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll.meta">
       <Link>x64\sfw_x64.dll.meta</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x64\pthreadVC2.dll">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\pthreadVC2.dll">
       <Link>x64\pthreadVC2.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x64\pthreadVC2.dll.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\pthreadVC2.dll.meta">
       <Link>x64\pthreadVC2.dll.meta</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x86\sfw_x86.dll">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x86\sfw_x86.dll">
       <Link>x86\sfw_x86.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x86\sfw_x86.dll.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x86\sfw_x86.dll.meta">
       <Link>x86\sfw_x86.dll.meta</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x86\pthreadVC2.dll">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x86\pthreadVC2.dll">
       <Link>x86\pthreadVC2.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(SolutionDir)\lib\sfw\win\x86\pthreadVC2.dll.meta">
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x86\pthreadVC2.dll.meta">
       <Link>x86\pthreadVC2.dll.meta</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 </Project>

--- a/lib/sfw/sfw.net.dll
+++ b/lib/sfw/sfw.net.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e4c42edfca7f2ca951dca6a219c1e40a220cc2a776fd8038b6fa7772caae65f
+oid sha256:21feeaa73e42bf03e86525bc5e1b954f4b9a2f16eed58a87c69e576509231480
 size 7168

--- a/lib/sfw/sfw.net.dll.mdb
+++ b/lib/sfw/sfw.net.dll.mdb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b791b502720cad7d39c3d6e08c1678a6039b5556782b8fcc1ab90de13a13c8f6
-size 1849
+oid sha256:9b338de30fd729ffaa83c9ddf3c90a03ad9bdaa3367580316fef3649594a5217
+size 1924

--- a/src/tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/IntegrationTests.csproj
@@ -115,6 +115,16 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="..\..\..\common\nativelibraries.props" />
+  <ItemGroup>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll">
+      <Link>sfw_x64.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll.meta">
+      <Link>sfw_x64.dll.meta</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -124,7 +134,4 @@
   </Target>
   -->
   <Import Project="..\..\..\common\build.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy $(OutDir)x64\* $(OutDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/unity/PackageProject/.gitignore
+++ b/unity/PackageProject/.gitignore
@@ -11,3 +11,9 @@
 ProjectVersion.txt
 
 Library/
+
+// These files come from lib/
+Assets/GitHub/Editor/libsfw.bundle.meta
+Assets/GitHub/Editor/libsfw.so.meta
+Assets/GitHub/Editor/x64/
+Assets/GitHub/Editor/x86/


### PR DESCRIPTION
Copying files in the build needs to go through msbuild so it doesn't rely on OS-specific things. 

Also fix the .gitignore for the package project, the meta files of the native libraries get copied directly from the `lib/` folder, which means the package project shouldn't be tracking them.