### PR TITLE
SettingsView needs to check for null Repository

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -51,8 +51,12 @@ namespace GitHub.Unity
             userSettingsView.OnEnable();
             AttachHandlers(Repository);
 
-            Repository.CheckCurrentRemoteChangedEvent(lastCurrentRemoteChangedEvent);
-            Repository.CheckLocksChangedEvent(lastLocksChangedEvent);
+            if (Repository != null)
+            {
+                Repository.CheckCurrentRemoteChangedEvent(lastCurrentRemoteChangedEvent);
+                Repository.CheckLocksChangedEvent(lastLocksChangedEvent);
+            }
+
             metricsHasChanged = true;
         }
 


### PR DESCRIPTION
Recently merged pull request #449 introduces a `NullReferenceException` in `SettingsView`.
I believe @shana was quickly making a change assuming that the `SettingsView` is not used when there is no `Repository`. Although that is the case for some (most?) of our views, the `SettingsView` is one of the few used where there may or may not be a `Repository` instance present.