### PR TITLE
Handling branch right click

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -333,40 +333,6 @@ namespace GitHub.Unity
             GUILayout.Space(rect.y - initialRect.y);
         }
 
-        private void CheckoutRemoteBranch(string selectedNodeName)
-        {
-            var indexOfFirstSlash = selectedNodeName.IndexOf('/');
-            var originName = selectedNodeName.Substring(0, indexOfFirstSlash);
-            var branchName = selectedNodeName.Substring(indexOfFirstSlash + 1);
-
-            if (Repository.LocalBranches.Any(localBranch => localBranch.Name == branchName))
-            {
-                EditorUtility.DisplayDialog(WarningCheckoutBranchExistsTitle,
-                    String.Format(WarningCheckoutBranchExistsMessage, branchName), WarningCheckoutBranchExistsOK);
-            }
-            else
-            {
-                var confirmCheckout = EditorUtility.DisplayDialog(ConfirmCheckoutBranchTitle,
-                    String.Format(ConfirmCheckoutBranchMessage, selectedNodeName, originName), ConfirmCheckoutBranchOK,
-                    ConfirmCheckoutBranchCancel);
-
-                if (confirmCheckout)
-                {
-                    GitClient.CreateBranch(branchName, selectedNodeName).FinallyInUI((success, e) => {
-                        if (success)
-                        {
-                            Redraw();
-                        }
-                        else
-                        {
-                            EditorUtility.DisplayDialog(Localization.SwitchBranchTitle,
-                                String.Format(Localization.SwitchBranchFailedDescription, selectedNodeName), Localization.Ok);
-                        }
-                    }).Start();
-                }
-            }
-        }
-
         private GenericMenu CreateContextMenuForLocalBranchNode(TreeNode node)
         {
             var genericMenu = new GenericMenu();
@@ -393,34 +359,6 @@ namespace GitHub.Unity
             return genericMenu;
         }
 
-        private void SwitchBranch(string branchName)
-        {
-            if (EditorUtility.DisplayDialog(ConfirmSwitchTitle, String.Format(ConfirmSwitchMessage, branchName), ConfirmSwitchOK,
-                ConfirmSwitchCancel))
-            {
-                GitClient.SwitchBranch(branchName).FinallyInUI((success, e) => {
-                    if (success)
-                    {
-                        Redraw();
-                    }
-                    else
-                    {
-                        EditorUtility.DisplayDialog(Localization.SwitchBranchTitle,
-                            String.Format(Localization.SwitchBranchFailedDescription, branchName), Localization.Ok);
-                    }
-                }).Start();
-            }
-        }
-
-        private void DeleteLocalBranch(string branchName)
-        {
-            var dialogMessage = string.Format(DeleteBranchMessageFormatString, branchName);
-            if (EditorUtility.DisplayDialog(DeleteBranchTitle, dialogMessage, DeleteBranchButton, CancelButtonLabel))
-            {
-                GitClient.DeleteBranch(branchName, true).Start();
-            }
-        }
-
         private GenericMenu CreateContextMenuForRemoteBranchNode(TreeNode node)
         {
             var genericMenu = new GenericMenu();
@@ -432,6 +370,68 @@ namespace GitHub.Unity
             });
             
             return genericMenu;
+        }
+
+        private void CheckoutRemoteBranch(string branch)
+        {
+            var indexOfFirstSlash = branch.IndexOf('/');
+            var originName = branch.Substring(0, indexOfFirstSlash);
+            var branchName = branch.Substring(indexOfFirstSlash + 1);
+
+            if (Repository.LocalBranches.Any(localBranch => localBranch.Name == branchName))
+            {
+                EditorUtility.DisplayDialog(WarningCheckoutBranchExistsTitle,
+                    String.Format(WarningCheckoutBranchExistsMessage, branchName), WarningCheckoutBranchExistsOK);
+            }
+            else
+            {
+                var confirmCheckout = EditorUtility.DisplayDialog(ConfirmCheckoutBranchTitle,
+                    String.Format(ConfirmCheckoutBranchMessage, branch, originName), ConfirmCheckoutBranchOK,
+                    ConfirmCheckoutBranchCancel);
+
+                if (confirmCheckout)
+                {
+                    GitClient.CreateBranch(branchName, branch).FinallyInUI((success, e) => {
+                        if (success)
+                        {
+                            Redraw();
+                        }
+                        else
+                        {
+                            EditorUtility.DisplayDialog(Localization.SwitchBranchTitle,
+                                String.Format(Localization.SwitchBranchFailedDescription, branch), Localization.Ok);
+                        }
+                    }).Start();
+                }
+            }
+        }
+
+        private void SwitchBranch(string branch)
+        {
+            if (EditorUtility.DisplayDialog(ConfirmSwitchTitle, String.Format(ConfirmSwitchMessage, branch), ConfirmSwitchOK,
+                ConfirmSwitchCancel))
+            {
+                GitClient.SwitchBranch(branch).FinallyInUI((success, e) => {
+                    if (success)
+                    {
+                        Redraw();
+                    }
+                    else
+                    {
+                        EditorUtility.DisplayDialog(Localization.SwitchBranchTitle,
+                            String.Format(Localization.SwitchBranchFailedDescription, branch), Localization.Ok);
+                    }
+                }).Start();
+            }
+        }
+
+        private void DeleteLocalBranch(string branch)
+        {
+            var dialogMessage = string.Format(DeleteBranchMessageFormatString, branch);
+            if (EditorUtility.DisplayDialog(DeleteBranchTitle, dialogMessage, DeleteBranchButton, CancelButtonLabel))
+            {
+                GitClient.DeleteBranch(branch, true).Start();
+            }
         }
 
         private int CompareBranches(GitBranch a, GitBranch b)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -32,6 +32,9 @@ namespace GitHub.Unity
         private const string DeleteBranchTitle = "Delete Branch?";
         private const string DeleteBranchButton = "Delete";
         private const string CancelButtonLabel = "Cancel";
