### PR TITLE
Functionality to track "first run" in cache objects

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -58,6 +58,11 @@ namespace GitHub.Unity
             repositoryManager.OnRemoteBranchAdded += RepositoryManager_OnRemoteBranchAdded;
             repositoryManager.OnRemoteBranchRemoved += RepositoryManager_OnRemoteBranchRemoved;
             repositoryManager.OnGitUserLoaded += user => User = user;
+
+            UpdateGitStatus();
+            UpdateGitLog();
+
+            new ActionTask(CancellationToken.None, UpdateLocks) { Affinity = TaskAffinity.UI }.Start();
         }
 
         public ITask SetupRemote(string remote, string remoteUrl)

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -58,11 +58,6 @@ namespace GitHub.Unity
             repositoryManager.OnRemoteBranchAdded += RepositoryManager_OnRemoteBranchAdded;
             repositoryManager.OnRemoteBranchRemoved += RepositoryManager_OnRemoteBranchRemoved;
             repositoryManager.OnGitUserLoaded += user => User = user;
-
-            UpdateGitStatus();
-            UpdateGitLog();
-
-            new ActionTask(CancellationToken.None, UpdateLocks) { Affinity = TaskAffinity.UI }.Start();
         }
 
         public ITask SetupRemote(string remote, string remoteUrl)
@@ -316,6 +311,9 @@ namespace GitHub.Unity
                     break;
 
                 case CacheType.GitUserCache:
+                    break;
+
+                case CacheType.RepositoryInfoCache:
                     break;
 
                 default:

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -19,18 +19,7 @@ namespace GitHub.Unity
         {
             get
             {
-                if (!firstRunValue.HasValue)
-                {
-                    firstRunValue = firstRun;
-                }
-
-                if (firstRun)
-                {
-                    firstRun = false;
-                    FirstRunAt = DateTimeOffset.Now;
-                    Save(true);
-                }
-
+                EnsureFirstRun();
                 return firstRunValue.Value;
             }
         }
