### PR TITLE
Adding functionality to GitClient to set user info

### DIFF
--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -87,6 +87,8 @@ namespace GitHub.Unity
 
     class GitClient : IGitClient
     {
+        private const string UserNameConfigKey = "user.name";
+        private const string UserEmailConfigKey = "user.email";
         private readonly IEnvironment environment;
         private readonly IProcessManager processManager;
         private readonly ITaskManager taskManager;
@@ -260,19 +262,19 @@ namespace GitHub.Unity
             string username = null;
             string email = null;
 
-            return GetConfig("user.name", GitConfigSource.User).Then((success, value) => {
+            return GetConfig(UserNameConfigKey, GitConfigSource.User).Then((success, value) => {
                 if (success)
                 {
                     username = value;
                 }
 
-            }).Then(GetConfig("user.email", GitConfigSource.User).Then((success, value) => {
+            }).Then(GetConfig(UserEmailConfigKey, GitConfigSource.User).Then((success, value) => {
                 if (success)
                 {
                     email = value;
                 }
             })).Then(success => {
-                Logger.Trace("user.name:{1} user.email:{2}", success, username, email);
+                Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
                 return new User { Name= username, Email = email };
             });
         }

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -272,15 +272,15 @@ namespace GitHub.Unity
                     }
                 })
                 .Then(GetConfig(UserEmailConfigKey, GitConfigSource.User)
-                    .Then((success, value) => {
-                        if (success)
-                        {
-                            email = value;
-                        }
-                    })).Then(success => {
-                    Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
-                    return new User { Name = username, Email = email };
-                });
+                .Then((success, value) => {
+                    if (success)
+                    {
+                        email = value;
+                    }
+                })).Then(success => {
+                Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
+                return new User { Name = username, Email = email };
+            });
         }
 
         public ITask<User> SetConfigUserAndEmail(string username, string email)

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -83,6 +83,8 @@ namespace GitHub.Unity
         ITask<Version> Version(IOutputProcessor<Version> processor = null);
 
         ITask<Version> LfsVersion(IOutputProcessor<Version> processor = null);
+
+        ITask<User> SetConfigUserAndEmail(string username, string email);
     }
 
     class GitClient : IGitClient
@@ -270,15 +272,22 @@ namespace GitHub.Unity
                     }
                 })
                 .Then(GetConfig(UserEmailConfigKey, GitConfigSource.User)
-                .Then((success, value) => {
-                    if (success)
-                    {
-                        email = value;
-                    }
-                })).Then(success => {
+                    .Then((success, value) => {
+                        if (success)
+                        {
+                            email = value;
+                        }
+                    })).Then(success => {
                     Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
-                    return new User { Name= username, Email = email };
+                    return new User { Name = username, Email = email };
                 });
+        }
+
+        public ITask<User> SetConfigUserAndEmail(string username, string email)
+        {
+            return SetConfig(UserNameConfigKey, username, GitConfigSource.User)
+                .Then(SetConfig(UserEmailConfigKey, email, GitConfigSource.User))
+                .Then(b => new User { Name = username, Email = email });
         }
 
         public ITask<List<GitLock>> ListLocks(bool local, BaseOutputListProcessor<GitLock> processor = null)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -63,16 +63,12 @@ namespace GitHub.Unity
                                          if (Repository != null)
                                          {
                                              Repository.User.Name = gitName = newGitName;
-                                             Repository.User.Email = newGitEmail;
+                                             Repository.User.Email = gitEmail = newGitEmail;
                                          }
                                          else
                                          {
-                                             if (cachedUser == null)
-                                             {
-                                                 cachedUser = new User();
-                                             }
-                                             cachedUser.Name = newGitName;
-                                             cachedUser.Email = newGitEmail;
+                                             gitName = newGitName;
+                                             gitEmail = newGitEmail;
                                          }
 
                                          Redraw();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -22,6 +22,7 @@ namespace GitHub.Unity
         [SerializeField] private string gitEmail;
         [SerializeField] private string newGitName;
         [SerializeField] private string newGitEmail;
