### PR TITLE
Changing to a format string that is compatible with parse operations in Mono

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -9,7 +9,7 @@ namespace GitHub.Unity
         public const string UsageFile = "usage.json";
         public const string GitInstallPathKey = "GitInstallPath";
         public const string TraceLoggingKey = "EnableTraceLogging";
-        public const string Iso8601Format = "o";
+        public const string Iso8601Format = "yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz";
 
         public static readonly Version MinimumGitVersion = new Version(2, 11, 0);
         public static readonly Version MinimumGitLfsVersion = new Version(2, 3, 4);


### PR DESCRIPTION
In recently merged pull request #457, we used the format string `o` to format `DateTimeOffset` objects to the Iso8601 format.

Although this works for output, it does not work for parsing. Usingn `o` in `DateTimeOffset.Parse()` or `DateTimeOffset.ParseExact()` throws an exception with `Invalid Format String` as the message.

Using the format string `yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz` outputs the same content as `o`, but also has the added benefit of working in Mono/Unity.