### PR TITLE
Remote Branches List Error

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -316,7 +316,7 @@ namespace GitHub.Unity
 
             rect.y += Styles.TreePadding;
 
-            treeRemotes.Render(rect, scroll, _ => {}, selectedNode =>
+            rect = treeRemotes.Render(rect, scroll, _ => {}, selectedNode =>
                 {
                     var indexOfFirstSlash = selectedNode.Name.IndexOf('/');
                     var originName = selectedNode.Name.Substring(0, indexOfFirstSlash);


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

Simple bugfix...
The modified rectangle after displaying the Remote Branches List is not captured.
Leading to us being unable to scroll into the Remote Branches region.

Depends on:
- [x] #151 