+        [SerializeField] private bool needsSaving;
 
         public override void InitializeView(IView parent)
         {
@@ -42,11 +43,17 @@ namespace GitHub.Unity
 
             EditorGUI.BeginDisabledGroup(IsBusy || Parent.IsBusy);
             {
-                newGitName = EditorGUILayout.TextField(GitConfigNameLabel, newGitName);
-                newGitEmail = EditorGUILayout.TextField(GitConfigEmailLabel, newGitEmail);
+                EditorGUI.BeginChangeCheck();
+                {
+                    newGitName = EditorGUILayout.TextField(GitConfigNameLabel, newGitName);
+                    newGitEmail = EditorGUILayout.TextField(GitConfigEmailLabel, newGitEmail);
+                }
 
-                var needsSaving = (newGitName != gitName || newGitEmail != gitEmail)
-                    && !(string.IsNullOrEmpty(newGitName) || string.IsNullOrEmpty(newGitEmail));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    needsSaving = !(string.IsNullOrEmpty(newGitName) || string.IsNullOrEmpty(newGitEmail))
+                        && (newGitName != gitName || newGitEmail != gitEmail);
+                }
 
                 EditorGUI.BeginDisabledGroup(!needsSaving);
                 {
@@ -70,6 +77,8 @@ namespace GitHub.Unity
                                              gitName = newGitName;
                                              gitEmail = newGitEmail;
                                          }
+
+                                         needsSaving = false;
 
                                          Redraw();
                                          Finish(true);
@@ -103,6 +112,7 @@ namespace GitHub.Unity
                 {
                     newGitName = gitName = Repository.User.Name;
                     newGitEmail = gitEmail = Repository.User.Email;
+                    needsSaving = false;
                 }
             }
         }
@@ -127,6 +137,7 @@ namespace GitHub.Unity
                     {
                         newGitName = gitName = user.Name;
                         newGitEmail = gitEmail = user.Email;
+                        needsSaving = false;
                         Redraw();
                     }
                 }).Start();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -56,14 +56,15 @@ namespace GitHub.Unity
                         GUI.FocusControl(null);
                         isBusy = true;
 
-                        GitClient.SetConfig("user.name", newGitName, GitConfigSource.User)
-                                 .Then((success, value) =>
-                                 {
+                        GitClient.SetConfigUserAndEmail(newGitName, newGitEmail)
+                                 .FinallyInUI((success, exception, user) => {
+                                     isBusy = false;
                                      if (success)
                                      {
                                          if (Repository != null)
                                          {
                                              Repository.User.Name = newGitName;
+                                             Repository.User.Email = newGitEmail;
                                          }
                                          else
                                          {
@@ -72,32 +73,12 @@ namespace GitHub.Unity
                                                  cachedUser = new User();
                                              }
                                              cachedUser.Name = newGitName;
+                                             cachedUser.Email = newGitEmail;
                                          }
-                                     }
-                                 })
-                                 .Then(
-                                     GitClient.SetConfig("user.email", newGitEmail, GitConfigSource.User)
-                                              .Then((success, value) =>
-                                              {
-                                                  if (success)
-                                                  {
-                                                      if (Repository != null)
-                                                      {
-                                                          Repository.User.Email = newGitEmail;
-                                                      }
-                                                      else
-                                                      {
-                                                          cachedUser.Email = newGitEmail;
-                                                      }
 
-                                                      userDataHasChanged = true;
-                                                  }
-                                              }))
-                                 .FinallyInUI((_, __) =>
-                                 {
-                                     isBusy = false;
-                                     Redraw();
-                                     Finish(true);
+                                         Redraw();
+                                         Finish(true);
+                                     }
                                  })
                                  .Start();
                     }


### PR DESCRIPTION
1. In preparation for #427 "Adding cache to GitClient"... The `GitClient` will need to perform certain cache operations after the user is saved. In order to take a smaller step towards that goal I'm centralizing the functionality to set the git user and email in `GitClient`
2. I also moved the definition of the name and email text boxes to a `BeginChangeCheck/EndChangeCheck` sequence. This ensures that `needsSaving` is only calculated when the textbox values have changed.

Depends on:
- [x] #425 
- [x] #423