### PR TITLE
Reduce verbosity of build script so it's easier to read

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eux
+#!/bin/sh -eu
 Configuration="dev"
 if [ $# -gt 0 ]; then
 	Configuration=$1
@@ -32,7 +32,7 @@ else
 	nuget restore GitHub.Unity.sln
 fi
 
-xbuild GitHub.Unity.sln /verbosity:normal /property:Configuration=$Configuration /target:$Target || true
+xbuild GitHub.Unity.sln /verbosity:minimal /property:Configuration=$Configuration /target:$Target || true
 
 rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/deleteme*
 rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/deleteme*


### PR DESCRIPTION
The build.sh script was set up with a lot of verbosity to help debug, but now we don't need all of this, so reduce it to the essential output. Keep strict error checking and exit early if subcommands exit with errors flags.