### PR TITLE
Utilizing a cache for user data

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -78,6 +78,7 @@ namespace GitHub.Unity
                 }
             }
 
+            Environment.User.Initialize(GitClient);
         }
 
         public ITask InitializeRepository()

--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -49,7 +49,7 @@ namespace GitHub.Unity
 
     public interface IGitUserCache : IManagedCache
     {
-        User User { get; }
+        User User { get; set; }
     }
 
     public interface IGitStatusCache : IManagedCache

--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -49,7 +49,8 @@ namespace GitHub.Unity
 
     public interface IGitUserCache : IManagedCache
     {
-        User User { get; set; }
+        string Name { get; set; }
+        string Email { get; set; }
     }
 
     public interface IGitStatusCache : IManagedCache

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -84,7 +84,7 @@ namespace GitHub.Unity
 
         ITask<Version> LfsVersion(IOutputProcessor<Version> processor = null);
 
-        ITask<GitUser> SetConfigUserAndEmail(string username, string email);
+        ITask<GitUser> SetConfigNameAndEmail(string username, string email);
     }
 
     class GitClient : IGitClient
@@ -283,7 +283,7 @@ namespace GitHub.Unity
             });
         }
 
-        public ITask<GitUser> SetConfigUserAndEmail(string username, string email)
+        public ITask<GitUser> SetConfigNameAndEmail(string username, string email)
         {
             return SetConfig(UserNameConfigKey, username, GitConfigSource.User)
                 .Then(SetConfig(UserEmailConfigKey, email, GitConfigSource.User))

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -123,7 +123,8 @@ namespace GitHub.Unity
 
         private void GitUserCacheOnCacheInvalidated()
         {
-
+            Logger.Trace("GitUserCache Invalidated");
+            UpdateUserAndEmail();
         }
 
         public void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent)
@@ -320,6 +321,8 @@ namespace GitHub.Unity
 
         private void UpdateUserAndEmail()
         {
+            Logger.Trace("UpdateUserAndEmail");
+
             string username = null;
             string email = null;
 

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -8,8 +8,6 @@ namespace GitHub.Unity
 {
     public interface IGitClient
     {
-        event Action<CacheUpdateEvent> CurrentUserChanged;
-
         Task<NPath> FindGitInstallation();
         ITask<ValidateGitInstallResult> ValidateGitInstall(NPath path);
 
@@ -24,6 +22,8 @@ namespace GitHub.Unity
 
         ITask<string> SetConfig(string key, string value, GitConfigSource configSource,
             IOutputProcessor<string> processor = null);
+
+        ITask<GitUser> GetConfigUserAndEmail();
 
         ITask<List<GitLock>> ListLocks(bool local,
             BaseOutputListProcessor<GitLock> processor = null);
@@ -84,11 +84,7 @@ namespace GitHub.Unity
 
         ITask<Version> LfsVersion(IOutputProcessor<Version> processor = null);
 
-        void SetConfigUserAndEmail(string username, string email);
-
-        void CheckUserChangedEvent(CacheUpdateEvent gitLogCacheUpdateEvent);
-
-        User CurrentUser { get; }
+        ITask<GitUser> SetConfigUserAndEmail(string username, string email);
     }
 
     class GitClient : IGitClient
@@ -100,49 +96,12 @@ namespace GitHub.Unity
         private readonly ITaskManager taskManager;
         private readonly CancellationToken cancellationToken;
 
-        public event Action<CacheUpdateEvent> CurrentUserChanged;
-        private bool cacheInitialized;
-
         public GitClient(IEnvironment environment, IProcessManager processManager, ITaskManager taskManager)
         {
-            Logger.Trace("Constructed");
-
             this.environment = environment;
             this.processManager = processManager;
             this.taskManager = taskManager;
             this.cancellationToken = taskManager.Token;
-        }
-
-        public void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent)
-        {
-            var managedCache = environment.CacheContainer.GitUserCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
-
-            Logger.Trace("Check GitUserCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
-                cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
-
-            if (raiseEvent)
-            {
-                var dateTimeOffset = managedCache.LastUpdatedAt;
-                var updateEvent = new CacheUpdateEvent { UpdatedTimeString = dateTimeOffset.ToString() };
-                HandleGitLogCacheUpdatedEvent(updateEvent);
-            }
-        }
-
-        public User CurrentUser
-        {
-            get
-            {
-                if (!cacheInitialized)
-                {
-                    cacheInitialized = true;
-                    environment.CacheContainer.GitUserCache.CacheInvalidated += GitUserCacheOnCacheInvalidated;
-                    environment.CacheContainer.GitUserCache.CacheUpdated += GitUserCacheOnCacheUpdated;
-                }
-
-                return environment.CacheContainer.GitUserCache.User;
-            }
-            private set { environment.CacheContainer.GitUserCache.User = value; }
         }
 
         public async Task<NPath> FindGitInstallation()
@@ -300,12 +259,35 @@ namespace GitHub.Unity
                 .Configure(processManager);
         }
 
-        public void SetConfigUserAndEmail(string username, string email)
+        public ITask<GitUser> GetConfigUserAndEmail()
         {
-            SetConfig(UserNameConfigKey, username, GitConfigSource.User)
+            string username = null;
+            string email = null;
+
+            return GetConfig(UserNameConfigKey, GitConfigSource.User)
+                .Then((success, value) => {
+                    if (success)
+                    {
+                        username = value;
+                    }
+                })
+                .Then(GetConfig(UserEmailConfigKey, GitConfigSource.User)
+                .Then((success, value) => {
+                    if (success)
+                    {
+                        email = value;
+                    }
+                })).Then(success => {
+                Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
+                return new GitUser(username, email);
+            });
+        }
+
+        public ITask<GitUser> SetConfigUserAndEmail(string username, string email)
+        {
+            return SetConfig(UserNameConfigKey, username, GitConfigSource.User)
                 .Then(SetConfig(UserEmailConfigKey, email, GitConfigSource.User))
-                .Then(UpdateUserAndEmail)
-                .Start();
+                .Then(b => new GitUser(username, email));
         }
 
         public ITask<List<GitLock>> ListLocks(bool local, BaseOutputListProcessor<GitLock> processor = null)
@@ -480,54 +462,28 @@ namespace GitHub.Unity
                 .Configure(processManager);
         }
 
