### PR TITLE
Rolling back of recent patches

### DIFF
--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -19,9 +19,6 @@ namespace GitHub.Unity
         ITask RequestLock(string file);
         ITask ReleaseLock(string file, bool force);
 
-        void RefreshLog();
-        void RefreshStatus();
-
         void CheckLogChangedEvent(CacheUpdateEvent gitLogCacheUpdateEvent);
         void CheckStatusChangedEvent(CacheUpdateEvent cacheUpdateEvent);
         void CheckCurrentBranchChangedEvent(CacheUpdateEvent cacheUpdateEvent);

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -21,7 +21,7 @@ namespace GitHub.Unity
 
         void RefreshLog();
         void RefreshStatus();
-        void UpdateConfigData();
+
         void CheckLogChangedEvent(CacheUpdateEvent gitLogCacheUpdateEvent);
         void CheckStatusChangedEvent(CacheUpdateEvent cacheUpdateEvent);
         void CheckCurrentBranchChangedEvent(CacheUpdateEvent cacheUpdateEvent);

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -142,11 +142,6 @@ namespace GitHub.Unity
             UpdateGitStatus();
         }
 
-        public void UpdateConfigData()
-        {
-            repositoryManager?.UpdateConfigData();
-        }
-
         public void CheckLogChangedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
             var managedCache = cacheContainer.GitLogCache;

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -81,22 +81,12 @@ namespace GitHub.Unity
 
         public ITask CommitAllFiles(string message, string body)
         {
-            return repositoryManager
-                .CommitAllFiles(message, body)
-                .Then(() => {
-                    UpdateGitStatus();
-                    UpdateGitLog();
-                });
+            return repositoryManager.CommitAllFiles(message, body);
         }
 
         public ITask CommitFiles(List<string> files, string message, string body)
         {
-            return repositoryManager
-                .CommitFiles(files, message, body)
-                .Then(() => {
-                    UpdateGitStatus();
-                    UpdateGitLog();
-                });
+            return repositoryManager.CommitFiles(files, message, body);
         }
 
         public ITask Pull()
@@ -130,16 +120,6 @@ namespace GitHub.Unity
         {
             return repositoryManager.UnlockFile(file, force)
                 .Then(UpdateLocks);
-        }
-
-        public void RefreshLog()
-        {
-            UpdateGitLog();
-        }
-
-        public void RefreshStatus()
-        {
-            UpdateGitStatus();
         }
 
         public void CheckLogChangedEvent(CacheUpdateEvent cacheUpdateEvent)

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -40,7 +40,6 @@ namespace GitHub.Unity
         ITask LockFile(string file);
         ITask UnlockFile(string file, bool force);
         int WaitForEvents();
-        void UpdateConfigData();
 
         IGitConfig Config { get; }
         IGitClient GitClient { get; }
@@ -178,6 +177,7 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
+                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 
@@ -187,6 +187,7 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
+                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 
@@ -295,11 +296,6 @@ namespace GitHub.Unity
         {
             var task = GitClient.Unlock(file, force);
             return HookupHandlers(task);
-        }
-
-        public void UpdateConfigData()
-        {
-            UpdateConfigData(false);
         }
 
         private void LoadGitUser()

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -177,7 +177,6 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
-                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 
@@ -187,7 +186,6 @@ namespace GitHub.Unity
             add.OnStart += t => IsBusy = true;
             return add
                 .Then(GitClient.Commit(message, body))
-                .Then(UpdateConfigData)
                 .Finally(() => IsBusy = false);
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -68,7 +68,6 @@ namespace GitHub.Unity
             if (Repository != null)
             {
                 Repository.CheckLocalAndRemoteBranchListChangedEvent(lastLocalAndRemoteBranchListChangedEvent);
-                Repository.UpdateConfigData();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -43,7 +43,7 @@ namespace GitHub.Unity
             if (Repository != null)
             {
                 Repository.CheckCurrentBranchChangedEvent(lastCurrentBranchChangedEvent);
-                Repository.RefreshStatus();
+                Repository.CheckStatusChangedEvent(lastStatusChangedEvent);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -73,8 +73,8 @@ namespace GitHub.Unity
 
             if (Repository != null)
             {
-                Repository.RefreshLog();
-                Repository.RefreshStatus();
+                Repository.CheckLogChangedEvent(lastLogChangedEvent);
+                Repository.CheckStatusChangedEvent(lastStatusChangedEvent);
                 Repository.CheckCurrentRemoteChangedEvent(lastCurrentRemoteChangedEvent);
             }
         }


### PR DESCRIPTION
**Note:** This pull request does not target master and will be part of a larger pull request

In order to temporarily solve the issues of #421 two patches, #431 and #428 were made.
These patches forcibly call methods to refresh sets of data that we know get corrupted by the current methods that process events. The first step towards resolving this issue is rolling back the patches.