+        private const string DeleteBranchContextMenuLabel = "Delete";
+        private const string SwitchBranchContextMenuLabel = "Switch";
+        private const string CheckoutBranchContextMenuLabel = "Checkout";
 
         [NonSerialized] private int listID = -1;
         [NonSerialized] private BranchesMode targetMode;
@@ -337,8 +340,8 @@ namespace GitHub.Unity
         {
             var genericMenu = new GenericMenu();
 
-            var deleteGuiContent = new GUIContent("Delete");
-            var switchGuiContent = new GUIContent("Switch");
+            var deleteGuiContent = new GUIContent(DeleteBranchContextMenuLabel);
+            var switchGuiContent = new GUIContent(SwitchBranchContextMenuLabel);
 
             if (node.IsActive)
             {
@@ -363,7 +366,7 @@ namespace GitHub.Unity
         {
             var genericMenu = new GenericMenu();
 
-            var checkoutGuiContent = new GUIContent("Checkout");
+            var checkoutGuiContent = new GUIContent(CheckoutBranchContextMenuLabel);
             
             genericMenu.AddItem(checkoutGuiContent, false, () => {
                 CheckoutRemoteBranch(node.Name);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -305,9 +305,9 @@ namespace GitHub.Unity
                             }).Start();
                     }
                 },
-                node =>
-                {
-                    Debug.Log("Right Click");
+                node => {
+                    GenericMenu menu = CreateContextMenuForLocalBranchNode(node);
+                    menu.ShowAsContext();
                 });
 
             if (treeHadFocus && treeLocals.SelectedNode == null)
@@ -364,9 +364,9 @@ namespace GitHub.Unity
                         }
                     }
                 },
-                node =>
-                {
-                    Debug.Log("Right Click");
+                node => {
+                    GenericMenu menu = CreateContextMenuForRemoteBranchNode(node);
+                    menu.ShowAsContext();
                 });
 
             if (treeHadFocus && treeRemotes.SelectedNode == null)
@@ -383,6 +383,39 @@ namespace GitHub.Unity
 
             //Debug.LogFormat("reserving: {0} {1} {2}", rect.y - initialRect.y, rect.y, initialRect.y);
             GUILayout.Space(rect.y - initialRect.y);
+        }
+
+        private GenericMenu CreateContextMenuForLocalBranchNode(TreeNode node)
+        {
+            var genericMenu = new GenericMenu();
+
+            var deleteGuiContent = new GUIContent("Delete");
+            var switchGuiContent = new GUIContent("Switch");
+
+            if (node.IsActive)
+            {
+                genericMenu.AddDisabledItem(deleteGuiContent);
+                genericMenu.AddDisabledItem(switchGuiContent);
+            }
+            else
+            {
+                genericMenu.AddItem(deleteGuiContent, false, (userData) => {
+                    Debug.Log("Delete Branch");
+                }, node);
+
+                genericMenu.AddItem(switchGuiContent, false, (userData) => {
+                    Debug.Log("Switch Branch");
+                }, node);
+            }
+
+            return genericMenu;
+        }
+
+        private GenericMenu CreateContextMenuForRemoteBranchNode(TreeNode node)
+        {
+            var genericMenu = new GenericMenu();
+
+            return genericMenu;
         }
 
         private int CompareBranches(GitBranch a, GitBranch b)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -282,7 +282,9 @@ namespace GitHub.Unity
 
             var treeHadFocus = treeLocals.SelectedNode != null;
 
