### PR TITLE
Changing UpdateRepositoryInfo to ClearRepositoryInfo

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -462,8 +462,8 @@ namespace GitHub.Unity
 
         private void ClearRepositoryInfo()
         {
-            CloneUrl = new UriString(CurrentRemote.Value.Url);
-            Name = CloneUrl.RepositoryName;
+            CloneUrl = null;
+            Name = null;
         }
 
         private void RepositoryManager_OnLocalBranchRemoved(string name)

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -417,7 +417,7 @@ namespace GitHub.Unity
                 {
                         CurrentConfigRemote = remote;
                         CurrentRemote = GetGitRemote(remote.Value);
-                        UpdateRepositoryInfo();
+                        ClearRepositoryInfo();
                 }
             }) { Affinity = TaskAffinity.UI }.Start();
         }
@@ -460,20 +460,10 @@ namespace GitHub.Unity
             LocalBranches = LocalConfigBranches.Values.Select(GetLocalGitBranch).ToArray();
         }
 
-        private void UpdateRepositoryInfo()
+        private void ClearRepositoryInfo()
         {
-            if (CurrentRemote.HasValue)
-            {
-                CloneUrl = new UriString(CurrentRemote.Value.Url);
-                Name = CloneUrl.RepositoryName;
-                Logger.Trace("CloneUrl: {0}", CloneUrl.ToString());
-            }
-            else
-            {
-                CloneUrl = null;
-                Name = LocalPath.FileName;
-                Logger.Trace("CloneUrl: [NULL]");
-            }
+            CloneUrl = new UriString(CurrentRemote.Value.Url);
+            Name = CloneUrl.RepositoryName;
         }
 
         private void RepositoryManager_OnLocalBranchRemoved(string name)


### PR DESCRIPTION
As mentioned here https://github.com/github-for-unity/Unity/pull/390#issuecomment-342514069

https://github.com/github-for-unity/Unity/blob/88c114e5ac64496dca8b8383905192aaed143f81/src/GitHub.Api/Git/Repository.cs#L590-L629

`Name` and `CloneUrl` are already calculated lazily. The functionality in `UpdateRepositoryInfo` is a duplicate of that lazy load. So it would be best to remove `UpdateRepositoryInfo` and add `ClearRepositoryInfo` which just clears the values and then lets the lazy load kick in.