### PR TITLE
Serializing DateTimeOffset objects with ISO8601

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -9,6 +9,7 @@ namespace GitHub.Unity
         public const string UsageFile = "usage.json";
         public const string GitInstallPathKey = "GitInstallPath";
         public const string TraceLoggingKey = "EnableTraceLogging";
+        public const string Iso8601Format = "o";
 
         public static readonly Version MinimumGitVersion = new Version(2, 11, 0);
         public static readonly Version MinimumGitLfsVersion = new Version(2, 3, 4);

--- a/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
@@ -329,8 +329,8 @@ namespace GitHub.Unity
                     Summary = summary,
                     Description = description,
                     CommitID = commitId,
-                    TimeString = time.Value.ToString(DateTimeFormatInfo.CurrentInfo),
-                    CommitTimeString = committerTime.Value.ToString(DateTimeFormatInfo.CurrentInfo)
+                    TimeString = time.Value.ToString(Constants.Iso8601Format),
+                    CommitTimeString = committerTime.Value.ToString(Constants.Iso8601Format)
                 });
             }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using Octokit;
 using UnityEditor;
 using UnityEngine;
 using Application = UnityEngine.Application;
@@ -92,7 +92,6 @@ namespace GitHub.Unity
         private static readonly TimeSpan DataTimeout = TimeSpan.MaxValue;
 
         [NonSerialized] private DateTimeOffset? lastUpdatedAtValue;
-
         [NonSerialized] private DateTimeOffset? lastVerifiedAtValue;
 
         public event Action CacheInvalidated;
@@ -148,14 +147,22 @@ namespace GitHub.Unity
             {
                 if (!lastUpdatedAtValue.HasValue)
                 {
-                    lastUpdatedAtValue = DateTimeOffset.Parse(LastUpdatedAtString);
+                    DateTimeOffset result;
+                    if (DateTimeOffset.TryParseExact(LastUpdatedAtString, Constants.Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.None, out result))
+                    {
+                        lastUpdatedAtValue = result;
+                    }
+                    else
+                    {
+                        lastUpdatedAtValue = DateTimeOffset.MinValue;
+                    }
                 }
 
                 return lastUpdatedAtValue.Value;
             }
             set
             {
-                LastUpdatedAtString = value.ToString();
+                LastUpdatedAtString = value.ToString(Constants.Iso8601Format);
                 lastUpdatedAtValue = null;
             }
         }
@@ -166,14 +173,22 @@ namespace GitHub.Unity
             {
                 if (!lastVerifiedAtValue.HasValue)
                 {
-                    lastVerifiedAtValue = DateTimeOffset.Parse(LastVerifiedAtString);
+                    DateTimeOffset result;
+                    if (DateTimeOffset.TryParseExact(LastVerifiedAtString, Constants.Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.None, out result))
+                    {
+                        lastVerifiedAtValue = result;
+                    }
+                    else
+                    {
+                        lastVerifiedAtValue = DateTimeOffset.MinValue;
+                    }
                 }
 
                 return lastVerifiedAtValue.Value;
             }
             set
             {
-                LastVerifiedAtString = value.ToString();
+                LastVerifiedAtString = value.ToString(Constants.Iso8601Format);
                 lastVerifiedAtValue = null;
             }
         }

--- a/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
+++ b/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
@@ -57,8 +57,8 @@ namespace IntegrationTests
                     CommitID = "018997938335742f8be694240a7c2b352ec0835f",
                     Description = "Moving project files where they should be kept",
                     Summary = "Moving project files where they should be kept",
-                    TimeString = firstCommitTime.ToString(DateTimeFormatInfo.CurrentInfo),
-                    CommitTimeString = firstCommitTime.ToString(DateTimeFormatInfo.CurrentInfo),
+                    TimeString = firstCommitTime.ToString(Constants.Iso8601Format),
+                    CommitTimeString = firstCommitTime.ToString(Constants.Iso8601Format),
                 },
                 new GitLogEntry
                 {
@@ -75,8 +75,8 @@ namespace IntegrationTests
                     CommitID = "03939ffb3eb8486dba0259b43db00842bbe6eca1",
                     Description = "Initial Commit",
                     Summary = "Initial Commit",
-                    TimeString = secondCommitTime.ToString(DateTimeFormatInfo.CurrentInfo),
-                    CommitTimeString = secondCommitTime.ToString(DateTimeFormatInfo.CurrentInfo),
+                    TimeString = secondCommitTime.ToString(Constants.Iso8601Format),
+                    CommitTimeString = secondCommitTime.ToString(Constants.Iso8601Format),
                 },
             });
         }
@@ -110,8 +110,8 @@ namespace IntegrationTests
                     CommitID = "06d6451d351626894a30e9134f551db12c74254b",
                     Description = "Я люблю github",
                     Summary = "Я люблю github",
-                    TimeString = commitTime.ToString(DateTimeFormatInfo.CurrentInfo),
-                    CommitTimeString = commitTime.ToString(DateTimeFormatInfo.CurrentInfo),
+                    TimeString = commitTime.ToString(Constants.Iso8601Format),
+                    CommitTimeString = commitTime.ToString(Constants.Iso8601Format),
                 }
             });
         }

--- a/src/tests/UnitTests/IO/LogEntryOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/LogEntryOutputProcessorTests.cs
@@ -58,8 +58,8 @@ namespace UnitTests
                     },
                     Summary = "Rename RepositoryModelBase to RepositoryModel",
                     Description = "Rename RepositoryModelBase to RepositoryModel",
-                    TimeString = commitTime.ToString(DateTimeFormatInfo.CurrentInfo),
-                    CommitTimeString = commitTime.ToString(DateTimeFormatInfo.CurrentInfo),
+                    TimeString = commitTime.ToString(Constants.Iso8601Format),
+                    CommitTimeString = commitTime.ToString(Constants.Iso8601Format),
                 },
             };
 


### PR DESCRIPTION
Fixes: #447

Cache objects were being serialized with their date times just being `ToString`d.
This works fine most of the time, but of course it is not consistent.