### PR TITLE
Batching Repository Watcher

### DIFF
--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -143,20 +143,21 @@ namespace GitHub.Unity
 
             signalProcessingEventsDone.Reset();
             processingEvents = true;
-            lastCountOfProcessedEvents = 0;
-            var fileEvents = nativeInterface.GetEvents();
+            var processedEventCount = 0;
 
+            var fileEvents = nativeInterface.GetEvents();
             if (fileEvents.Length > 0)
             {
                 Logger.Trace("Handling {0} Events", fileEvents.Length);
-                var processedEventCount = ProcessEvents(fileEvents);
-                lastCountOfProcessedEvents = processedEventCount;
+                processedEventCount = ProcessEvents(fileEvents);
                 Logger.Trace("Processed {0} Events", processedEventCount);
             }
 
+            lastCountOfProcessedEvents = processedEventCount;
             processingEvents = false;
             signalProcessingEventsDone.Set();
-            return lastCountOfProcessedEvents;
+
+            return processedEventCount;
         }
 
         private int ProcessEvents(Event[] fileEvents)

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -196,12 +196,11 @@ namespace GitHub.Unity
                 // handling events in .git/*
                 if (fileA.IsChildOf(paths.DotGitPath))
                 {
-                    if (fileA.Equals(paths.DotGitConfig))
+                    if (!configChanged && fileA.Equals(paths.DotGitConfig))
                     {
                         configChanged = true;
-                        eventsProcessed++;
                     }
-                    else if (fileA.Equals(paths.DotGitHead))
+                    else if (!headChanged && fileA.Equals(paths.DotGitHead))
                     {
                         if (fileEvent.Type != EventType.DELETED)
                         {
@@ -209,12 +208,10 @@ namespace GitHub.Unity
                         }
 
                         headChanged = true;
-                        eventsProcessed++;
                     }
-                    else if (fileA.Equals(paths.DotGitIndex))
+                    else if (!indexChanged && fileA.Equals(paths.DotGitIndex))
                     {
                         indexChanged = true;
-                        eventsProcessed++;
                     }
                     else if (fileA.IsChildOf(paths.RemotesPath))
                     {
@@ -351,7 +348,6 @@ namespace GitHub.Unity
                     }
 
                     repositoryChanged = true;
-                    eventsProcessed++;
                 }
             }
 
@@ -359,24 +355,28 @@ namespace GitHub.Unity
             {
                 Logger.Trace("ConfigChanged");
                 ConfigChanged?.Invoke();
+                eventsProcessed++;
             }
 
             if (headChanged)
             {
                 Logger.Trace("HeadChanged: {0}", headContent ?? "[null]");
                 HeadChanged?.Invoke(headContent);
+                eventsProcessed++;
             }
 
             if (indexChanged)
             {
                 Logger.Trace("IndexChanged");
                 IndexChanged?.Invoke();
+                eventsProcessed++;
             }
 
             if (repositoryChanged)
             {
                 Logger.Trace("RepositoryChanged");
                 RepositoryChanged?.Invoke();
+                eventsProcessed++;
             }
 
             return eventsProcessed;

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -149,9 +149,22 @@ namespace GitHub.Unity
             if (fileEvents.Length > 0)
             {
                 Logger.Trace("Processing {0} Events", fileEvents.Length);
+                ProcessEvents(fileEvents);
             }
 
