### PR TITLE
Changing the struct GitBranch to use a default constructor and fields

### DIFF
--- a/src/GitHub.Api/Git/GitBranch.cs
+++ b/src/GitHub.Api/Git/GitBranch.cs
@@ -11,12 +11,15 @@ namespace GitHub.Unity
     [Serializable]
     public struct GitBranch : ITreeData
     {
-        private string name;
-        private string tracking;
-        private bool active;
+        public static GitBranch Default = new GitBranch();
+
+        public string name;
+        public string tracking;
+        public bool isActive;
+
         public string Name { get { return name; } }
         public string Tracking { get { return tracking; } }
-        public bool IsActive { get { return active; } }
+        public bool IsActive { get { return isActive; } }
 
         public GitBranch(string name, string tracking, bool active)
         {
@@ -24,7 +27,7 @@ namespace GitHub.Unity
 
             this.name = name;
             this.tracking = tracking;
-            this.active = active;
+            this.isActive = active;
         }
 
         public override string ToString()


### PR DESCRIPTION
The current constructor for this struct prevents us from creating a default value for the struct itself.

https://github.com/github-for-unity/Unity/blob/2f38e6a1ae10ca804900fe19240be902095dd0f3/src/GitHub.Api/Git/GitBranch.cs#L21-L28