### PR TITLE
Disabling Authenticate menu item when appropriate

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
@@ -23,9 +23,15 @@ namespace GitHub.Unity
         public event Action<bool> OnClose;
 
         [MenuItem("GitHub/Authenticate")]
-        public static void Launch()
+        public static void Authenticate()
         {
             Open(PopupViewType.AuthenticationView);
+        }
+
+        [MenuItem("GitHub/Authenticate", true)]
+        public static bool EnableAuthenticate()
+        {
+            return !EntryPoint.ApplicationManager.Platform.Keychain.HasKeys;
         }
 
         public static PopupWindow Open(PopupViewType popupViewType, Action<bool> onClose = null)


### PR DESCRIPTION
Fixes #306 

After you add a menu item, it cannot be hidden.
All you can do is disable it.