### PR TITLE
Tweaking the popup window refactor

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
@@ -100,6 +100,7 @@
     <Compile Include="UI\ChangesView.cs" />
     <Compile Include="UI\HistoryView.cs" />
     <Compile Include="UI\IView.cs" />
+    <Compile Include="UI\LoadingView.cs" />
     <Compile Include="UI\PublishView.cs" />
     <Compile Include="UI\SettingsView.cs" />
     <Compile Include="UI\Subview.cs" />

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -7,7 +7,6 @@ namespace GitHub.Unity
     abstract class BaseWindow :  EditorWindow, IView
     {
         [NonSerialized] private bool initialized = false;
-
         [NonSerialized] private IApplicationManager cachedManager;
         [NonSerialized] private IRepository cachedRepository;
         [NonSerialized] private bool initializeWasCalled;
@@ -46,8 +45,7 @@ namespace GitHub.Unity
         }
 
         public virtual void Finish(bool result)
-        {
-        }
+        {}
 
         public virtual void Awake()
         {
@@ -63,9 +61,11 @@ namespace GitHub.Unity
                 InitializeWindow(EntryPoint.ApplicationManager);
         }
 
-        public virtual void OnDisable() {}
+        public virtual void OnDisable()
+        {}
 
-        public virtual void Update() {}
+        public virtual void Update()
+        {}
 
         public virtual void OnDataUpdate()
         {}
@@ -104,9 +104,7 @@ namespace GitHub.Unity
         }
 
         public virtual void OnDestroy()
-        {
-           
-        }
+        {}
 
         public virtual void OnSelectionChange()
         {}

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LoadingView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LoadingView.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit;
+using Rackspace.Threading;
+using UnityEditor;
+using UnityEngine;
+
+namespace GitHub.Unity
+{
+    class LoadingView : Subview
+    {
+        private static readonly Vector2 viewSize = new Vector2(300, 250);
+
+        private const string WindowTitle = "Loading...";
+        private const string Header = "";
+
+
+        public override void InitializeView(IView parent)
+        {
+            base.InitializeView(parent);
+            Title = WindowTitle;
+            Size = viewSize;
+        }
+
+        public override void OnGUI()
+        {}
+    }
+}

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
@@ -9,15 +9,16 @@ namespace GitHub.Unity
     {
         public enum PopupViewType
         {
+            None,
             PublishView,
             AuthenticationView
         }
 
-        [NonSerialized] private Subview activeView;
-
         [SerializeField] private PopupViewType activeViewType;
+
         [SerializeField] private AuthenticationView authenticationView;
         [SerializeField] private PublishView publishView;
+        [SerializeField] private LoadingView loadingView;
 
         public event Action<bool> OnClose;
 
@@ -53,50 +54,37 @@ namespace GitHub.Unity
 
             publishView = publishView ?? new PublishView();
             authenticationView = authenticationView ?? new AuthenticationView();
+            loadingView = loadingView ?? new LoadingView();
 
             publishView.InitializeView(this);
             authenticationView.InitializeView(this);
+            loadingView.InitializeView(this);
         }
 
         public override void OnEnable()
         {
             base.OnEnable();
 
-            if (ActiveView != null)
-            {
-                minSize = maxSize = ActiveView.Size;
-                ActiveView.OnEnable();
-            }
+            minSize = maxSize = ActiveView.Size;
+            ActiveView.OnEnable();
         }
 
         public override void OnDisable()
         {
             base.OnDisable();
-
-            if (ActiveView != null)
-            {
-                ActiveView.OnDisable();
-            }
+            ActiveView.OnDisable();
         }
 
         public override void OnUI()
         {
             base.OnUI();
-
-            if (ActiveView != null)
-            {
-                ActiveView.OnGUI();
-            }
+            ActiveView.OnGUI();
         }
 
         public override void Refresh()
         {
             base.Refresh();
-
-            if (ActiveView != null)
-            {
-                ActiveView.Refresh();
-            }
+            ActiveView.Refresh();
         }
 
         public override void OnSelectionChange()
@@ -122,37 +110,24 @@ namespace GitHub.Unity
 
         private Subview ActiveView
         {
-            get { return activeView; }
+            get
+            {
+                switch (activeViewType)
+                {
+                    case PopupViewType.PublishView:
+                        return publishView;
+                    case PopupViewType.AuthenticationView:
+                        return authenticationView;
+                    default:
+                        return loadingView;
+                }
+            }
         }
 
         private PopupViewType ActiveViewType
         {
             get { return activeViewType; }
-            set
-            {
-                var valueChanged = false;
-                if (activeViewType != value)
-                {
-                    valueChanged = true;
-                    activeViewType = value;
-                }
-
-                if (activeView == null || valueChanged)
-                {
-                    switch (activeViewType)
-                    {
-                        case PopupViewType.PublishView:
-                            activeView = publishView;
-                            break;
-
-                        case PopupViewType.AuthenticationView:
-                            activeView = authenticationView;
-                            break;
-
-                        default: throw new ArgumentOutOfRangeException("value", value, null);
-                    }
-                }
-            }
+            set { activeViewType = value; }
         }
     }
 }


### PR DESCRIPTION
Add a loading view and make it so the PopupWindow always has an active view and there's no null checks.

Maybe we can use the loading view to show a loading animation and replace it with the real view when it's done? This might not be feasible in the current model given that we only call OnGUI on the active view, but those null checks are giving me the creeps tbh, we should always be showing **something** on screen - at most we just use the loading view as an empty view to transition into other views perhaps?

Up for debate :P