### PR TITLE
Calling UpdateConfigData in BranchView.OnEnable() to refresh BranchList

### DIFF
--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -21,7 +21,7 @@ namespace GitHub.Unity
 
         void RefreshLog();
         void RefreshStatus();
-
+        void UpdateConfigData();
         void CheckLogChangedEvent(CacheUpdateEvent gitLogCacheUpdateEvent);
         void CheckStatusChangedEvent(CacheUpdateEvent cacheUpdateEvent);
         void CheckCurrentBranchChangedEvent(CacheUpdateEvent cacheUpdateEvent);

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -142,6 +142,11 @@ namespace GitHub.Unity
             UpdateGitStatus();
         }
 
+        public void UpdateConfigData()
+        {
+            repositoryManager?.UpdateConfigData();
+        }
+
         public void CheckLogChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitLogCache;

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -40,6 +40,7 @@ namespace GitHub.Unity
         ITask LockFile(string file);
         ITask UnlockFile(string file, bool force);
         int WaitForEvents();
+        void UpdateConfigData();
 
         IGitConfig Config { get; }
         IGitClient GitClient { get; }
@@ -177,7 +178,6 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
-                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 
@@ -187,7 +187,6 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
-                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 
@@ -296,6 +295,11 @@ namespace GitHub.Unity
         {
             var task = GitClient.Unlock(file, force);
             return HookupHandlers(task);
+        }
+
+        public void UpdateConfigData()
+        {
+            UpdateConfigData(false);
         }
 
         private void LoadGitUser()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -68,6 +68,7 @@ namespace GitHub.Unity
             if (Repository != null)
             {
                 Repository.CheckLocalAndRemoteBranchListChangedEvent(lastLocalAndRemoteBranchListChangedEvent);
+                Repository.UpdateConfigData();
             }
         }
 


### PR DESCRIPTION
Update to #428 
Removing the functionality to call `UpdateConfigData` after commit and calling it through `BranchView.OnEnable()` instead.