### PR TITLE
Functionality to mark folder nodes as "root"

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -831,16 +831,16 @@ namespace GitHub.Unity
             }
         }
 
-        private static Texture2D rootFolderIcon;
+        private static Texture2D globeIcon;
         public static Texture2D GlobeIcon
         {
             get
             {
-                if (rootFolderIcon == null)
+                if (globeIcon == null)
                 {
-                    rootFolderIcon = Utility.GetIcon("globe.png", "globe@2x.png");
+                    globeIcon = Utility.GetIcon("globe.png", "globe@2x.png");
                 }
-                return rootFolderIcon;
+                return globeIcon;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -832,7 +832,7 @@ namespace GitHub.Unity
         }
 
         private static Texture2D rootFolderIcon;
-        public static Texture2D RootFolderIcon
+        public static Texture2D GlobeIcon
         {
             get
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -141,7 +141,9 @@ namespace GitHub.Unity
             if (treeLocals == null)
             {
                 treeLocals = new BranchesTree();
+
                 treeRemotes = new BranchesTree();
+                treeRemotes.IsRemote = true;
 
                 UpdateTreeIcons();
             }
@@ -167,10 +169,10 @@ namespace GitHub.Unity
                     treeLocals.ActiveNodeIcon = Styles.ActiveBranchIcon;
                 }
 
-                if (treeLocals.NodeIcon == null)
+                if (treeLocals.BranchIcon == null)
                 {
                     localsLoaded = true;
-                    treeLocals.NodeIcon = Styles.BranchIcon;
+                    treeLocals.BranchIcon = Styles.BranchIcon;
                 }
 
                 if (treeLocals.FolderIcon == null)
@@ -188,16 +190,16 @@ namespace GitHub.Unity
                     treeRemotes.ActiveNodeIcon = Styles.ActiveBranchIcon;
                 }
 
-                if (treeRemotes.NodeIcon == null)
+                if (treeRemotes.BranchIcon == null)
                 {
                     remotesLoaded = true;
-                    treeRemotes.NodeIcon = Styles.BranchIcon;
+                    treeRemotes.BranchIcon = Styles.BranchIcon;
                 }
 
-                if (treeRemotes.RootFolderIcon == null)
+                if (treeRemotes.RemoteIcon == null)
                 {
                     remotesLoaded = true;
-                    treeRemotes.RootFolderIcon = Styles.RootFolderIcon;
+                    treeRemotes.RemoteIcon = Styles.RootFolderIcon;
                 }
 
                 if (treeRemotes.FolderIcon == null)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -160,12 +160,12 @@ namespace GitHub.Unity
         {
             if (treeLocals != null)
             {
-                treeLocals.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.RootFolderIcon);
+                treeLocals.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.GlobeIcon);
             }
 
             if (treeRemotes != null)
             {
-                treeRemotes.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.RootFolderIcon);
+                treeRemotes.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.GlobeIcon);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -455,22 +455,22 @@ namespace GitHub.Unity
     {
         [SerializeField] public bool IsRemote;
         
-        [NonSerialized] public Texture2D ActiveNodeIcon;
+        [NonSerialized] public Texture2D ActiveBranchIcon;
         [NonSerialized] public Texture2D BranchIcon;
         [NonSerialized] public Texture2D FolderIcon;
-        [NonSerialized] public Texture2D RemoteIcon;
+        [NonSerialized] public Texture2D GlobeIcon;
 
         protected override Texture2D GetNodeIcon(TreeNode node)
         {
             Texture2D nodeIcon;
             if (node.IsActive)
             {
-                nodeIcon = ActiveNodeIcon;
+                nodeIcon = ActiveBranchIcon;
             }
             else if (node.IsFolder)
             {
                 nodeIcon = IsRemote && node.Level == 1
-                    ? RemoteIcon
+                    ? GlobeIcon
                     : FolderIcon;
             }
             else
@@ -481,15 +481,15 @@ namespace GitHub.Unity
         }
 
 
-        public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D rootFolderIcon)
+        public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D globeIcon)
         {
-            var needsLoad = ActiveNodeIcon == null || BranchIcon == null || FolderIcon == null || RemoteIcon == null;
+            var needsLoad = ActiveBranchIcon == null || BranchIcon == null || FolderIcon == null || GlobeIcon == null;
             if (needsLoad)
             {
-                ActiveNodeIcon = activeBranchIcon;
+                ActiveBranchIcon = activeBranchIcon;
                 BranchIcon = branchIcon;
                 FolderIcon = folderIcon;
-                RemoteIcon = rootFolderIcon;
+                GlobeIcon = globeIcon;
 
                 LoadNodeIcons();
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -12,9 +12,11 @@ namespace GitHub.Unity
     public class BranchesTree: Tree
     {
         [NonSerialized] public Texture2D ActiveNodeIcon;
-        [NonSerialized] public Texture2D NodeIcon;
+        [NonSerialized] public Texture2D BranchIcon;
         [NonSerialized] public Texture2D FolderIcon;
-        [NonSerialized] public Texture2D RootFolderIcon;
+        [NonSerialized] public Texture2D RemoteIcon;
+
+        [SerializeField] public bool IsRemote;
 
         protected override Texture2D GetNodeIcon(TreeNode node)
         {
@@ -25,14 +27,13 @@ namespace GitHub.Unity
             }
             else if (node.IsFolder)
             {
-                if (node.Level == 1)
-                    nodeIcon = RootFolderIcon;
-                else
-                    nodeIcon = FolderIcon;
+                nodeIcon = IsRemote && node.Level == 1
+                    ? RemoteIcon
+                    : FolderIcon;
             }
             else
             {
-                nodeIcon = NodeIcon;
+                nodeIcon = BranchIcon;
             }
             return nodeIcon;
         }


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

Fixes #454

- Renaming icons to be something more useful
- Adding functionality to render the globe icon at the right time

Depends on:
- [x] #151 
- [x] #465
- [x] #479