### PR TITLE
Fix switching views

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -86,15 +86,12 @@ namespace GitHub.Unity
 
         private void RepositoryOnLocalAndRemoteBranchListChanged(CacheUpdateEvent cacheUpdateEvent)
         {
+        {
             if (!lastLocalAndRemoteBranchListChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () =>
-                    {
-                        lastLocalAndRemoteBranchListChangedEvent = cacheUpdateEvent;
-                        localAndRemoteBranchListHasUpdate = true;
-                        Redraw();
-                    })
-                    { Affinity = TaskAffinity.UI }.Start();
+                lastLocalAndRemoteBranchListChangedEvent = cacheUpdateEvent;
+                localAndRemoteBranchListHasUpdate = true;
+                Redraw();
             }
         }
 
@@ -114,16 +111,11 @@ namespace GitHub.Unity
 
         private void AttachHandlers(IRepository repository)
         {
-            if (repository == null)
-                return;
-
             repository.LocalAndRemoteBranchListChanged += RepositoryOnLocalAndRemoteBranchListChanged;
         }
 
         private void DetachHandlers(IRepository repository)
         {
-            if (repository == null)
-                return;
 
             repository.LocalAndRemoteBranchListChanged -= RepositoryOnLocalAndRemoteBranchListChanged;
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -86,7 +86,6 @@ namespace GitHub.Unity
 
         private void RepositoryOnLocalAndRemoteBranchListChanged(CacheUpdateEvent cacheUpdateEvent)
         {
-        {
             if (!lastLocalAndRemoteBranchListChangedEvent.Equals(cacheUpdateEvent))
             {
                 lastLocalAndRemoteBranchListChangedEvent = cacheUpdateEvent;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -51,12 +51,8 @@ namespace GitHub.Unity
             userSettingsView.OnEnable();
             AttachHandlers(Repository);
 
-            if (Repository != null)
-            {
-                Repository.CheckCurrentRemoteChangedEvent(lastCurrentRemoteChangedEvent);
-                Repository.CheckLocksChangedEvent(lastLocksChangedEvent);
-            }
-
+            Repository.CheckCurrentRemoteChangedEvent(lastCurrentRemoteChangedEvent);
+            Repository.CheckLocksChangedEvent(lastLocksChangedEvent);
             metricsHasChanged = true;
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -129,9 +129,8 @@ namespace GitHub.Unity
             if (Repository != null && activeTab == SubTab.InitProject)
             {
                 changeTab = SubTab.History;
+                UpdateActiveTab();
             }
-
-            UpdateActiveTab();
         }
 
         public override void OnSelectionChange()
@@ -317,7 +316,6 @@ namespace GitHub.Unity
             // Subtabs & toolbar
             GUILayout.BeginHorizontal(EditorStyles.toolbar);
             {
-                changeTab = activeTab;
                 EditorGUI.BeginChangeCheck();
                 {
                     if (HasRepository)
@@ -352,7 +350,8 @@ namespace GitHub.Unity
             {
                 var fromView = ActiveView;
                 activeTab = changeTab;
-                SwitchView(fromView, ActiveView);
+                var toView = ActiveView;
+                SwitchView(fromView, toView);
             }
         }
 
@@ -363,6 +362,7 @@ namespace GitHub.Unity
             if (fromView != null)
                 fromView.OnDisable();
             toView.OnEnable();
+            toView.OnDataUpdate();
 
             // this triggers a repaint
             Repaint();
@@ -424,9 +424,9 @@ namespace GitHub.Unity
             base.ShowNotification(content);
         }
 
-        private static SubTab TabButton(SubTab tab, string title, SubTab activeTab)
+        private static SubTab TabButton(SubTab tab, string title, SubTab currentTab)
         {
-            return GUILayout.Toggle(activeTab == tab, title, EditorStyles.toolbarButton) ? tab : activeTab;
+            return GUILayout.Toggle(currentTab == tab, title, EditorStyles.toolbarButton) ? tab : currentTab;
         }
 
         private Subview ToView(SubTab tab)


### PR DESCRIPTION
Switching views was happening in such a way that the new view would not get OnDataUpdate called between OnEnable and OnUI, because OnDataUpdate only gets called during layout events, and we switch the view (calling OnEnable on it) during the onmouseup event. That meant that the newly-active view would not load data until the next ui cycle, which causes exceptions to be thrown, given that the rendering code relies on data to always be there in some way (either cached or empty or whatever, but *something* needs to exist)

This ensures that OnDataUpdate gets called on the new view manually. This means that the event type for OnUI is going to be mouseup... which might confuse the new view if it's trying to handle it? I think it's probably fine because by this point the event object has been marked as used, which means other controls that want to handle the event will ignore it.