### PR TITLE
Temporaily disabling integration test that incorrectly fails often

### DIFF
--- a/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
@@ -192,7 +192,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnRemoteBranchRemoved(Args.String, Args.String);
         }
 
-        [Test]
+        [Test, Ignore("Fails often")]
         public async Task ShouldAddAndCommitAllFiles()
         {
             await Initialize(TestRepoMasterCleanSynchronized);


### PR DESCRIPTION
Due to #382 I'm temporarily disabling this test