+            processingEvents = false;
+            signalProcessingEventsDone.Set();
+            return lastCountOfProcessedEvents;
+        }
+
+        private void ProcessEvents(Event[] fileEvents)
+        {
+            var configChanged = false;
+            var headChanged = false;
             var repositoryChanged = false;
+            var indexChanged = false;
+
+            string headContent = null;
 
             foreach (var fileEvent in fileEvents)
             {
@@ -180,7 +193,148 @@ namespace GitHub.Unity
                 // handling events in .git/*
                 if (fileA.IsChildOf(paths.DotGitPath))
                 {
-                    HandleEventInDotGit(fileEvent, fileA, fileB);
+                    if (fileA.Equals(paths.DotGitConfig))
+                    {
+                        Logger.Trace("ConfigChanged");
+
+                        configChanged = true;
+                    }
+                    else if (fileA.Equals(paths.DotGitHead))
+                    {
+                        if (fileEvent.Type != EventType.DELETED)
+                        {
+                            headContent = paths.DotGitHead.ReadAllLines().FirstOrDefault();
+                        }
+
+                        Logger.Trace("HeadChanged: {0}", headContent ?? "[null]");
+                        headChanged = true;
+                    }
+                    else if (fileA.Equals(paths.DotGitIndex))
+                    {
+                        Logger.Trace("IndexChanged");
+                        indexChanged = true;
+                    }
+                    else if (fileA.IsChildOf(paths.RemotesPath))
+                    {
+                        var relativePath = fileA.RelativeTo(paths.RemotesPath);
+                        var relativePathElements = relativePath.Elements.ToArray();
+
+                        if (!relativePathElements.Any())
+                        {
+                            continue;
+                        }
+
+                        var origin = relativePathElements[0];
+
+                        if (fileEvent.Type == EventType.DELETED)
+                        {
+                            if (fileA.ExtensionWithDot == ".lock")
+                            {
+                                continue;
+                            }
+
+                            var branch = string.Join(@"/", relativePathElements.Skip(1).ToArray());
+
+                            Logger.Trace("RemoteBranchDeleted: {0}/{1}", origin, branch);
+                            RemoteBranchDeleted?.Invoke(origin, branch);
+                        }
+                        else if (fileEvent.Type == EventType.RENAMED)
+                        {
+                            if (fileA.ExtensionWithDot != ".lock")
+                            {
+                                continue;
+                            }
+
+                            if (fileB != null && fileB.FileExists())
+                            {
+                                if (fileA.FileNameWithoutExtension == fileB.FileNameWithoutExtension)
+                                {
+                                    var branchPathElement = relativePathElements
+                                        .Skip(1).Take(relativePathElements.Length - 2)
+                                        .Union(new[] { fileA.FileNameWithoutExtension }).ToArray();
+
+                                    var branch = string.Join(@"/", branchPathElement);
+
+                                    Logger.Trace("RemoteBranchCreated: {0}/{1}", origin, branch);
+                                    RemoteBranchCreated?.Invoke(origin, branch);
+                                }
+                            }
+                        }
+                    }
+                    else if (fileA.IsChildOf(paths.BranchesPath))
+                    {
+                        if (fileEvent.Type == EventType.MODIFIED)
+                        {
+                            if (fileA.DirectoryExists())
+                            {
+                                continue;
+                            }
+
+                            if (fileA.ExtensionWithDot == ".lock")
+                            {
+                                continue;
+                            }
+
+                            var relativePath = fileA.RelativeTo(paths.BranchesPath);
+                            var relativePathElements = relativePath.Elements.ToArray();
+
+                            if (!relativePathElements.Any())
+                            {
+                                continue;
+                            }
+
+                            var branch = string.Join(@"/", relativePathElements.ToArray());
+
+                            Logger.Trace("LocalBranchChanged: {0}", branch);
+                            LocalBranchChanged?.Invoke(branch);
+                        }
+                        else if (fileEvent.Type == EventType.DELETED)
+                        {
+                            if (fileA.ExtensionWithDot == ".lock")
+                            {
+                                continue;
+                            }
+
+                            var relativePath = fileA.RelativeTo(paths.BranchesPath);
+                            var relativePathElements = relativePath.Elements.ToArray();
+
+                            if (!relativePathElements.Any())
+                            {
+                                continue;
+                            }
+
+                            var branch = string.Join(@"/", relativePathElements.ToArray());
+
+                            Logger.Trace("LocalBranchDeleted: {0}", branch);
+                            LocalBranchDeleted?.Invoke(branch);
+                        }
+                        else if (fileEvent.Type == EventType.RENAMED)
+                        {
+                            if (fileA.ExtensionWithDot != ".lock")
+                            {
+                                continue;
+                            }
+
+                            if (fileB != null && fileB.FileExists())
+                            {
+                                if (fileA.FileNameWithoutExtension == fileB.FileNameWithoutExtension)
+                                {
+                                    var relativePath = fileB.RelativeTo(paths.BranchesPath);
+                                    var relativePathElements = relativePath.Elements.ToArray();
+
+                                    if (!relativePathElements.Any())
+                                    {
+                                        continue;
+                                    }
+
+                                    var branch = string.Join(@"/", relativePathElements.ToArray());
+
+                                    Logger.Trace("LocalBranchCreated: {0}", branch);
+                                    LocalBranchCreated?.Invoke(branch);
+                                }
+                            }
+                        }
+                    }
                 }
                 else
                 {
@@ -191,164 +345,32 @@ namespace GitHub.Unity
 
                     repositoryChanged = true;
                 }
+
                 lastCountOfProcessedEvents++;
+            }
+
+            if (configChanged)
+            {
+                Logger.Trace("ConfigChanged");
+                ConfigChanged?.Invoke();
+            }
+
+            if (headChanged)
+            {
+                Logger.Trace("ConfigChanged");
+                HeadChanged?.Invoke(headContent);
+            }
+
+            if (indexChanged)
+            {
+                Logger.Trace("IndexChanged");
+                IndexChanged?.Invoke();
             }
 
             if (repositoryChanged)
             {
                 Logger.Trace("RepositoryChanged");
                 RepositoryChanged?.Invoke();
-            }
-
-            processingEvents = false;
-            signalProcessingEventsDone.Set();
-            return lastCountOfProcessedEvents;
-        }
-
-        private void HandleEventInDotGit(Event fileEvent, NPath fileA, NPath fileB = null)
-        {
-            if (fileA.Equals(paths.DotGitConfig))
-            {
-                Logger.Trace("ConfigChanged");
-
-                ConfigChanged?.Invoke();
-            }
-            else if (fileA.Equals(paths.DotGitHead))
-            {
-                string headContent = null;
-                if (fileEvent.Type != EventType.DELETED)
-                {
-                    headContent = paths.DotGitHead.ReadAllLines().FirstOrDefault();
-                }
-
-                Logger.Trace("HeadChanged: {0}", headContent ?? "[null]");
-                HeadChanged?.Invoke(headContent);
-            }
-            else if (fileA.Equals(paths.DotGitIndex))
-            {
-                Logger.Trace("IndexChanged");
-                IndexChanged?.Invoke();
-            }
-            else if (fileA.IsChildOf(paths.RemotesPath))
-            {
-                var relativePath = fileA.RelativeTo(paths.RemotesPath);
-                var relativePathElements = relativePath.Elements.ToArray();
-
-                if (!relativePathElements.Any())
-                {
-                    return;
-                }
-
-                var origin = relativePathElements[0];
-
-                if (fileEvent.Type == EventType.DELETED)
-                {
-                    if (fileA.ExtensionWithDot == ".lock")
-                    {
-                        return;
-                    }
-
-                    var branch = string.Join(@"/", relativePathElements.Skip(1).ToArray());
-
-                    Logger.Trace("RemoteBranchDeleted: {0}/{1}", origin, branch);
-                    RemoteBranchDeleted?.Invoke(origin, branch);
-                }
-                else if (fileEvent.Type == EventType.RENAMED)
-                {
-                    if (fileA.ExtensionWithDot != ".lock")
-                    {
-                        return;
-                    }
-
-                    if (fileB != null && fileB.FileExists())
-                    {
-                        if (fileA.FileNameWithoutExtension == fileB.FileNameWithoutExtension)
-                        {
-                            var branchPathElement = relativePathElements.Skip(1)
-                                                              .Take(relativePathElements.Length-2)
-                                                              .Union(new [] { fileA.FileNameWithoutExtension }).ToArray();
-
-                            var branch = string.Join(@"/", branchPathElement);
-
-                            Logger.Trace("RemoteBranchCreated: {0}/{1}", origin, branch);
-                            RemoteBranchCreated?.Invoke(origin, branch);
-                        }
-                    }
-                }
-            }
-            else if (fileA.IsChildOf(paths.BranchesPath))
-            {
-                if (fileEvent.Type == EventType.MODIFIED)
-                {
-                    if (fileA.DirectoryExists())
-                    {
-                        return;
-                    }
-
-                    if (fileA.ExtensionWithDot == ".lock")
-                    {
-                        return;
-                    }
-
-                    var relativePath = fileA.RelativeTo(paths.BranchesPath);
-                    var relativePathElements = relativePath.Elements.ToArray();
-
-                    if (!relativePathElements.Any())
-                    {
-                        return;
-                    }
-
-                    var branch = string.Join(@"/", relativePathElements.ToArray());
-
-                    Logger.Trace("LocalBranchChanged: {0}", branch);
-                    LocalBranchChanged?.Invoke(branch);
-                }
-                else if (fileEvent.Type == EventType.DELETED)
-                {
-                    if (fileA.ExtensionWithDot == ".lock")
-                    {
-                        return;
-                    }
-
-                    var relativePath = fileA.RelativeTo(paths.BranchesPath);
-                    var relativePathElements = relativePath.Elements.ToArray();
-
-                    if (!relativePathElements.Any())
-                    {
-                        return;
-                    }
-
-                    var branch = string.Join(@"/", relativePathElements.ToArray());
-
-                    Logger.Trace("LocalBranchDeleted: {0}", branch);
-                    LocalBranchDeleted?.Invoke(branch);
-                }
-                else if (fileEvent.Type == EventType.RENAMED)
-                {
-                    if (fileA.ExtensionWithDot != ".lock")
-                    {
-                        return;
-                    }
-
-                    if (fileB != null && fileB.FileExists())
-                    {
-                        if (fileA.FileNameWithoutExtension == fileB.FileNameWithoutExtension)
-                        {
-                            var relativePath = fileB.RelativeTo(paths.BranchesPath);
-                            var relativePathElements = relativePath.Elements.ToArray();
-
-                            if (!relativePathElements.Any())
-                            {
-                                return;
-                            }
-
-                            var branch = string.Join(@"/", relativePathElements.ToArray());
-
-                            Logger.Trace("LocalBranchCreated: {0}", branch);
-                            LocalBranchCreated?.Invoke(branch);
-                        }
-                    }
-                }
             }
         }
 