-        private void GitUserCacheOnCacheUpdated(DateTimeOffset timeOffset)
-        {
-            HandleGitLogCacheUpdatedEvent(new CacheUpdateEvent
-            {
-                UpdatedTimeString = timeOffset.ToString()
-            });
-        }
-
-        private void GitUserCacheOnCacheInvalidated()
-        {
-            Logger.Trace("GitUserCache Invalidated");
-            UpdateUserAndEmail();
-        }
-        
-        private void HandleGitLogCacheUpdatedEvent(CacheUpdateEvent cacheUpdateEvent)
-        {
-            Logger.Trace("GitUserCache Updated {0}", cacheUpdateEvent.UpdatedTimeString);
-            CurrentUserChanged?.Invoke(cacheUpdateEvent);
-        }
-
-        private void UpdateUserAndEmail()
-        {
-            Logger.Trace("UpdateUserAndEmail");
-
-            string username = null;
-            string email = null;
-
-            GetConfig(UserNameConfigKey, GitConfigSource.User)
-                .Then((success, value) => {
-                    if (success)
-                    {
-                        username = value;
-                    }
-                })
-                .Then(GetConfig(UserEmailConfigKey, GitConfigSource.User)
-                .Then((success, value) => {
-                    if (success)
-                    {
-                        email = value;
-                    }
-                })).ThenInUI(success => {
-                    CurrentUser = new User {
-                        Name = username,
-                        Email = email
-                    };
-                }).Start();
-        }
-
         protected static ILogging Logger { get; } = Logging.GetLogger<GitClient>();
+    }
+
+    public struct GitUser
+    {
+        public static GitUser Default = new GitUser();
+
+        public string name;
+        public string email;
+
+        public string Name { get { return name; } }
+        public string Email { get { return email; } }
+
+        public GitUser(string name, string email)
+        {
+            this.name = name;
+            this.email = email;
+        }
+
+        public override string ToString()
+        {
+            return $"Name:\"{Name}\" Email:\"{Email}\"";
+        }
     }
 }

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -64,7 +64,6 @@ namespace GitHub.Unity
         GitRemote[] Remotes { get; }
         GitBranch[] LocalBranches { get; }
         GitBranch[] RemoteBranches { get; }
-        IUser User { get; set; }
         List<GitLock> CurrentLocks { get; }
         string CurrentBranchName { get; }
         List<GitLogEntry> CurrentLog { get; }

--- a/src/GitHub.Api/Git/ManagedCacheExtensions.cs
+++ b/src/GitHub.Api/Git/ManagedCacheExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace GitHub.Unity
+{
+    static class ManagedCacheExtensions
+    {
+        public static bool ShouldRaiseCacheEvent(this IManagedCache managedCache, CacheUpdateEvent cacheUpdateEvent)
+        {
+            bool raiseEvent;
+            if (cacheUpdateEvent.UpdatedTimeString == null)
+            {
+                raiseEvent = managedCache.LastUpdatedAt != DateTimeOffset.MinValue;
+            }
+            else
+            {
+                raiseEvent = managedCache.LastUpdatedAt.ToString() != cacheUpdateEvent.UpdatedTimeString;
+            }
+            return raiseEvent;
+        }
+    }
+}

--- a/src/GitHub.Api/Git/ManagedCacheExtensions.cs
+++ b/src/GitHub.Api/Git/ManagedCacheExtensions.cs
@@ -4,18 +4,18 @@ namespace GitHub.Unity
 {
     static class ManagedCacheExtensions
     {
-        public static bool ShouldRaiseCacheEvent(this IManagedCache managedCache, CacheUpdateEvent cacheUpdateEvent)
+        public static bool IsLastUpdatedTimeDifferent(this IManagedCache managedCache, CacheUpdateEvent cacheUpdateEvent)
         {
-            bool raiseEvent;
+            bool isDifferent;
             if (cacheUpdateEvent.UpdatedTimeString == null)
             {
-                raiseEvent = managedCache.LastUpdatedAt != DateTimeOffset.MinValue;
+                isDifferent = managedCache.LastUpdatedAt != DateTimeOffset.MinValue;
             }
             else
             {
-                raiseEvent = managedCache.LastUpdatedAt.ToString() != cacheUpdateEvent.UpdatedTimeString;
+                isDifferent = managedCache.LastUpdatedAt.ToString() != cacheUpdateEvent.UpdatedTimeString;
             }
-            return raiseEvent;
+            return isDifferent;
         }
     }
 }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -704,7 +704,7 @@ namespace GitHub.Unity
             {
                 var dateTimeOffset = managedCache.LastUpdatedAt;
                 var updateEvent = new CacheUpdateEvent { UpdatedTimeString = dateTimeOffset.ToString() };
-                HandleGitLogCacheUpdatedEvent(updateEvent);
+                HandleUserCacheUpdatedEvent(updateEvent);
             }
         }
 
