### PR TITLE
Gross copy pasta error with removing a remote branch

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -303,9 +303,9 @@ namespace GitHub.Unity
             Dictionary<string, ConfigBranch> branchList;
             if (remoteBranches.TryGetValue(remote, out branchList))
             {
-                if (localBranches.ContainsKey(name))
+                if (branchList.ContainsKey(name))
                 {
-                    localBranches.Remove(name);
+                    branchList.Remove(name);
 
                     Logger.Trace("OnRemoteBranchListChanged");
                     OnRemoteBranchListChanged?.Invoke();


### PR DESCRIPTION
I found this copy paste error while converting Repository