### PR TITLE
Changes to appveyor script to capture tests of failed builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,9 +57,10 @@ test:
     except:
     - DoNotRunOnAppVeyor
     - TimeSensitive
-after_test:
-  - ps: Get-ChildItem build\*.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 artifacts:
 - path: unity\PackageProject
   type: zip
   name: github-for-unity-packageproject
+- path: build\*.log
+on_failure:
+  - ps: Get-ChildItem build\*.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,9 @@ test:
     except:
     - DoNotRunOnAppVeyor
     - TimeSensitive
+after_test:
+  - ps: Get-ChildItem build\*.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 artifacts:
 - path: unity\PackageProject
   type: zip
   name: github-for-unity-packageproject
-- path: build\*.log


### PR DESCRIPTION
Fixes: #446 

In AppVeyor, with our build we are capturing the build artifacts and test logs, but if your tests fail the `artifacts` task does not run.

I'm debugging a set of integration tests that consistently fail on AppVeyor but work locally.
Our tests write their logging output to a file and I would like to get those outputs in AppVeyor.

The only way to do is is to script the build failure event to upload any files if found