--- a/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace IntegrationTests
 {
-    [TestFixture/*, Category("TimeSensitive")*/]
+    [TestFixture]
     class RepositoryManagerTests : BaseGitEnvironmentTest
     {
         private RepositoryManagerEvents repositoryManagerEvents;
@@ -53,7 +53,6 @@ namespace IntegrationTests
             repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
@@ -62,7 +61,7 @@ namespace IntegrationTests
             result.AssertEqual(expected);
         }
 
-        [Test, Category("TimeSensitive")]
+        [Test]
         public async Task ShouldAddAndCommitFiles()
         {
             await Initialize(TestRepoMasterCleanSynchronized);
@@ -93,14 +92,12 @@ namespace IntegrationTests
             var testDocumentTxt = TestRepoMasterCleanSynchronized.Combine("Assets", "TestDocument.txt");
             testDocumentTxt.WriteAllText("foobar");
             await TaskManager.Wait();
-            WaitForNotBusy(repositoryManagerEvents, 1);
             RepositoryManager.WaitForEvents();
             WaitForNotBusy(repositoryManagerEvents, 1);
 
             repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -118,18 +115,18 @@ namespace IntegrationTests
             await TaskManager.Wait();
             RepositoryManager.WaitForEvents();
             WaitForNotBusy(repositoryManagerEvents, 1);
+            repositoryManagerEvents.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(1));
 
-            repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
+            repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.Received(2).OnIsBusyChanged(Args.Bool);
+            repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
-        [Test, Category("TimeSensitive")]
+        [Test]
         public async Task ShouldAddAndCommitAllFiles()
         {
             await Initialize(TestRepoMasterCleanSynchronized);
@@ -162,12 +159,10 @@ namespace IntegrationTests
             await TaskManager.Wait();
             WaitForNotBusy(repositoryManagerEvents, 1);
             RepositoryManager.WaitForEvents();
-            WaitForNotBusy(repositoryManagerEvents, 1);
 
             repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -183,20 +178,19 @@ namespace IntegrationTests
                 .StartAsAsync();
 
             await TaskManager.Wait();
-            RepositoryManager.WaitForEvents();
             WaitForNotBusy(repositoryManagerEvents, 1);
+            RepositoryManager.WaitForEvents();
 
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.Received(2).OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
-        [Test, Category("TimeSensitive")]
+        [Test]
         public async Task ShouldDetectBranchChange()
         {
             await Initialize(TestRepoMasterCleanSynchronized);
@@ -217,14 +211,14 @@ namespace IntegrationTests
             await TaskManager.Wait();
             RepositoryManager.WaitForEvents();
             WaitForNotBusy(repositoryManagerEvents, 5);
+            repositoryManagerEvents.OnStatusUpdate.WaitOne(TimeSpan.FromSeconds(1));
 
             repositoryManagerListener.Received().OnStatusUpdate(Args.GitStatus);
-            repositoryManagerListener.Received(1).OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
-            repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.Received(1).OnHeadChanged();
+            repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
+            repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnIsBusyChanged(Args.Bool);
+            repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             result.AssertEqual(expected);
@@ -240,14 +234,13 @@ namespace IntegrationTests
 
             await RepositoryManager.DeleteBranch("feature/document", true).StartAsAsync();
             await TaskManager.Wait();
-            RepositoryManager.WaitForEvents();
             WaitForNotBusy(repositoryManagerEvents, 1);
+            RepositoryManager.WaitForEvents();
 
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             //TODO: Deleting a branch causes a config reload, which raises OnActiveBranchChanged/OnActiveRemoteChanged
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -269,7 +262,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -285,7 +277,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received(1).OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.Received(2).OnIsBusyChanged(Args.Bool);
@@ -319,9 +310,8 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
+            repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
@@ -342,14 +332,13 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
-        [Test, Category("TimeSensitive")]
+        [Test]
         public async Task ShouldDetectChangesToRemotesWhenSwitchingBranches()
         {
             var expectedCloneUrl = "https://github.com/EvilStanleyGoldman/IOTestsRepo.git";
@@ -374,7 +363,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.Received().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
@@ -400,7 +388,6 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
@@ -435,9 +422,8 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
+            repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
             repositoryManagerListener.ClearReceivedCalls();
@@ -457,13 +443,12 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 
-        [Test, Category("TimeSensitive")]
+        [Test]
         public async Task ShouldDetectGitPull()
         {
             await Initialize(TestRepoMasterCleanSynchronized);
@@ -488,7 +473,6 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
@@ -515,7 +499,6 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.Received(2).OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);

--- a/src/tests/IntegrationTests/SetupFixture.cs
+++ b/src/tests/IntegrationTests/SetupFixture.cs
@@ -12,7 +12,10 @@ namespace IntegrationTests
         {
             Logging.TracingEnabled = true;
 
-            Logging.LogAdapter = new MultipleLogAdapter(new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-integration-tests.log"));
+            Logging.LogAdapter = new MultipleLogAdapter(
+                new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-integration-tests.log"),
+                new ConsoleLogAdapter()
+            );
         }
     }
 }

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -11,7 +11,6 @@ namespace TestUtils.Events
         void OnStatusUpdate(GitStatus status);
         void OnActiveBranchChanged(ConfigBranch? branch);
         void OnActiveRemoteChanged(ConfigRemote? remote);
-        void OnHeadChanged();
         void OnLocalBranchListChanged();
         void OnRemoteBranchListChanged();
         void OnIsBusyChanged(bool busy);
@@ -101,7 +100,6 @@ namespace TestUtils.Events
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);

--- a/src/tests/UnitTests/Repository/RepositoryManagerTests.cs
+++ b/src/tests/UnitTests/Repository/RepositoryManagerTests.cs
@@ -181,7 +181,6 @@ namespace UnitTests
 
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
         }
@@ -243,7 +242,6 @@ namespace UnitTests
 
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
         }
@@ -282,7 +280,6 @@ namespace UnitTests
 
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
         }
@@ -321,7 +318,6 @@ namespace UnitTests
 
             repositoryManagerListener.DidNotReceive().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnHeadChanged();
             repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
         }


### PR DESCRIPTION
Depends on:
- [x] #295 

Using the same approach to batch events for `RepositoryChanged` I batched the events of:
- `ConfigChanged`
- `HeadChanged`
- `IndexChanged`

This has a large effect on the integration tests, which I think will run a lot more reliably.