### PR TITLE
Combining RepositoryManager OnLocalBranchListUpdated & OnRemoteBranchListUpdated

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -53,8 +53,7 @@ namespace GitHub.Unity
             repositoryManager.OnCurrentRemoteUpdated += RepositoryManager_OnCurrentRemoteUpdated;
             repositoryManager.OnStatusUpdated += status => CurrentStatus = status;
             repositoryManager.OnLocksUpdated += locks => CurrentLocks = locks;
-            repositoryManager.OnLocalBranchListUpdated += RepositoryManager_OnLocalBranchListUpdated;
-            repositoryManager.OnRemoteBranchListUpdated += RepositoryManager_OnRemoteBranchListUpdated;
+            repositoryManager.OnBranchListsUpdated += RepositoryManager_OnBranchListsUpdated;
             repositoryManager.OnLocalBranchUpdated += RepositoryManager_OnLocalBranchUpdated;
             repositoryManager.OnLocalBranchAdded += RepositoryManager_OnLocalBranchAdded;
             repositoryManager.OnLocalBranchRemoved += RepositoryManager_OnLocalBranchRemoved;
@@ -62,7 +61,7 @@ namespace GitHub.Unity
             repositoryManager.OnRemoteBranchRemoved += RepositoryManager_OnRemoteBranchRemoved;
             repositoryManager.OnGitUserLoaded += user => User = user;
         }
-
+        
         public void Refresh()
         {
             repositoryManager?.Refresh();
@@ -202,24 +201,21 @@ namespace GitHub.Unity
             }
         }
 
-        private void RepositoryManager_OnRemoteBranchListUpdated(Dictionary<string, ConfigRemote> updatedRemotes, Dictionary<string, Dictionary<string, ConfigBranch>> branches)
+        private void RepositoryManager_OnBranchListsUpdated(Dictionary<string, ConfigBranch> updateBranches, Dictionary<string, ConfigRemote> updateRemotes, Dictionary<string, Dictionary<string, ConfigBranch>> updateRemoteBranches)
         {
-            remotes = updatedRemotes;
-
-            Remotes = remotes.Select(pair => GetGitRemote(pair.Value)).ToArray();
-
-            remoteBranches = branches;
-
-            Logger.Trace("OnRemoteBranchListChanged");
-            OnRemoteBranchListChanged?.Invoke();
-        }
-
-        private void RepositoryManager_OnLocalBranchListUpdated(Dictionary<string, ConfigBranch> branches)
-        {
-            localBranches = branches;
+            localBranches = updateBranches;
 
             Logger.Trace("OnLocalBranchListChanged");
             OnLocalBranchListChanged?.Invoke();
+
+            remotes = updateRemotes;
+
+            Remotes = remotes.Select(pair => GetGitRemote(pair.Value)).ToArray();
+
+            remoteBranches = updateRemoteBranches;
+
+            Logger.Trace("OnRemoteBranchListChanged");
+            OnRemoteBranchListChanged?.Invoke();
         }
 
         private void UpdateRepositoryInfo()

--- a/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryManagerTests.cs
@@ -98,8 +98,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -157,8 +156,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -183,8 +181,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.Received().OnLocalBranchUpdated(expectedLocalBranch);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -234,8 +231,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -260,8 +256,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.Received().OnLocalBranchUpdated(expectedLocalBranch);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -301,8 +296,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -357,8 +351,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.Received().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.Received().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.Received().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.Received().OnLocalBranchRemoved(deletedBranch);
@@ -411,8 +404,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.Received().OnLocalBranchAdded(createdBranch1);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -461,8 +453,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.Received().OnLocalBranchAdded(createdBranch2);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -545,16 +536,14 @@ namespace IntegrationTests
             RepositoryManager.WaitForEvents();
             repositoryManagerEvents.WaitForNotBusy();
 
-            repositoryManagerEvents.OnRemoteBranchListUpdated.WaitOne(TimeSpan.FromSeconds(1));
-            repositoryManagerEvents.OnLocalBranchListUpdated.WaitOne(TimeSpan.FromSeconds(1));
+            repositoryManagerEvents.OnBranchListsUpdated.WaitOne(TimeSpan.FromSeconds(1));
 
             repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnStatusUpdated(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.Received().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.Received().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.Received().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -580,16 +569,14 @@ namespace IntegrationTests
             await TaskManager.Wait();
             RepositoryManager.WaitForEvents();
             repositoryManagerEvents.WaitForNotBusy();
-            repositoryManagerEvents.OnRemoteBranchListUpdated.WaitOne(TimeSpan.FromSeconds(1));
-            repositoryManagerEvents.OnLocalBranchListUpdated.WaitOne(TimeSpan.FromSeconds(1));
+            repositoryManagerEvents.OnBranchListsUpdated.WaitOne(TimeSpan.FromSeconds(1));
 
             repositoryManagerListener.Received().OnIsBusyChanged(Args.Bool);
             repositoryManagerListener.DidNotReceive().OnStatusUpdated(Args.GitStatus);
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.Received().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.Received().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.Received().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -679,8 +666,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.Received().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.Received().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.Received().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.Received().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -738,8 +724,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.Received().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.Received().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -810,8 +795,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.Received().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);
@@ -899,8 +883,7 @@ namespace IntegrationTests
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -12,8 +12,7 @@ namespace TestUtils.Events
         void OnIsBusyChanged(bool busy);
         void OnStatusUpdated(GitStatus status);
         void OnLocksUpdated(IEnumerable<GitLock> locks);
