### PR TITLE
Fix to update user name and email is correctly in SettingsView

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -294,7 +294,7 @@ namespace GitHub.Unity
                                 {
                                     if (Repository != null)
                                     {
-                                        Repository.User.Name = value;
+                                        Repository.User.Name = newGitName;
                                     }
                                     else
                                     {
@@ -302,7 +302,7 @@ namespace GitHub.Unity
                                         {
                                             cachedUser = new User();
                                         }
-                                        cachedUser.Name = value;
+                                        cachedUser.Name = newGitName;
                                     }
                                 }
                             })
@@ -314,13 +314,14 @@ namespace GitHub.Unity
                                 {
                                     if (Repository != null)
                                     {
-                                        Repository.User.Email = value;
+                                        Repository.User.Email = newGitEmail;
                                     }
                                     else
                                     {
-                                        cachedUser.Email = value;
-                                        userDataHasChanged = true;
+                                        cachedUser.Email = newGitEmail;
                                     }
+
+                                    userDataHasChanged = true;
                                 }
                             }))
                         .FinallyInUI((_, __) =>


### PR DESCRIPTION
Fixes #274

- `value` is the output of the set command, not a return of the input sent.
- We should be sure to set `userDataHasChanged`