### PR TITLE
Fix to Unity 2017.1 .Net 4.6 

### DIFF
--- a/common/SolutionInfo.cs
+++ b/common/SolutionInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "0.21.0";
+        internal const string Version = "0.21.1";
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -14,10 +14,6 @@ namespace GitHub.Unity
         private static readonly ILogging logger = Logging.GetLogger<Utility>();
 
         public const string StatusRenameDivider = "->";
-        public static readonly Regex ListBranchesRegex =
-            new Regex(@"^(?<active>\*)?\s+(?<name>[\w\d\/\-_]+)\s*(?:[a-z|0-9]{7} \[(?<tracking>[\w\d\/\-\_]+)\])?");
-        public static readonly Regex ListRemotesRegex =
-            new Regex(@"(?<name>[\w\d\-_]+)\s+(?<url>https?:\/\/(?<login>(?<user>[\w\d]+)(?::(?<token>[\w\d]+))?)@(?<host>[\w\d\.\/\%]+))\s+\((?<function>fetch|push)\)");
         public static readonly Regex LogCommitRegex = new Regex(@"commit\s(\S+)");
         public static readonly Regex LogMergeRegex = new Regex(@"Merge:\s+(\S+)\s+(\S+)");
         public static readonly Regex LogAuthorRegex = new Regex(@"Author:\s+(.+)\s<(.+)>");


### PR DESCRIPTION
Fixes #334 

Initially for #145 in #310 I went to remove these regex expressions as they are not used.
Testing that, it worked.
I went back and tried to fix the stored procedures.
Resharper believed `\_` to be incorrect. Expresso (a .net regex tool) didn't seem to mind it.
I assumed that was the error and changed it to `_`. After that I failed to test appropriately.