@@ -749,7 +749,7 @@ namespace GitHub.Unity
 
         private void GitUserCacheOnCacheUpdated(DateTimeOffset timeOffset)
         {
-            HandleGitLogCacheUpdatedEvent(new CacheUpdateEvent
+            HandleUserCacheUpdatedEvent(new CacheUpdateEvent
             {
                 UpdatedTimeString = timeOffset.ToString()
             });
@@ -761,7 +761,7 @@ namespace GitHub.Unity
             UpdateUserAndEmail();
         }
 
-        private void HandleGitLogCacheUpdatedEvent(CacheUpdateEvent cacheUpdateEvent)
+        private void HandleUserCacheUpdatedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             Logger.Trace("GitUserCache Updated {0}", cacheUpdateEvent.UpdatedTimeString);
             Changed?.Invoke(cacheUpdateEvent);

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -713,14 +713,14 @@ namespace GitHub.Unity
 
         public string Name
         {
-            get { return cacheContainer.GitUserCache.User.Name; }
-            private set { cacheContainer.GitUserCache.User.Name = value; }
+            get { return cacheContainer.GitUserCache.Name; }
+            private set { cacheContainer.GitUserCache.Name = value; }
         }
 
         public string Email
         {
-            get { return cacheContainer.GitUserCache.User.Email; }
-            private set { cacheContainer.GitUserCache.User.Email = value; }
+            get { return cacheContainer.GitUserCache.Email; }
+            private set { cacheContainer.GitUserCache.Email = value; }
         }
 
         private void GitUserCacheOnCacheUpdated(DateTimeOffset timeOffset)
@@ -747,15 +747,12 @@ namespace GitHub.Unity
         {
             Logger.Trace("UpdateUserAndEmail");
 
-            string username = null;
-            string email = null;
-
             gitClient.GetConfigUserAndEmail()
-                .Then((success, value) => {
+                .ThenInUI((success, value) => {
                     if (success)
                     {
-                        username = value.Name;
-                        email = value.Email;
+                        Name = value.Name;
+                        Email = value.Email;
                     }
                 }).Start();
         }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -35,7 +35,6 @@ namespace GitHub.Unity
             Guard.ArgumentNotNull(localPath, nameof(localPath));
 
             LocalPath = localPath;
-            User = new User();
 
             cacheContainer = container;
             cacheContainer.CacheInvalidated += CacheContainer_OnCacheInvalidated;
@@ -57,7 +56,6 @@ namespace GitHub.Unity
             repositoryManager.OnLocalBranchRemoved += RepositoryManager_OnLocalBranchRemoved;
             repositoryManager.OnRemoteBranchAdded += RepositoryManager_OnRemoteBranchAdded;
             repositoryManager.OnRemoteBranchRemoved += RepositoryManager_OnRemoteBranchRemoved;
-            repositoryManager.OnGitUserLoaded += user => User = user;
 
             UpdateGitStatus();
             UpdateGitLog();
@@ -145,7 +143,7 @@ namespace GitHub.Unity
         public void CheckLogChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitLogCache;
-            var raiseEvent = ShouldRaiseCacheEvent(cacheUpdateEvent, managedCache);
+            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
 
             Logger.Trace("Check GitLogCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -161,7 +159,7 @@ namespace GitHub.Unity
         public void CheckStatusChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitStatusCache;
-            var raiseEvent = ShouldRaiseCacheEvent(cacheUpdateEvent, managedCache);
+            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
 
             Logger.Trace("Check GitStatusCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -192,7 +190,7 @@ namespace GitHub.Unity
         private void CheckRepositoryInfoCacheEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.RepositoryInfoCache;
-            var raiseEvent = ShouldRaiseCacheEvent(cacheUpdateEvent, managedCache);
+            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
 
             Logger.Trace("Check RepositoryInfoCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -209,7 +207,7 @@ namespace GitHub.Unity
         {
             CacheUpdateEvent cacheUpdateEvent1 = cacheUpdateEvent;
             var managedCache = cacheContainer.GitLocksCache;
-            var raiseEvent = ShouldRaiseCacheEvent(cacheUpdateEvent1, managedCache);
+            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent1);
 
             Logger.Trace("Check GitLocksCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent1.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -272,7 +270,7 @@ namespace GitHub.Unity
         private void CheckBranchCacheEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.BranchCache;
-            var raiseEvent = ShouldRaiseCacheEvent(cacheUpdateEvent, managedCache);
+            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
 
             Logger.Trace("Check BranchCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -283,20 +281,6 @@ namespace GitHub.Unity
                 var updateEvent = new CacheUpdateEvent { UpdatedTimeString = dateTimeOffset.ToString() };
                 HandleBranchCacheUpdatedEvent(updateEvent);
             }
-        }
-
-        private static bool ShouldRaiseCacheEvent(CacheUpdateEvent cacheUpdateEvent, IManagedCache managedCache)
-        {
-            bool raiseEvent;
-            if (cacheUpdateEvent.UpdatedTimeString == null)
-            {
-                raiseEvent = managedCache.LastUpdatedAt != DateTimeOffset.MinValue;
-            }
-            else
-            {
-                raiseEvent = managedCache.LastUpdatedAt.ToString() != cacheUpdateEvent.UpdatedTimeString;
-            }
-            return raiseEvent;
         }
 
         private void CacheContainer_OnCacheInvalidated(CacheType cacheType)
@@ -670,8 +654,6 @@ namespace GitHub.Unity
         internal string DebuggerDisplay => String.Format(CultureInfo.InvariantCulture,
             "{0} Owner: {1} Name: {2} CloneUrl: {3} LocalPath: {4} Branch: {5} Remote: {6}", GetHashCode(), Owner, Name,
             CloneUrl, LocalPath, CurrentBranch, CurrentRemote);
-
-        public IUser User { get; set; }
 
         protected static ILogging Logger { get; } = Logging.GetLogger<Repository>();
     }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -672,6 +672,8 @@ namespace GitHub.Unity
         string Email { get; }
         event Action<CacheUpdateEvent> UserChanged;
         void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent);
+        void Initialize(IGitClient client);
+        void SetNameAndEmail(string name, string email);
     }
 
     [Serializable]
@@ -704,6 +706,28 @@ namespace GitHub.Unity
                 var updateEvent = new CacheUpdateEvent { UpdatedTimeString = dateTimeOffset.ToString() };
                 HandleGitLogCacheUpdatedEvent(updateEvent);
             }
+        }
+
+        public void Initialize(IGitClient client)
+        {
+            Guard.ArgumentNotNull(client, nameof(client));
+
+            Logger.Trace("Initialize");
+
+            gitClient = client;
+            UpdateUserAndEmail();
+        }
+
+        public void SetNameAndEmail(string name, string email)
+        {
+            gitClient.SetConfigNameAndEmail(name, email)
+                     .ThenInUI((success, value) => {
+                         if (success)
+                         {
+                             Name = value.Name;
+                             Email = value.Email;
+                         }
+                     }).Start();
         }
 
         public override string ToString()

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -665,13 +665,25 @@ namespace GitHub.Unity
     [Serializable]
     public class User : IUser
     {
+        public string name;
+        public string email;
+
         public override string ToString()
         {
             return String.Format("Name: {0} Email: {1}", Name, Email);
         }
 
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name
+        {
+            get { return name; }
+            set { name = value; }
+        }
+
+        public string Email
+        {
+            get { return email; }
+            set { email = value; }
+        }
     }
 
     [Serializable]

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -148,7 +148,7 @@ namespace GitHub.Unity
         public void CheckLogChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitLogCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent);
 
             Logger.Trace("Check GitLogCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -164,7 +164,7 @@ namespace GitHub.Unity
         public void CheckStatusChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitStatusCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent);
 
             Logger.Trace("Check GitStatusCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -195,7 +195,7 @@ namespace GitHub.Unity
         private void CheckRepositoryInfoCacheEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.RepositoryInfoCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent);
 
             Logger.Trace("Check RepositoryInfoCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -212,7 +212,7 @@ namespace GitHub.Unity
         {
             CacheUpdateEvent cacheUpdateEvent1 = cacheUpdateEvent;
             var managedCache = cacheContainer.GitLocksCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent1);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent1);
 
             Logger.Trace("Check GitLocksCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent1.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -275,7 +275,7 @@ namespace GitHub.Unity
         private void CheckBranchCacheEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.BranchCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent);
 
             Logger.Trace("Check BranchCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);
@@ -685,7 +685,7 @@ namespace GitHub.Unity
         public void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitUserCache;
-            var raiseEvent = managedCache.ShouldRaiseCacheEvent(cacheUpdateEvent);
+            var raiseEvent = managedCache.IsLastUpdatedTimeDifferent(cacheUpdateEvent);
 
             Logger.Trace("Check GitUserCache CacheUpdateEvent Current:{0} Check:{1} Result:{2}", managedCache.LastUpdatedAt,
                 cacheUpdateEvent.UpdatedTimeString ?? "[NULL]", raiseEvent);

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -769,16 +769,20 @@ namespace GitHub.Unity
 
         private void UpdateUserAndEmail()
         {
-            Logger.Trace("UpdateUserAndEmail");
+            if (gitClient != null)
+            {
+                Logger.Trace("UpdateUserAndEmail");
 
-            gitClient.GetConfigUserAndEmail()
-                .ThenInUI((success, value) => {
-                    if (success)
+                gitClient.GetConfigUserAndEmail()
+                    .ThenInUI((success, value) =>
                     {
-                        Name = value.Name;
-                        Email = value.Email;
-                    }
-                }).Start();
+                        if (success)
+                        {
+                            Name = value.Name;
+                            Email = value.Email;
+                        }
+                    }).Start();
+            }
         }
         
         protected static ILogging Logger { get; } = Logging.GetLogger<Repository>();

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -670,7 +670,7 @@ namespace GitHub.Unity
     {
         string Name { get; }
         string Email { get; }
-        event Action<CacheUpdateEvent> UserChanged;
+        event Action<CacheUpdateEvent> Changed;
         void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent);
         void Initialize(IGitClient client);
         void SetNameAndEmail(string name, string email);
