### PR TITLE
Forcing update on index change

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -429,7 +429,9 @@ namespace GitHub.Unity
         }
 
         private void Watcher_OnIndexChanged()
-        {}
+        {
+            OnRepositoryUpdated?.Invoke();
+        }
 
         private void Watcher_OnLocalBranchCreated(string name)
         {


### PR DESCRIPTION
Due to commit operations sometimes being interpreted as LocalBranchCreated/LocalBranchDeleted
We need to force an update of GitStatus on Index change as a temporary measure.

```
171108-13:42:41 TRACE [ 1] <GitClient>                         Add all files
171108-13:42:41 TRACE [ 1] <GitClient>                         Commit
171108-13:42:41 TRACE [ 4] <RepositoryManager>                 IsBusyChanged Value:True
171108-13:42:42 TRACE [10] <RepositoryWatcher>                 Handling 198 Events
171108-13:42:42 TRACE [10] <RepositoryWatcher>                 IndexChanged
171108-13:42:42 TRACE [10] <RepositoryWatcher>                 LocalBranchCreated: master
171108-13:42:42 TRACE [10] <RepositoryWatcher>                 LocalBranchDeleted: master
171108-13:42:42 TRACE [10] <RepositoryWatcher>                 Processed 3 Events
171108-13:42:43 TRACE [10] <RepositoryWatcher>                 Handling 35 Events
171108-13:42:43 TRACE [10] <RepositoryWatcher>                 Processed 0 Events
```