### PR TITLE
Changing a nullable GitStatus operations to non nullable

### DIFF
--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -15,7 +15,7 @@ namespace GitHub.Unity
 
         ITask LfsInstall(IOutputProcessor<string> processor = null);
 
-        ITask<GitStatus?> Status(IOutputProcessor<GitStatus?> processor = null);
+        ITask<GitStatus> Status(IOutputProcessor<GitStatus> processor = null);
 
         ITask<string> GetConfig(string key, GitConfigSource configSource,
             IOutputProcessor<string> processor = null);
@@ -207,7 +207,7 @@ namespace GitHub.Unity
                 .Configure(processManager);
         }
 
-        public ITask<GitStatus?> Status(IOutputProcessor<GitStatus?> processor = null)
+        public ITask<GitStatus> Status(IOutputProcessor<GitStatus> processor = null)
         {
             Logger.Trace("Status");
 

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -397,10 +397,10 @@ namespace GitHub.Unity
             var task = GitClient.Status()
                 .Finally((success, ex, data) =>
                 {
-                    Logger.Trace($"GitStatus update: {success} {(data.HasValue ? data.Value.ToString() : "[null]")}");
-                    if (success && data.HasValue)
+                    Logger.Trace($"GitStatus update: {success} {data}");
+                    if (success)
                     {
-                        OnStatusUpdated?.Invoke(data.Value);
+                        OnStatusUpdated?.Invoke(data);
                         Logger.Trace("Updated Git Status");
                     }
                 });

--- a/src/GitHub.Api/Git/Tasks/GitStatusTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitStatusTask.cs
@@ -2,12 +2,12 @@ using System.Threading;
 
 namespace GitHub.Unity
 {
-    class GitStatusTask : ProcessTask<GitStatus?>
+    class GitStatusTask : ProcessTask<GitStatus>
     {
         private const string TaskName = "git status";
 
         public GitStatusTask(IGitObjectFactory gitObjectFactory,
-            CancellationToken token, IOutputProcessor<GitStatus?> processor = null)
+            CancellationToken token, IOutputProcessor<GitStatus> processor = null)
             : base(token, processor ?? new StatusOutputProcessor(gitObjectFactory))
         {
             Name = TaskName;

--- a/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace GitHub.Unity
 {
-    class StatusOutputProcessor : BaseOutputProcessor<GitStatus?>
+    class StatusOutputProcessor : BaseOutputProcessor<GitStatus>
     {
         private static readonly Regex branchTrackedAndDelta = new Regex(@"(.*)\.\.\.(.*)\s\[(.*)\]",
             RegexOptions.Compiled);

--- a/src/tests/IntegrationTests/ProcessManagerExtensions.cs
+++ b/src/tests/IntegrationTests/ProcessManagerExtensions.cs
@@ -44,7 +44,7 @@ namespace IntegrationTests
                 .Configure(processManager, path, logNameStatus, workingDirectory, false);
         }
 
-        public static ITask<GitStatus?> GetGitStatus(this IProcessManager processManager,
+        public static ITask<GitStatus> GetGitStatus(this IProcessManager processManager,
             NPath workingDirectory,
             IEnvironment environment, IProcessEnvironment gitEnvironment,
             NPath gitPath = null)
@@ -54,7 +54,7 @@ namespace IntegrationTests
 
             NPath path = gitPath ?? defaultGitPath;
 
-            return new ProcessTask<GitStatus?>(CancellationToken.None, processor)
+            return new ProcessTask<GitStatus>(CancellationToken.None, processor)
                 .Configure(processManager, path, "status -b -u --porcelain", workingDirectory, false);
         }
 

--- a/src/tests/TestUtils/Substitutes/CreateRepositoryProcessRunnerOptions.cs
+++ b/src/tests/TestUtils/Substitutes/CreateRepositoryProcessRunnerOptions.cs
@@ -7,12 +7,12 @@ namespace TestUtils
     {
         public Dictionary<GitConfigGetKey, string> GitConfigGetResults { get; set; }
 
-        public GitStatus? GitStatusResults { get; set; }
+        public GitStatus GitStatusResults { get; set; }
 
         public List<GitLock> GitListLocksResults { get; set; }
 
         public CreateRepositoryProcessRunnerOptions(Dictionary<GitConfigGetKey, string> getConfigResults = null,
-            GitStatus? gitStatusResults = null,
+            GitStatus gitStatusResults = new GitStatus(),
             List<GitLock> gitListLocksResults = null)
         {
             GitListLocksResults = gitListLocksResults;

--- a/src/tests/TestUtils/Substitutes/SubstituteFactory.cs
+++ b/src/tests/TestUtils/Substitutes/SubstituteFactory.cs
@@ -411,13 +411,12 @@ namespace TestUtils
                 });
 
             gitClient.Status().Returns(info => {
-                GitStatus? result = options.GitStatusResults;
-
-                var ret = new FuncTask<GitStatus?>(CancellationToken.None, _ => result);
+                var result = options.GitStatusResults;
+                var ret = new FuncTask<GitStatus>(CancellationToken.None, _ => result);
 
                 logger.Trace(@"RunGitStatus() -> {0}",
-                    result != null ? $"Success: \"{result.Value}\"" : "Failure");
-                var task = Args.GitStatusTask;
+                    $"Success: \"{result}\"");
+                
                 return ret;
             });
 

--- a/src/tests/UnitTests/ProcessManagerExtensions.cs
+++ b/src/tests/UnitTests/ProcessManagerExtensions.cs
@@ -62,12 +62,12 @@ namespace UnitTests
 
             NPath path = gitPath ?? defaultGitPath;
 
-            var results = await new ProcessTask<GitStatus?>(CancellationToken.None, processor)
+            var results = await new ProcessTask<GitStatus>(CancellationToken.None, processor)
                 .Configure(processManager, path, "status -b -u --porcelain", workingDirectory, false)
                 .Start()
                 .Task;
 
-            return results.Value;
+            return results;
         }
  
         public static async Task<List<GitRemote>> GetGitRemoteEntries(this ProcessManager processManager,


### PR DESCRIPTION
I realized there was never a situation where `GitStatus` should be null.
We do a lot of checking if `GitStatus` is null and getting the value.
I tracked it all back to an error in how `StatusOutputProcessor` is defined.
It never returns a null `GitStatus` but is defined as `GitStatus?` once that is changed the rest of the code changes accordingly.