@@ -39,17 +28,34 @@ namespace GitHub.Unity
         {
             get
             {
+                EnsureFirstRun();
+
                 if (!firstRunAtValue.HasValue)
                 {
-                    firstRunAtValue = DateTimeOffset.Parse(firstRunAtString);
+                    firstRunAtValue = DateTimeOffset.ParseExact(firstRunAtString, Constants.Iso8601Format, CultureInfo.InvariantCulture);
                 }
 
                 return firstRunAtValue.Value;
             }
             private set
             {
-                firstRunAtString = value.ToString();
-                firstRunAtValue = null;
+                firstRunAtString = value.ToString(Constants.Iso8601Format);
+                firstRunAtValue = value;
+            }
+        }
+
+        private void EnsureFirstRun()
+        {
+            if (!firstRunValue.HasValue)
+            {
+                firstRunValue = firstRun;
+            }
+
+            if (firstRun)
+            {
+                firstRun = false;
+                FirstRunAt = DateTimeOffset.Now;
+                Save(true);
             }
         }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -557,7 +557,7 @@ namespace GitHub.Unity
 
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private string firstInitializedAtString = DateTimeOffset.MinValue.ToString();
+        [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
 
         [SerializeField] private ConfigBranch gitConfigBranch;
         [SerializeField] private ConfigRemote gitConfigRemote;
@@ -815,8 +815,8 @@ namespace GitHub.Unity
 
         public override string InitializedAtString
         {
-            get { return firstInitializedAtString; }
-            protected set { firstInitializedAtString = value; }
+            get { return initializedAtString; }
+            protected set { initializedAtString = value; }
         }
 
         public override TimeSpan DataTimeout
@@ -830,7 +830,7 @@ namespace GitHub.Unity
     {
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private string firstInitializedAtString = DateTimeOffset.MinValue.ToString();
+        [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private List<GitLogEntry> log = new List<GitLogEntry>();
 
         public GitLogCache() : base(true)
@@ -874,8 +874,8 @@ namespace GitHub.Unity
 
         public override string InitializedAtString
         {
-            get { return firstInitializedAtString; }
-            protected set { firstInitializedAtString = value; }
+            get { return initializedAtString; }
+            protected set { initializedAtString = value; }
         }
 
         public override TimeSpan DataTimeout
@@ -889,7 +889,7 @@ namespace GitHub.Unity
     {
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private string firstInitializedAtString = DateTimeOffset.MinValue.ToString();
+        [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private GitStatus status;
 
         public GitStatusCache() : base(true)
@@ -933,8 +933,8 @@ namespace GitHub.Unity
 
         public override string InitializedAtString
         {
-            get { return firstInitializedAtString; }
-            protected set { firstInitializedAtString = value; }
+            get { return initializedAtString; }
+            protected set { initializedAtString = value; }
         }
 
         public override TimeSpan DataTimeout
@@ -948,7 +948,7 @@ namespace GitHub.Unity
     {
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private string firstInitializedAtString = DateTimeOffset.MinValue.ToString();
+        [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private List<GitLock> gitLocks = new List<GitLock>();
 
         public GitLocksCache() : base(true)
@@ -992,8 +992,8 @@ namespace GitHub.Unity
 
         public override string InitializedAtString
         {
-            get { return firstInitializedAtString; }
-            protected set { firstInitializedAtString = value; }
+            get { return initializedAtString; }
+            protected set { initializedAtString = value; }
         }
 
         public override TimeSpan DataTimeout
@@ -1007,7 +1007,7 @@ namespace GitHub.Unity
     {
         [SerializeField] private string lastUpdatedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private string lastVerifiedAtString = DateTimeOffset.MinValue.ToString();
-        [SerializeField] private string firstInitializedAtString = DateTimeOffset.MinValue.ToString();
+        [SerializeField] private string initializedAtString = DateTimeOffset.MinValue.ToString();
         [SerializeField] private User user;
 
         public GitUserCache() : base(true)
@@ -1051,8 +1051,8 @@ namespace GitHub.Unity
 
         public override string InitializedAtString
         {
-            get { return firstInitializedAtString; }
-            protected set { firstInitializedAtString = value; }
+            get { return initializedAtString; }
+            protected set { initializedAtString = value; }
         }
 
         public override TimeSpan DataTimeout

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -148,7 +148,7 @@ namespace GitHub.Unity
         {
             Logger.Trace("Invalidated");
             CacheInvalidated.SafeInvoke();
-            SaveData(DateTimeOffset.Now, true);
+            SaveData(DateTimeOffset.Now, false);
         }
 
         protected void SaveData(DateTimeOffset now, bool isUpdated)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -135,18 +135,20 @@ namespace GitHub.Unity
 
                 if (invalidOnFirstRun)
                 {
+                    Logger.Trace("FirstRun Invalidation");
                     InvalidateData();
                 }
             }
             else if (DateTimeOffset.Now - LastUpdatedAt > DataTimeout)
             {
+                Logger.Trace("Timeout Invalidation");
                 InvalidateData();
             }
         }
 
         public void InvalidateData()
         {
-            Logger.Trace("Invalidated");
+            Logger.Trace("Invalidate");
             CacheInvalidated.SafeInvoke();
             SaveData(DateTimeOffset.Now, false);
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -199,7 +199,7 @@ namespace GitHub.Unity
             set
             {
                 LastUpdatedAtString = value.ToString(Constants.Iso8601Format);
-                lastUpdatedAtValue = null;
+                lastUpdatedAtValue = value;
             }
         }
 
@@ -225,7 +225,7 @@ namespace GitHub.Unity
             set
             {
                 LastVerifiedAtString = value.ToString(Constants.Iso8601Format);
-                lastVerifiedAtValue = null;
+                lastVerifiedAtValue = value;
             }
         }
 
@@ -251,7 +251,7 @@ namespace GitHub.Unity
             set
             {
                 InitializedAtString = value.ToString(Constants.Iso8601Format);
-                initializedAtValue = null;
+                initializedAtValue = value;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -110,8 +110,6 @@ namespace GitHub.Unity
 
     abstract class ManagedCacheBase<T> : ScriptObjectSingleton<T> where T : ScriptableObject, IManagedCache
     {
-        private static readonly TimeSpan DataTimeout = TimeSpan.FromMinutes(1);
-
         [NonSerialized] private DateTimeOffset? lastUpdatedAtValue;
         [NonSerialized] private DateTimeOffset? lastVerifiedAtValue;
         [NonSerialized] private DateTimeOffset? firstInitializedAtValue;
@@ -174,6 +172,7 @@ namespace GitHub.Unity
             }
         }
 
+        public abstract TimeSpan DataTimeout { get; }
         public abstract string LastUpdatedAtString { get; protected set; }
         public abstract string LastVerifiedAtString { get; protected set; }
         public abstract string FirstInitializedAtString { get; protected set; }
@@ -543,6 +542,11 @@ namespace GitHub.Unity
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
         }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.MaxValue; }
+        }
     }
 
     [Location("cache/branches.yaml", LocationAttribute.Location.LibraryFolder)]
@@ -814,6 +818,11 @@ namespace GitHub.Unity
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
         }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.MaxValue; }
+        }
     }
 
     [Location("cache/gitlog.yaml", LocationAttribute.Location.LibraryFolder)]
@@ -867,6 +876,11 @@ namespace GitHub.Unity
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
+        }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.FromMinutes(1); }
         }
     }
 
