### PR TITLE
Cache events are raised on the main thread

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -107,11 +107,9 @@ namespace GitHub.Unity
         {
             if (!lastStatusChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastStatusChangedEvent = cacheUpdateEvent;
-                    currentStatusHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastStatusChangedEvent = cacheUpdateEvent;
+                currentStatusHasUpdate = true;
+                Redraw();
             }
         }
 
@@ -119,11 +117,9 @@ namespace GitHub.Unity
         {
             if (!lastCurrentBranchChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastCurrentBranchChangedEvent = cacheUpdateEvent;
-                    currentBranchHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastCurrentBranchChangedEvent = cacheUpdateEvent;
+                currentBranchHasUpdate = true;
+                Redraw();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -296,11 +296,9 @@ namespace GitHub.Unity
         {
             if (!lastStatusChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastStatusChangedEvent = cacheUpdateEvent;
-                    currentStatusHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastStatusChangedEvent = cacheUpdateEvent;
+                currentStatusHasUpdate = true;
+                Redraw();
             }
         }
 
@@ -308,11 +306,9 @@ namespace GitHub.Unity
         {
             if (!lastLogChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastLogChangedEvent = cacheUpdateEvent;
-                    currentLogHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastLogChangedEvent = cacheUpdateEvent;
+                currentLogHasUpdate = true;
+                Redraw();
             }
         }
 
@@ -320,11 +316,9 @@ namespace GitHub.Unity
         {
             if (!lastCurrentRemoteChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastCurrentRemoteChangedEvent = cacheUpdateEvent;
-                    currentRemoteHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastCurrentRemoteChangedEvent = cacheUpdateEvent;
+                currentRemoteHasUpdate = true;
+                Redraw();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -95,13 +95,9 @@ namespace GitHub.Unity
         {
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () =>
-                    {
-                        lastCheckUserChangedEvent = cacheUpdateEvent;
-                        userHasChanges = true;
-                        Redraw();
-                    })
-                    { Affinity = TaskAffinity.UI }.Start();
+                lastCheckUserChangedEvent = cacheUpdateEvent;
+                userHasChanges = true;
+                Redraw();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -45,14 +45,10 @@ namespace GitHub.Unity
         {
             if (!lastRepositoryStatusChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(CancellationToken.None, () =>
-                {
-                    lastRepositoryStatusChangedEvent = cacheUpdateEvent;
-                    entries.Clear();
-                    entries.AddRange(repository.CurrentStatus.Entries);
-                    OnStatusUpdate();
-                })
-                { Affinity = TaskAffinity.UI }.Start();
+                lastRepositoryStatusChangedEvent = cacheUpdateEvent;
+                entries.Clear();
+                entries.AddRange(repository.CurrentStatus.Entries);
+                OnStatusUpdate();
             }
         }
 
@@ -60,13 +56,9 @@ namespace GitHub.Unity
         {
             if (!lastLocksChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(CancellationToken.None, () =>
-                {
-                    lastLocksChangedEvent = cacheUpdateEvent;
-                    locks = repository.CurrentLocks;
-                    OnLocksUpdate();
-                })
-                { Affinity = TaskAffinity.UI }.Start();
+                lastLocksChangedEvent = cacheUpdateEvent;
+                locks = repository.CurrentLocks;
+                OnLocksUpdate();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -126,11 +126,9 @@ namespace GitHub.Unity
         {
             if (!lastLocksChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastLocksChangedEvent = cacheUpdateEvent;
-                    currentLocksHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastLocksChangedEvent = cacheUpdateEvent;
+                currentLocksHasUpdate = true;
+                Redraw();
             }
         }
 
@@ -138,11 +136,9 @@ namespace GitHub.Unity
         {
             if (!lastCurrentRemoteChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                    lastCurrentRemoteChangedEvent = cacheUpdateEvent;
-                    currentRemoteHasUpdate = true;
-                    Redraw();
-                }) { Affinity = TaskAffinity.UI }.Start();
+                lastCurrentRemoteChangedEvent = cacheUpdateEvent;
+                currentRemoteHasUpdate = true;
+                Redraw();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -96,13 +96,10 @@ namespace GitHub.Unity
 
             if (!lastCheckUserChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () => {
-                        lastCheckUserChangedEvent = cacheUpdateEvent;
-                        userHasChanges = true;
-                        isBusy = false;
-                        Redraw();
-                    })
-                    { Affinity = TaskAffinity.UI }.Start();
+                lastCheckUserChangedEvent = cacheUpdateEvent;
+                userHasChanges = true;
+                isBusy = false;
+                Redraw();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -270,13 +270,9 @@ namespace GitHub.Unity
         {
             if (!lastCurrentBranchAndRemoteChangedEvent.Equals(cacheUpdateEvent))
             {
-                new ActionTask(TaskManager.Token, () =>
-                {
-                    lastCurrentBranchAndRemoteChangedEvent = cacheUpdateEvent;
-                    currentBranchAndRemoteHasUpdate = true;
-                    Redraw();
-                })
-                { Affinity = TaskAffinity.UI }.Start();
+                lastCurrentBranchAndRemoteChangedEvent = cacheUpdateEvent;
+                currentBranchAndRemoteHasUpdate = true;
+                Redraw();
             }
         }
 


### PR DESCRIPTION
Fixes: #444 

Cache events are raised on the main thread. Therefore we do not need to shuffle delegates through the task system to make sure they are executed on the main thread. This is just slowing things down.