@@ -682,7 +682,7 @@ namespace GitHub.Unity
         private ICacheContainer cacheContainer;
         private IGitClient gitClient;
 
-        public event Action<CacheUpdateEvent> UserChanged;
+        public event Action<CacheUpdateEvent> Changed;
 
         public User(ICacheContainer cacheContainer)
         {
@@ -764,7 +764,7 @@ namespace GitHub.Unity
         private void HandleGitLogCacheUpdatedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             Logger.Trace("GitUserCache Updated {0}", cacheUpdateEvent.UpdatedTimeString);
-            UserChanged?.Invoke(cacheUpdateEvent);
+            Changed?.Invoke(cacheUpdateEvent);
         }
 
         private void UpdateUserAndEmail()
@@ -785,7 +785,7 @@ namespace GitHub.Unity
             }
         }
         
-        protected static ILogging Logger { get; } = Logging.GetLogger<Repository>();
+        protected static ILogging Logger { get; } = Logging.GetLogger<User>();
     }
 
     [Serializable]

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -8,7 +8,6 @@ namespace GitHub.Unity
     public interface IRepositoryManager : IDisposable
     {
         event Action<ConfigBranch?, ConfigRemote?> OnCurrentBranchAndRemoteUpdated;
-        event Action<IUser> OnGitUserLoaded;
         event Action<bool> OnIsBusyChanged;
         event Action<string> OnLocalBranchAdded;
         event Action<Dictionary<string, ConfigBranch>> OnLocalBranchListUpdated;
@@ -101,7 +100,6 @@ namespace GitHub.Unity
         private bool isBusy;
 
         public event Action<ConfigBranch?, ConfigRemote?> OnCurrentBranchAndRemoteUpdated;
-        public event Action<IUser> OnGitUserLoaded;
         public event Action<bool> OnIsBusyChanged;
         public event Action<string> OnLocalBranchAdded;
         public event Action<Dictionary<string, ConfigBranch>> OnLocalBranchListUpdated;
@@ -150,7 +148,6 @@ namespace GitHub.Unity
             Logger.Trace("Start");
 
             UpdateConfigData();
-            LoadGitUser();
             watcher.Start();
         }
 
@@ -296,15 +293,6 @@ namespace GitHub.Unity
         {
             var task = GitClient.Unlock(file, force);
             return HookupHandlers(task);
-        }
-
-        private void LoadGitUser()
-        {
-            GitClient.GetConfigUserAndEmail()
-                .Then((success, user) => {
-                    Logger.Trace("OnGitUserLoaded: {0}", user);
-                    OnGitUserLoaded?.Invoke(user);
-                }).Start();
         }
 
         private void SetupWatcher()

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Application\Organization.cs" />
     <Compile Include="Cache\CacheInterfaces.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />
