### PR TITLE
Refactor HookupHandlers in order accurately wrap tasks

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -173,20 +173,20 @@ namespace GitHub.Unity
 
         public ITask CommitAllFiles(string message, string body)
         {
-            var add = GitClient.AddAll();
-            add.OnStart += t => IsBusy = true;
-            return add
-                .Then(GitClient.Commit(message, body))
-                .Finally(() => IsBusy = false);
+            var task = GitClient.AddAll()
+                .Then(GitClient.Commit(message, body));
+
+            HookupHandlers(task, true);
+            return task;
         }
 
         public ITask CommitFiles(List<string> files, string message, string body)
         {
-            var add = GitClient.Add(files);
-            add.OnStart += t => IsBusy = true;
-            return add
-                .Then(GitClient.Commit(message, body))
-                .Finally(() => IsBusy = false);
+            var task = GitClient.Add(files)
+                .Then(GitClient.Commit(message, body));
+
+            HookupHandlers(task, true);
+            return task;
         }
 
         public ITask<List<GitLogEntry>> Log()


### PR DESCRIPTION
Fixes #424 

`HookupHandlers` was refactored to use the task system in order to accurately wrap operations performed in `RepositoryManager`.
Tasks that are exclusive or batches of exclusive operations should toggle the busy flag.
Tasks that directly cause changes to the file system should stop the watcher.

| RepositoryManager Method | Tasks Invoked   | Exclusive operations | File system changes   |
|--|--|--|--|
|  CommitAllFiles  |  GitAddTask, GitCommitTask  |  👍   |    |  
|  CommitFiles  | GitAddTask, GitCommitTask    |  👍   |    |  
|  Log |  GitLogTask  |    |    |  
|  Status|   GitStatusTask |  👍   |    |  
| Fetch|  GitFetchTask  |  👍   |    |  
|  Pull| GitPullTask  | 👍    |  👍   |  
|  Push| GitPushTask  | 👍    |    |  
|   Revert |   GitRevertTask | 👍    |  👍   |  
|  RemoteAdd| GitRemoteAddTask   | 👍    |    |  
|  RemoteRemove|   GitRemoteRemoveTask | 👍    |    |  
|  RemoteChange| GitRemoteChangeTask   | 👍    |    |  
|  SwitchBranch| GitSwitchBranchesTask   | 👍    |   👍  |  
| DeleteBranch |  GitBranchDeleteTask  |  👍   |    |  
| CreateBranch |  GitBranchCreateTask  |  👍   |    |  
|  ListLocks|  GitListLocksTask  |    |    |  
|LockFile  |   GitLockTask |  👍   |    |  
| UnlockFile | GitUnlockTask   |  👍   |    |  