-            rect = treeLocals.Render(rect, scroll, _ => { }, node =>
+            rect = treeLocals.Render(rect, scroll,
+                node =>{ },
+                node =>
                 {
                     if (EditorUtility.DisplayDialog(ConfirmSwitchTitle, String.Format(ConfirmSwitchMessage, node.Name), ConfirmSwitchOK,
                             ConfirmSwitchCancel))
@@ -302,6 +304,10 @@ namespace GitHub.Unity
                                 }
                             }).Start();
                     }
+                },
+                node =>
+                {
+                    Debug.Log("Right Click");
                 });
 
             if (treeHadFocus && treeLocals.SelectedNode == null)
@@ -316,7 +322,9 @@ namespace GitHub.Unity
 
             rect.y += Styles.TreePadding;
 
-            rect = treeRemotes.Render(rect, scroll, _ => {}, selectedNode =>
+            rect = treeRemotes.Render(rect, scroll,
+                node => { },
+                selectedNode =>
                 {
                     var indexOfFirstSlash = selectedNode.Name.IndexOf('/');
                     var originName = selectedNode.Name.Substring(0, indexOfFirstSlash);
@@ -355,6 +363,10 @@ namespace GitHub.Unity
                                 .Start();
                         }
                     }
+                },
+                node =>
+                {
+                    Debug.Log("Right Click");
                 });
 
             if (treeHadFocus && treeRemotes.SelectedNode == null)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -280,9 +280,15 @@ namespace GitHub.Unity
             rect = treeLocals.Render(rect, scroll,
                 node =>{ },
                 node => {
+                    if (node.IsFolder)
+                        return;
+
                     SwitchBranch(node.Name);
                 },
                 node => {
+                    if (node.IsFolder)
+                        return;
+
                     var menu = CreateContextMenuForLocalBranchNode(node);
                     menu.ShowAsContext();
                 });
@@ -301,11 +307,17 @@ namespace GitHub.Unity
 
             rect = treeRemotes.Render(rect, scroll,
                 node => { },
-                selectedNode => {
-                    CheckoutRemoteBranch(selectedNode.Name);
+                node => {
+                    if (node.IsFolder)
+                        return;
+
+                    CheckoutRemoteBranch(node.Name);
                 },
                 node => {
-                    GenericMenu menu = CreateContextMenuForRemoteBranchNode(node);
+                    if (node.IsFolder)
+                       return;
+
+                    var menu = CreateContextMenuForRemoteBranchNode(node);
                     menu.ShowAsContext();
                 });
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -132,7 +132,7 @@ namespace GitHub.Unity
             foldersKeys = Folders.Keys.Cast<string>().ToList();
         }
 
-        public Rect Render(Rect rect, Vector2 scroll, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null)
+        public Rect Render(Rect rect, Vector2 scroll, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null, Action<TreeNode> rightClick = null)
         {
             Profiler.BeginSample("TreeControl");
             bool visible = true;
@@ -191,7 +191,7 @@ namespace GitHub.Unity
                 {
                     if (visible)
                     {
-                        RequiresRepaint = HandleInput(rect, node, i, singleClick, doubleClick);
+                        RequiresRepaint = HandleInput(rect, node, i, singleClick, doubleClick, rightClick);
                     }
                     rect.y += ItemHeight + ItemSpacing;
                 }
@@ -257,7 +257,7 @@ namespace GitHub.Unity
             return idx;
         }
 
-        private bool HandleInput(Rect rect, TreeNode currentNode, int index, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null)
+        private bool HandleInput(Rect rect, TreeNode currentNode, int index, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null, Action<TreeNode> rightClick = null)
         {
             bool selectionChanged = false;
             var clickRect = new Rect(0f, rect.y, rect.width, rect.height);
@@ -267,13 +267,19 @@ namespace GitHub.Unity
                 SelectedNode = currentNode;
                 selectionChanged = true;
                 var clickCount = Event.current.clickCount;
-                if (clickCount == 1 && singleClick != null)
+                var mouseButton = Event.current.button;
+
+                if (mouseButton == 0 && clickCount == 1 && singleClick != null)
                 {
                     singleClick(currentNode);
                 }
-                if (clickCount > 1 && doubleClick != null)
+                if (mouseButton == 0 && clickCount > 1 && doubleClick != null)
                 {
                     doubleClick(currentNode);
+                }
+                if (mouseButton == 1 && clickCount == 1 && rightClick != null)
+                {
+                    rightClick(currentNode);
                 }
             }
 


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

Fixes #453

- Adding right click context menu's to access functionality that is already in the `BranchesView`.
  - Adding right click functionality to `TreeControl`
  - Refactoring Delete, Switch and Checkout functionality to functions
  - Adding a context menu to the right click handler

Depends on:
- [x] #151 
- [x] #465