### PR TITLE
Refactor RepositoryWatcher event batching

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -460,6 +460,9 @@ namespace GitHub.Unity
             LoadBranchesFromConfig();
             LoadRemotesFromConfig();
 
+            OnLocalBranchListChanged?.Invoke();
+            OnRemoteBranchListChanged?.Invoke();
+
             OnActiveBranchChanged?.Invoke(GetActiveBranch());
             OnActiveRemoteChanged?.Invoke(GetActiveRemote());
         }

--- a/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
@@ -301,6 +301,8 @@ namespace IntegrationTests
             await RepositoryManager.RemoteRemove("origin").StartAsAsync();
             await TaskManager.Wait();
             RepositoryManager.WaitForEvents();
+            WaitForNotBusy(repositoryManagerEvents);
+            repositoryManagerEvents.OnRemoteBranchListChanged.WaitOne(TimeSpan.FromSeconds(1));
 
             Environment.Repository.CurrentRemote.HasValue.Should().BeFalse();
 
@@ -310,7 +312,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
+            repositoryManagerListener.Received().OnLocalBranchListChanged();
             repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
@@ -321,6 +323,8 @@ namespace IntegrationTests
             await RepositoryManager.RemoteAdd("origin", "https://github.com/EvilShana/IOTestsRepo.git").StartAsAsync();
             await TaskManager.Wait();
             RepositoryManager.WaitForEvents();
+            WaitForNotBusy(repositoryManagerEvents);
+            repositoryManagerEvents.OnRemoteBranchListChanged.WaitOne(TimeSpan.FromSeconds(1));
 
             Environment.Repository.CurrentRemote.HasValue.Should().BeTrue();
             Environment.Repository.CurrentRemote.Value.Name.Should().Be("origin");
@@ -332,8 +336,8 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnStatusUpdate(Args.GitStatus);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
+            repositoryManagerListener.Received().OnLocalBranchListChanged();
+            repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
@@ -422,7 +426,7 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
+            repositoryManagerListener.Received().OnLocalBranchListChanged();
             repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
 
@@ -443,8 +447,8 @@ namespace IntegrationTests
             repositoryManagerListener.ReceivedWithAnyArgs().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.Received().OnActiveBranchChanged(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnActiveRemoteChanged(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListChanged();
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListChanged();
+            repositoryManagerListener.Received().OnLocalBranchListChanged();
+            repositoryManagerListener.Received().OnRemoteBranchListChanged();
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
         }
 

--- a/src/tests/IntegrationTests/Events/RepositoryWatcherTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryWatcherTests.cs
@@ -44,7 +44,7 @@ namespace IntegrationTests
                     Logger.Trace("Continue test");
 
                     repositoryWatcherListener.DidNotReceive().ConfigChanged();
-                    repositoryWatcherListener.DidNotReceive().HeadChanged(Args.String);
+                    repositoryWatcherListener.DidNotReceive().HeadChanged();
                     repositoryWatcherListener.Received().IndexChanged();
                     repositoryWatcherListener.DidNotReceive().LocalBranchCreated(Args.String);
                     repositoryWatcherListener.DidNotReceive().LocalBranchDeleted(Args.String);

--- a/src/tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/IntegrationTests.csproj
@@ -122,8 +122,8 @@
       <Link>sfw_x64.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(SolutionDir)\lib\sfw\win\x64\sfw_x64.dll.meta">
-      <Link>sfw_x64.dll.meta</Link>
+    <None Include="$(SolutionDir)\lib\sfw\win\x64\pthreadVC2.dll">
+      <Link>pthreadVC2.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
The fix made in #325 to batch the repository watcher events had the unfortunate effect of slightly changing the order of events. This tweak should restore the previous order, wherever that may be pertinent and still keep the batching effect.