-        void OnLocalBranchListUpdated(Dictionary<string, ConfigBranch> branchList);
-        void OnRemoteBranchListUpdated(Dictionary<string, ConfigRemote> remotesList, Dictionary<string, Dictionary<string, ConfigBranch>> remoteBranchList);
+        void OnBranchListsUpdated(Dictionary<string, ConfigBranch> branchList, Dictionary<string, ConfigRemote> remotesList, Dictionary<string, Dictionary<string, ConfigBranch>> remoteBranchList);
         void OnLocalBranchUpdated(string name);
         void OnLocalBranchAdded(string name);
         void OnLocalBranchRemoved(string name);
@@ -33,8 +32,7 @@ namespace TestUtils.Events
         public EventWaitHandle OnCurrentBranchUpdated { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnCurrentRemoteUpdated { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnHeadUpdated { get; } = new AutoResetEvent(false);
-        public EventWaitHandle OnLocalBranchListUpdated { get; } = new AutoResetEvent(false);
-        public EventWaitHandle OnRemoteBranchListUpdated { get; } = new AutoResetEvent(false);
+        public EventWaitHandle OnBranchListsUpdated { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnLocalBranchUpdated { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnLocalBranchAdded { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnLocalBranchRemoved { get; } = new AutoResetEvent(false);
@@ -51,8 +49,7 @@ namespace TestUtils.Events
             OnCurrentBranchUpdated.Reset();
             OnCurrentRemoteUpdated.Reset();
             OnHeadUpdated.Reset();
-            OnLocalBranchListUpdated.Reset();
-            OnRemoteBranchListUpdated.Reset();
+            OnBranchListsUpdated.Reset();
             OnLocalBranchUpdated.Reset();
             OnLocalBranchAdded.Reset();
             OnLocalBranchRemoved.Reset();
@@ -119,16 +116,10 @@ namespace TestUtils.Events
                 managerEvents?.OnCurrentRemoteUpdated.Set();
             };
 
-            repositoryManager.OnLocalBranchListUpdated += branchList => {
-                logger?.Trace("OnLocalBranchListUpdated");
-                listener.OnLocalBranchListUpdated(branchList);
-                managerEvents?.OnLocalBranchListUpdated.Set();
-            };
-
-            repositoryManager.OnRemoteBranchListUpdated += (remotesList, branchList) => {
-                logger?.Trace("OnRemoteBranchListUpdated");
-                listener.OnRemoteBranchListUpdated(remotesList, branchList);
-                managerEvents?.OnRemoteBranchListUpdated.Set();
+            repositoryManager.OnBranchListsUpdated += (branches, remotes, remoteBranches) => {
+                logger?.Trace("OnBranchListsUpdated");
+                listener.OnBranchListsUpdated(branches, remotes, remoteBranches);
+                managerEvents?.OnBranchListsUpdated.Set();
             };
 
             repositoryManager.OnLocalBranchUpdated += name => {
@@ -175,8 +166,7 @@ namespace TestUtils.Events
             repositoryManagerListener.DidNotReceive().OnLocksUpdated(Args.EnumerableGitLock);
             repositoryManagerListener.DidNotReceive().OnCurrentBranchUpdated(Arg.Any<ConfigBranch?>());
             repositoryManagerListener.DidNotReceive().OnCurrentRemoteUpdated(Arg.Any<ConfigRemote?>());
-            repositoryManagerListener.DidNotReceive().OnLocalBranchListUpdated(Arg.Any<Dictionary<string, ConfigBranch>>());
-            repositoryManagerListener.DidNotReceive().OnRemoteBranchListUpdated(Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
+            repositoryManagerListener.DidNotReceive().OnBranchListsUpdated(Arg.Any<Dictionary<string, ConfigBranch>>(), Arg.Any<Dictionary<string, ConfigRemote>>(), Arg.Any<Dictionary<string, Dictionary<string, ConfigBranch>>>());
             repositoryManagerListener.DidNotReceive().OnLocalBranchUpdated(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchAdded(Args.String);
             repositoryManagerListener.DidNotReceive().OnLocalBranchRemoved(Args.String);

--- a/src/tests/UnitTests/Git/RepositoryTests.cs
+++ b/src/tests/UnitTests/Git/RepositoryTests.cs
@@ -91,11 +91,9 @@ namespace UnitTests
                 expectedRemote = remote;
             };
 
-            repositoryManager.OnLocalBranchListUpdated += Raise.Event<Action<Dictionary<string, ConfigBranch>>>(branchDictionary);
+            repositoryManager.OnBranchListsUpdated += Raise.Event<Action<Dictionary<string, ConfigBranch>, Dictionary<string, ConfigRemote>, Dictionary<string, Dictionary<string, ConfigBranch>>>>(branchDictionary, remoteDictionary, remoteBranchDictionary);
 
             repositoryEvents.OnLocalBranchListChanged.WaitOne(repositoryEventsTimeout).Should().BeTrue("OnLocalBranchListChanged not raised");
-
-            repositoryManager.OnRemoteBranchListUpdated += Raise.Event<Action<Dictionary<string, ConfigRemote>, Dictionary<string, Dictionary<string, ConfigBranch>>>>(remoteDictionary, remoteBranchDictionary);
 
             repositoryEvents.OnRemoteBranchListChanged.WaitOne(repositoryEventsTimeout).Should().BeTrue("OnRemoteBranchListChanged not raised");
 


### PR DESCRIPTION
These two events are fired one after each other when they are part of the same load operation.