### PR TITLE
Making GitLock serializable

### DIFF
--- a/src/GitHub.Api/Git/GitLock.cs
+++ b/src/GitHub.Api/Git/GitLock.cs
@@ -5,12 +5,12 @@ namespace GitHub.Unity
     [Serializable]
     public struct GitLock
     {
-        public static GitLock Default = new GitLock(null, null, null, -1);
+        public static GitLock Default = new GitLock { ID = -1 };
 
-        public readonly int ID;
-        public readonly string Path;
-        public readonly string FullPath;
-        public readonly string User;
+        public int ID;
+        public string Path;
+        public string FullPath;
+        public string User;
 
         public GitLock(string path, string fullPath, string user, int id)
         {


### PR DESCRIPTION
Quick fix to GitLock which prevents it's serialization