@@ -922,6 +936,11 @@ namespace GitHub.Unity
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
         }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.FromMinutes(1); }
+        }
     }
 
     [Location("cache/gitlocks.yaml", LocationAttribute.Location.LibraryFolder)]
@@ -976,6 +995,11 @@ namespace GitHub.Unity
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
         }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.FromMinutes(1); }
+        }
     }
 
     [Location("cache/gituser.yaml", LocationAttribute.Location.LibraryFolder)]
@@ -1029,6 +1053,11 @@ namespace GitHub.Unity
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
+        }
+
+        public override TimeSpan DataTimeout
+        {
+            get { return TimeSpan.FromMinutes(10); }
         }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -112,7 +112,7 @@ namespace GitHub.Unity
     {
         [NonSerialized] private DateTimeOffset? lastUpdatedAtValue;
         [NonSerialized] private DateTimeOffset? lastVerifiedAtValue;
-        [NonSerialized] private DateTimeOffset? firstInitializedAtValue;
+        [NonSerialized] private DateTimeOffset? initializedAtValue;
         [NonSerialized] private readonly bool invalidOnFirstRun;
 
         public event Action CacheInvalidated;
@@ -126,9 +126,9 @@ namespace GitHub.Unity
 
         public void ValidateData()
         {
-            if (ApplicationCache.Instance.FirstRunAt > FirstInitializedAt)
+            if (ApplicationCache.Instance.FirstRunAt > InitializedAt)
             {
-                FirstInitializedAt = DateTimeOffset.Now;
+                InitializedAt = DateTimeOffset.Now;
                 Save(true);
 
                 if (invalidOnFirstRun)
@@ -175,7 +175,7 @@ namespace GitHub.Unity
         public abstract TimeSpan DataTimeout { get; }
         public abstract string LastUpdatedAtString { get; protected set; }
         public abstract string LastVerifiedAtString { get; protected set; }
-        public abstract string FirstInitializedAtString { get; protected set; }
+        public abstract string InitializedAtString { get; protected set; }
 
         public DateTimeOffset LastUpdatedAt
         {
@@ -213,21 +213,21 @@ namespace GitHub.Unity
             }
         }
 
-        public DateTimeOffset FirstInitializedAt
+        public DateTimeOffset InitializedAt
         {
             get
             {
-                if (!firstInitializedAtValue.HasValue)
+                if (!initializedAtValue.HasValue)
                 {
-                    firstInitializedAtValue = DateTimeOffset.Parse(FirstInitializedAtString);
+                    initializedAtValue = DateTimeOffset.Parse(InitializedAtString);
                 }
 
-                return firstInitializedAtValue.Value;
+                return initializedAtValue.Value;
             }
             set
             {
-                FirstInitializedAtString = value.ToString();
-                firstInitializedAtValue = null;
+                InitializedAtString = value.ToString();
+                initializedAtValue = null;
             }
         }
 
@@ -537,7 +537,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
@@ -813,7 +813,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
@@ -872,7 +872,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
@@ -931,7 +931,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
@@ -990,7 +990,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }
@@ -1049,7 +1049,7 @@ namespace GitHub.Unity
             protected set { lastVerifiedAtString = value; }
         }
 
-        public override string FirstInitializedAtString
+        public override string InitializedAtString
         {
             get { return firstInitializedAtString; }
             protected set { firstInitializedAtString = value; }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -235,14 +235,22 @@ namespace GitHub.Unity
             {
                 if (!initializedAtValue.HasValue)
                 {
-                    initializedAtValue = DateTimeOffset.Parse(InitializedAtString);
+                    DateTimeOffset result;
+                    if (DateTimeOffset.TryParseExact(InitializedAtString, Constants.Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.None, out result))
+                    {
+                        initializedAtValue = result;
+                    }
+                    else
+                    {
+                        initializedAtValue = DateTimeOffset.MinValue;
+                    }
                 }
 
                 return initializedAtValue.Value;
             }
             set
             {
-                InitializedAtString = value.ToString();
+                InitializedAtString = value.ToString(Constants.Iso8601Format);
                 initializedAtValue = null;
             }
         }


### PR DESCRIPTION
As mentioned in #409

We want to start using the Invalidated events on cache objects to know when we need to re-populate data.

For some of those cache objects, we want to fire an implicit invalidated on the application's "First Run" as opposed to a domain reload. That way we know these objects need to be populated immediately.

This change adds:
- functionality to track the first run time in `ApplicationCache`
- functionality to track when `ManagedCacheBase` objects are initialized
- functionality in `ManagedCacheBase.ValidateData()` to verify if cache objects were initialized after application first run time, otherwise it will update and fire an "Invalidated" event
- functionality to define which cache objects are invalid on first tun

This provides base functionality to:
- #427 
- #436 

Depends on:
- [x] #435