+    <Compile Include="Git\ManagedCacheExtensions.cs" />
     <Compile Include="Git\Tasks\GitLfsVersionTask.cs" />
     <Compile Include="Git\Tasks\GitVersionTask.cs" />
     <Compile Include="Git\ValidateGitInstallResult.cs" />

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -48,6 +48,7 @@ namespace GitHub.Unity
             UnityAssetsPath = assetsPath;
             UnityProjectPath = assetsPath.Parent;
             UnityVersion = unityVersion;
+            User = new User(CacheContainer);
         }
 
         public void InitializeRepository(NPath expectedRepositoryPath = null)
@@ -134,6 +135,7 @@ namespace GitHub.Unity
         public NPath RepositoryPath { get; private set; }
         public ICacheContainer CacheContainer { get; private set; }
         public IRepository Repository { get; set; }
+        public IUser User { get; set; }
 
         public bool IsWindows { get { return OnWindows; } }
         public bool IsLinux { get { return OnLinux; } }

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -7,7 +7,6 @@ namespace GitHub.Unity
     public class DefaultEnvironment : IEnvironment
     {
         private const string logFile = "github-unity.log";
-        private ICacheContainer cacheContainer;
 
         public NPath LogPath { get; }
         public DefaultEnvironment()
@@ -39,7 +38,7 @@ namespace GitHub.Unity
         public DefaultEnvironment(ICacheContainer cacheContainer)
             : this()
         {
-            this.cacheContainer = cacheContainer;
+            this.CacheContainer = cacheContainer;
         }
 
         public void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityPath, NPath assetsPath)
@@ -86,7 +85,7 @@ namespace GitHub.Unity
             {
                 Logger.Trace("Determined expectedRepositoryPath:{0}", expectedRepositoryPath);
                 RepositoryPath = expectedRepositoryPath;
-                Repository = new Repository(RepositoryPath, cacheContainer);
+                Repository = new Repository(RepositoryPath, CacheContainer);
             }
         }
 
@@ -133,6 +132,7 @@ namespace GitHub.Unity
         public NPath GitInstallPath { get; private set; }
 
         public NPath RepositoryPath { get; private set; }
+        public ICacheContainer CacheContainer { get; private set; }
         public IRepository Repository { get; set; }
 
         public bool IsWindows { get { return OnWindows; } }

--- a/src/GitHub.Api/Platform/IEnvironment.cs
+++ b/src/GitHub.Api/Platform/IEnvironment.cs
@@ -29,5 +29,6 @@ namespace GitHub.Unity
         IFileSystem FileSystem { get; set; }
         IRepository Repository { get; set; }
         string ExecutableExtension { get; }
+        ICacheContainer CacheContainer { get; }
     }
 }

--- a/src/GitHub.Api/Platform/IEnvironment.cs
+++ b/src/GitHub.Api/Platform/IEnvironment.cs
@@ -27,6 +27,7 @@ namespace GitHub.Unity
         NPath SystemCachePath { get; set; }
         NPath LogPath { get; }
         IFileSystem FileSystem { get; set; }
+        IUser User { get; set; }
         IRepository Repository { get; set; }
         string ExecutableExtension { get; }
         ICacheContainer CacheContainer { get; }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -1008,28 +1008,53 @@ namespace GitHub.Unity
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private User user;
+        [SerializeField] private string gitName;
+        [SerializeField] private string gitEmail;
 
         public GitUserCache() : base(true)
         { }
 
