### PR TITLE
Making sure favorites is not null

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -52,7 +52,7 @@ namespace GitHub.Unity
         [SerializeField] private List<Remote> remotes = new List<Remote>();
         [SerializeField] private Vector2 scroll;
         [SerializeField] private BranchTreeNode selectedNode;
-        private List<string> favoritesList;
+        [SerializeField] private List<string> favoritesList = new List<string>();
 
         public override void InitializeView(IView parent)
         {


### PR DESCRIPTION
Fixing to a bug created this release in #275.

`favoritesList` was coming up null, causing an exception and preventing the branch tree from displaying.