### PR TITLE
Adding some logging for what credential manager is found

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -64,8 +64,15 @@ namespace GitHub.Unity
                 if (Environment.IsWindows)
                 {
                     var credentialHelper = await GitClient.GetConfig("credential.helper", GitConfigSource.Global).StartAwait();
-                    if (string.IsNullOrEmpty(credentialHelper))
+
+                    if (!string.IsNullOrEmpty(credentialHelper))
                     {
+                        Logger.Trace("Windows CredentialHelper: {0}", credentialHelper);
+                    }
+                    else
+                    {
+                        Logger.Warning("No Windows CredentialHeloper found: Setting to wincred");
+
                         await GitClient.SetConfig("credential.helper", "wincred", GitConfigSource.Global).StartAwait();
                     }
                 }

--- a/src/GitHub.Api/Git/GitCredentialManager.cs
+++ b/src/GitHub.Api/Git/GitCredentialManager.cs
@@ -133,6 +133,8 @@ namespace GitHub.Unity
                 .Configure(processManager)
                 .StartAwait();
 
+            Logger.Trace("Loaded Credential Helper: {0}", credHelper);
+
             if (credHelper != null)
             {
                 return true;


### PR DESCRIPTION
So we only set the credential manager if one is not found configured.
That leads me to believe the other windows users that are having an error do not have `wincred` as their credential helper. To help diagnose their issues we need to know what they are using.