### PR TITLE
Making the folders selectable via mouse

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -448,8 +448,10 @@ namespace GitHub.Unity
 
             if (IsFolder)
             {
+                var toggleRect = new Rect(nodeRect.x, nodeRect.y, style.border.horizontal, nodeRect.height);
+
                 EditorGUI.BeginChangeCheck();
-                GUI.Toggle(nodeRect, !IsCollapsed, "", GUIStyle.none);
+                GUI.Toggle(toggleRect, !IsCollapsed, "", GUIStyle.none);
                 changed = EditorGUI.EndChangeCheck();
             }
 


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

Fixes #455 

Folder line items in the tree view are not "selectable" because the clickable area to open/close the folder overlaps it.

Depends on:
- [x] #151 
- [x] #465