-        public User User
+        public string Name
         {
             get
             {
                 ValidateData();
-                return user;
+                return gitName;
             }
             set
             {
                 var now = DateTimeOffset.Now;
                 var isUpdated = false;
 
-                Logger.Trace("Updating: {0} user:{1}", now, value);
+                Logger.Trace("Updating: {0} Name:{1}", now, value);
 
-                if (!user.Equals(value))
+                if (!gitName.Equals(value))
                 {
-                    user = value;
+                    gitName = value;
+                    isUpdated = true;
+                }
+
+                SaveData(now, isUpdated);
+            }
+        }
+
+        public string Email
+        {
+            get
+            {
+                ValidateData();
+                return gitEmail;
+            }
+            set
+            {
+                var now = DateTimeOffset.Now;
+                var isUpdated = false;
+
+                Logger.Trace("Updating: {0} Email:{1}", now, value);
+
+                if (!gitEmail.Equals(value))
+                {
+                    gitEmail = value;
                     isUpdated = true;
                 }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -1058,7 +1058,7 @@ namespace GitHub.Unity
 
                 Logger.Trace("Updating: {0} Name:{1}", now, value);
 
-                if (!gitName.Equals(value))
+                if (gitName != value)
                 {
                     gitName = value;
                     isUpdated = true;
@@ -1082,7 +1082,7 @@ namespace GitHub.Unity
 
                 Logger.Trace("Updating: {0} Email:{1}", now, value);
 
-                if (!gitEmail.Equals(value))
+                if (gitEmail != value)
                 {
                     gitEmail = value;
                     isUpdated = true;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -915,28 +915,27 @@ namespace GitHub.Unity
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private User user;
 
-        public void UpdateData(User userUpdate)
-        {
-            var now = DateTimeOffset.Now;
-            var isUpdated = false;
-
-            Logger.Trace("Processing Update: {0}", now);
-
-            if (user != userUpdate)
-            {
-                user = userUpdate;
-                isUpdated = true;
-            }
-
-            SaveData(now, isUpdated);
-        }
-
         public User User
         {
             get
             {
                 ValidateData();
                 return user;
+            }
+            set
+            {
+                var now = DateTimeOffset.Now;
+                var isUpdated = false;
+
+                Logger.Trace("Processing Update: {0}", now);
+
+                if (user != value)
+                {
+                    user = value;
+                    isUpdated = true;
+                }
+
+                SaveData(now, isUpdated);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -7,6 +7,7 @@ namespace GitHub.Unity
     abstract class BaseWindow :  EditorWindow, IView
     {
         [NonSerialized] private bool initialized = false;
+        [NonSerialized] private IUser cachedUser;
         [NonSerialized] private IRepository cachedRepository;
         [NonSerialized] private bool initializeWasCalled;
         [NonSerialized] private bool inLayout;
@@ -21,6 +22,7 @@ namespace GitHub.Unity
             initialized = true;
             initializeWasCalled = true;
             Manager = applicationManager;
+            cachedUser = Environment.User;
             cachedRepository = Environment.Repository;
             Initialize(applicationManager);
             if (requiresRedraw)
@@ -103,6 +105,8 @@ namespace GitHub.Unity
         public abstract bool IsBusy { get; }
         public IRepository Repository { get { return inLayout ? cachedRepository : Environment.Repository; } }
         public bool HasRepository { get { return Repository != null; } }
+        public IUser User { get { return cachedUser; } }
+        public bool HasUser { get { return User != null; } }
 
         protected ITaskManager TaskManager { get { return Manager.TaskManager; } }
         protected IGitClient GitClient { get { return Manager.GitClient; } }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/IView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/IView.cs
@@ -14,6 +14,8 @@ namespace GitHub.Unity
         void Finish(bool result);
         IRepository Repository { get; }
         bool HasRepository { get; }
+        IUser User { get; }
+        bool HasUser { get; }
         IApplicationManager Manager { get; }
         bool IsBusy { get; }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -88,10 +88,10 @@ namespace GitHub.Unity
 
         private void AttachHandlers()
         {
-            User.UserChanged += UserOnUserChanged;
+            User.Changed += UserOnChanged;
         }
 
-        private void UserOnUserChanged(CacheUpdateEvent cacheUpdateEvent)
+        private void UserOnChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
@@ -107,7 +107,7 @@ namespace GitHub.Unity
 
         private void DetachHandlers()
         {
-            User.UserChanged -= UserOnUserChanged;
+            User.Changed -= UserOnChanged;
         }
 
         private void MaybeUpdateData()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -93,7 +93,7 @@ namespace GitHub.Unity
         {
             if (GitClient != null)
             {
-                GitClient.CurrentUserChanged+=GitClientOnCurrentUserChanged;
+                GitClient.CurrentUserChanged += GitClientOnCurrentUserChanged;
             }
         }
 
@@ -124,9 +124,10 @@ namespace GitHub.Unity
             if (userHasChanges)
             {
                 userHasChanges = false;
+                var currentUser = GitClient.CurrentUser;
+                isUserDataPresent = !string.IsNullOrEmpty(currentUser.Name)
+                    && !string.IsNullOrEmpty(currentUser.Email);
                 hasCompletedInitialCheck = true;
-                isUserDataPresent = !string.IsNullOrEmpty(GitClient.CurrentUser.Name)
-                    && !string.IsNullOrEmpty(GitClient.CurrentUser.Email);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -22,10 +22,7 @@ namespace GitHub.Unity
             base.OnEnable();
             AttachHandlers();
 
-            if (GitClient != null)
-            {
-                GitClient.CheckUserChangedEvent(lastCheckUserChangedEvent);
-            }
+            User.CheckUserChangedEvent(lastCheckUserChangedEvent);
         }
 
         public override void OnDisable()
@@ -91,13 +88,10 @@ namespace GitHub.Unity
 
         private void AttachHandlers()
         {
-            if (GitClient != null)
-            {
-                GitClient.CurrentUserChanged += GitClientOnCurrentUserChanged;
-            }
+            User.UserChanged += UserOnUserChanged;
         }
 
-        private void GitClientOnCurrentUserChanged(CacheUpdateEvent cacheUpdateEvent)
+        private void UserOnUserChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
@@ -113,10 +107,7 @@ namespace GitHub.Unity
 
         private void DetachHandlers()
         {
-            if (GitClient != null)
-            {
-                GitClient.CurrentUserChanged -= GitClientOnCurrentUserChanged;
-            }
+            User.UserChanged -= UserOnUserChanged;
         }
 
         private void MaybeUpdateData()
@@ -124,9 +115,8 @@ namespace GitHub.Unity
             if (userHasChanges)
             {
                 userHasChanges = false;
-                var currentUser = GitClient.CurrentUser;
-                isUserDataPresent = !string.IsNullOrEmpty(currentUser.Name)
-                    && !string.IsNullOrEmpty(currentUser.Email);
+                isUserDataPresent = !string.IsNullOrEmpty(User.Name)
+                    && !string.IsNullOrEmpty(User.Email);
                 hasCompletedInitialCheck = true;
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
@@ -52,6 +52,8 @@ namespace GitHub.Unity
         public IApplicationManager Manager { get { return Parent.Manager; } }
         public IRepository Repository { get { return Parent.Repository; } }
         public bool HasRepository { get { return Parent.HasRepository; } }
+        public IUser User { get { return Parent.User; } }
+        public bool HasUser { get { return Parent.HasUser; } }
         public abstract bool IsBusy { get; }
         protected ITaskManager TaskManager { get { return Manager.TaskManager; } }
         protected IGitClient GitClient { get { return Manager.GitClient; } }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -15,15 +15,14 @@ namespace GitHub.Unity
         private const string GitConfigEmailLabel = "Email";
         private const string GitConfigUserSave = "Save User";
 
-        [NonSerialized] private bool isBusy;
-
         [SerializeField] private string gitName;
         [SerializeField] private string gitEmail;
         [SerializeField] private string newGitName;
         [SerializeField] private string newGitEmail;
         [SerializeField] private bool needsSaving;
-
         [SerializeField] private CacheUpdateEvent lastCheckUserChangedEvent;
+
+        [NonSerialized] private bool isBusy;
         [NonSerialized] private bool userHasChanges;
 
         public override void InitializeView(IView parent)
@@ -88,6 +87,7 @@ namespace GitHub.Unity
             base.OnDisable();
             DetachHandlers();
         }
+        
         private void AttachHandlers()
         {
             if (GitClient != null)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -16,13 +16,15 @@ namespace GitHub.Unity
         private const string GitConfigUserSave = "Save User";
 
         [NonSerialized] private bool isBusy;
-        [NonSerialized] private bool userDataHasChanged;
 
         [SerializeField] private string gitName;
         [SerializeField] private string gitEmail;
         [SerializeField] private string newGitName;
         [SerializeField] private string newGitEmail;
         [SerializeField] private bool needsSaving;
+
+        [SerializeField] private CacheUpdateEvent lastCheckUserChangedEvent;
+        [NonSerialized] private bool userHasChanges;
 
         public override void InitializeView(IView parent)
         {
@@ -62,29 +64,7 @@ namespace GitHub.Unity
                         GUI.FocusControl(null);
                         isBusy = true;
 
-                        GitClient.SetConfigUserAndEmail(newGitName, newGitEmail)
-                                 .FinallyInUI((success, exception, user) => {
-                                     isBusy = false;
-                                     if (success)
-                                     {
-                                         if (Repository != null)
-                                         {
-                                             Repository.User.Name = gitName = newGitName;
-                                             Repository.User.Email = gitEmail = newGitEmail;
-                                         }
-                                         else
-                                         {
-                                             gitName = newGitName;
-                                             gitEmail = newGitEmail;
-                                         }
-
-                                         needsSaving = false;
-
-                                         Redraw();
-                                         Finish(true);
-                                     }
-                                 })
-                                 .Start();
+                        GitClient.SetConfigUserAndEmail(newGitName, newGitEmail);
                     }
                 }
                 EditorGUI.EndDisabledGroup();
@@ -95,52 +75,57 @@ namespace GitHub.Unity
         public override void OnEnable()
         {
             base.OnEnable();
-            userDataHasChanged = true;
+            AttachHandlers();
+
+            if (GitClient != null)
+            {
+                GitClient.CheckUserChangedEvent(lastCheckUserChangedEvent);
+            }
+        }
+
+        public override void OnDisable()
+        {
+            base.OnDisable();
+            DetachHandlers();
+        }
+        private void AttachHandlers()
+        {
+            if (GitClient != null)
+            {
+                GitClient.CurrentUserChanged += GitClientOnCurrentUserChanged;
+            }
+        }
+
+        private void GitClientOnCurrentUserChanged(CacheUpdateEvent cacheUpdateEvent)
+        {
+            if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
+            {
+                new ActionTask(TaskManager.Token, () =>
+                    {
+                        lastCheckUserChangedEvent = cacheUpdateEvent;
+                        userHasChanges = true;
+                        Redraw();
+                    })
+                    { Affinity = TaskAffinity.UI }.Start();
+            }
+        }
+
+        private void DetachHandlers()
+        {
+            if (GitClient != null)
+            {
+                GitClient.CurrentUserChanged -= GitClientOnCurrentUserChanged;
+            }
         }
 
         private void MaybeUpdateData()
         {
-            if (userDataHasChanged)
+            if (userHasChanges)
             {
-                userDataHasChanged = false;
-
-                if (Repository == null)
-                {
-                    UpdateUserDataFromClient();
-                }
-                else
-                {
-                    newGitName = gitName = Repository.User.Name;
-                    newGitEmail = gitEmail = Repository.User.Email;
-                    needsSaving = false;
-                }
+                userHasChanges = false;
+                gitName = newGitName = GitClient.CurrentUser.Name;
+                gitEmail = newGitEmail = GitClient.CurrentUser.Email;
             }
-        }
-
-        private void UpdateUserDataFromClient()
-        {
-            if (String.IsNullOrEmpty(EntryPoint.Environment.GitExecutablePath))
-            {
-                return;
-            }
-
-            if (GitClient == null)
-            {
-                return;
-            }
-
-            Logger.Trace("Update user data from GitClient");
-
-            GitClient.GetConfigUserAndEmail()
-                .ThenInUI((success, user) => {
-                    if (success && !String.IsNullOrEmpty(user.Name) && !String.IsNullOrEmpty(user.Email))
-                    {
-                        newGitName = gitName = user.Name;
-                        newGitEmail = gitEmail = user.Email;
-                        needsSaving = false;
-                        Redraw();
-                    }
-                }).Start();
         }
 
         public override bool IsBusy

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -118,6 +118,7 @@ namespace GitHub.Unity
                 userHasChanges = false;
                 gitName = newGitName = User.Name;
                 gitEmail = newGitEmail = User.Email;
+                needsSaving = false;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -87,12 +87,12 @@ namespace GitHub.Unity
         
         private void AttachHandlers()
         {
-            User.UserChanged += UserOnUserChanged;
+            User.Changed += UserOnChanged;
         }
 
-        private void UserOnUserChanged(CacheUpdateEvent cacheUpdateEvent)
+        private void UserOnChanged(CacheUpdateEvent cacheUpdateEvent)
         {
-            Logger.Trace("UserOnUserChanged");
+            Logger.Trace("UserOnChanged");
 
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
@@ -108,7 +108,7 @@ namespace GitHub.Unity
 
         private void DetachHandlers()
         {
-            User.UserChanged -= UserOnUserChanged;
+            User.Changed -= UserOnChanged;
         }
 
         private void MaybeUpdateData()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -98,12 +98,14 @@ namespace GitHub.Unity
 
         private void GitClientOnCurrentUserChanged(CacheUpdateEvent cacheUpdateEvent)
         {
+            Logger.Trace("GitClientOnCurrentUserChanged");
+
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () =>
-                    {
+                new ActionTask(TaskManager.Token, () => {
                         lastCheckUserChangedEvent = cacheUpdateEvent;
                         userHasChanges = true;
+                        isBusy = false;
                         Redraw();
                     })
                     { Affinity = TaskAffinity.UI }.Start();
@@ -123,8 +125,9 @@ namespace GitHub.Unity
             if (userHasChanges)
             {
                 userHasChanges = false;
-                gitName = newGitName = GitClient.CurrentUser.Name;
-                gitEmail = newGitEmail = GitClient.CurrentUser.Email;
+                var currentUser = GitClient.CurrentUser;
+                gitName = newGitName = currentUser.Name;
+                gitEmail = newGitEmail = currentUser.Email;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -63,7 +63,7 @@ namespace GitHub.Unity
                         GUI.FocusControl(null);
                         isBusy = true;
 
-                        GitClient.SetConfigUserAndEmail(newGitName, newGitEmail);
+                        User.SetNameAndEmail(newGitName, newGitEmail);
                     }
                 }
                 EditorGUI.EndDisabledGroup();
@@ -92,7 +92,7 @@ namespace GitHub.Unity
 
         private void UserOnUserChanged(CacheUpdateEvent cacheUpdateEvent)
         {
-            Logger.Trace("GitClientOnCurrentUserChanged");
+            Logger.Trace("UserOnUserChanged");
 
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -76,10 +76,7 @@ namespace GitHub.Unity
             base.OnEnable();
             AttachHandlers();
 
-            if (GitClient != null)
-            {
-                GitClient.CheckUserChangedEvent(lastCheckUserChangedEvent);
-            }
+            User.CheckUserChangedEvent(lastCheckUserChangedEvent);
         }
 
         public override void OnDisable()
@@ -90,13 +87,10 @@ namespace GitHub.Unity
         
         private void AttachHandlers()
         {
-            if (GitClient != null)
-            {
-                GitClient.CurrentUserChanged += GitClientOnCurrentUserChanged;
-            }
+            User.UserChanged += UserOnUserChanged;
         }
 
-        private void GitClientOnCurrentUserChanged(CacheUpdateEvent cacheUpdateEvent)
+        private void UserOnUserChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             Logger.Trace("GitClientOnCurrentUserChanged");
 
@@ -114,10 +108,7 @@ namespace GitHub.Unity
 
         private void DetachHandlers()
         {
-            if (GitClient != null)
-            {
-                GitClient.CurrentUserChanged -= GitClientOnCurrentUserChanged;
-            }
+            User.UserChanged -= UserOnUserChanged;
         }
 
         private void MaybeUpdateData()
@@ -125,9 +116,8 @@ namespace GitHub.Unity
             if (userHasChanges)
             {
                 userHasChanges = false;
-                var currentUser = GitClient.CurrentUser;
-                gitName = newGitName = currentUser.Name;
-                gitEmail = newGitEmail = currentUser.Email;
+                gitName = newGitName = User.Name;
+                gitEmail = newGitEmail = User.Email;
             }
         }
 

--- a/src/tests/IntegrationTests/Git/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/Git/IntegrationTestEnvironment.cs
@@ -120,5 +120,10 @@ namespace IntegrationTests
         public IRepository Repository { get; set; }
         public IFileSystem FileSystem { get { return defaultEnvironment.FileSystem; } set { defaultEnvironment.FileSystem = value; } }
         public string ExecutableExtension { get { return defaultEnvironment.ExecutableExtension; } }
+
+        public ICacheContainer CacheContainer
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 }

--- a/src/tests/IntegrationTests/Git/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/Git/IntegrationTestEnvironment.cs
@@ -118,6 +118,7 @@ namespace IntegrationTests
         public NPath GitInstallPath => defaultEnvironment.GitInstallPath;
 
         public IRepository Repository { get; set; }
+        public IUser User { get; set; }
         public IFileSystem FileSystem { get { return defaultEnvironment.FileSystem; } set { defaultEnvironment.FileSystem = value; } }
         public string ExecutableExtension { get { return defaultEnvironment.ExecutableExtension; } }
 

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -19,7 +19,6 @@ namespace TestUtils.Events
         void OnLocalBranchRemoved(string name);
         void OnRemoteBranchAdded(string origin, string name);
         void OnRemoteBranchRemoved(string origin, string name);
-        void OnGitUserLoaded(IUser user);
         void OnCurrentBranchAndRemoteUpdated(ConfigBranch? configBranch, ConfigRemote? configRemote);
     }
 
@@ -38,7 +37,6 @@ namespace TestUtils.Events
         public EventWaitHandle OnLocalBranchRemoved { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnRemoteBranchAdded { get; } = new AutoResetEvent(false);
         public EventWaitHandle OnRemoteBranchRemoved { get; } = new AutoResetEvent(false);
-        public EventWaitHandle OnGitUserLoaded { get; } = new AutoResetEvent(false);
 
         public void Reset()
         {
@@ -55,7 +53,6 @@ namespace TestUtils.Events
             OnLocalBranchRemoved.Reset();
             OnRemoteBranchAdded.Reset();
             OnRemoteBranchRemoved.Reset();
-            OnGitUserLoaded.Reset();
         }
 
         public void WaitForNotBusy(int seconds = 1)
@@ -137,12 +134,6 @@ namespace TestUtils.Events
                 logger?.Trace("OnRemoteBranchRemoved Origin:{0} Name:{1}", origin, name);
                 listener.OnRemoteBranchRemoved(origin, name);
                 managerEvents?.OnRemoteBranchRemoved.Set();
-            };
-
-            repositoryManager.OnGitUserLoaded += user => {
-                logger?.Trace("OnGitUserLoaded Name:{0}", user);
-                listener.OnGitUserLoaded(user);
-                managerEvents?.OnGitUserLoaded.Set();
             };
         }
 


### PR DESCRIPTION
Fixes: #412 

Problems:
1. user data is not cached and queried for on demand
2. the object `User` has been used as a data object from `GitClient`

Solutions:
1. Introduce `GitUser` as the data object from `GitClient`
2. Use `User` much like `Repository` as the central front end to user data and actions
   1. `User` gets initialized with a `GitClient` and initiates a process to update it's data
   2. `User` listens to invalidation events from the `GitUserCache` and updates it's data
3. Remove vestiges of `User` and user data from `Repository` and `RepositoryManager`
4. Updating functionality in `UserSettingsView` and `InitProviewView` to use the new cache

Depends on:
- [x] #426
- [x] #434
- [x] #425 
- [x] #423
- [x] #459
- [x] #460