### PR TITLE
Removing the extra InitializeRepository call

### DIFF
--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -42,7 +42,6 @@ namespace GitHub.Unity
             UnityAssetsPath = assetsPath;
             UnityProjectPath = assetsPath.Parent;
             UnityVersion = unityVersion;
-            InitializeRepository();
         }
 
         public void InitializeRepository(NPath expectedRepositoryPath = null)


### PR DESCRIPTION
`ApplicationCache` calls `DefaultEnvironment.Initialize` then `DefaultEnvironment.InitializeRepository`.
Meanwhile `DefaultEnvironment.Initiailize` calls `InitializeRepository` itself.