### PR TITLE
Not attempting to serialize Texture2D objects and reloading Icons

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -7,40 +7,6 @@ using UnityEngine;
 
 namespace GitHub.Unity
 {
-    [Serializable]
-    public class SerializableTexture2D
-    {
-        [SerializeField] private byte[] bytes;
-        [SerializeField] private int height;
-        [SerializeField] private int width;
-        [SerializeField] private TextureFormat format;
-        [SerializeField] private bool mipmap;
-        [SerializeField] private Texture2D texture;
-
-        public Texture2D Texture
-        {
-            get
-            {
-                if (texture == null)
-                {
-                    texture = new Texture2D(width, height, format, mipmap);
-                    texture.LoadRawTextureData(bytes);
-                    texture.Apply();
-                }
-                return texture;
-            }
-            set
-            {
-                texture = value;
-                bytes = value.GetRawTextureData();
-                height = value.height;
-                width = value.width;
-                format = value.format;
-                mipmap = value.mipmapCount > 1;
-            }
-        }
-    }
-
     class Utility : ScriptableObject
     {
         public static Texture2D GetIcon(string filename, string filename2x = "")

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -16,12 +16,25 @@ namespace GitHub.Unity
                 filename = filename2x;
             }
 
+            Texture2D texture2D = null;
+
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("GitHub.Unity.IconsAndLogos." + filename);
             if (stream != null)
-                return stream.ToTexture2D();
+            {
+                texture2D = stream.ToTexture2D();
+            }
+            else
+            {
+                var iconPath = EntryPoint.Environment.ExtensionInstallPath.Combine("IconsAndLogos", filename).ToString(SlashMode.Forward);
+                texture2D = AssetDatabase.LoadAssetAtPath<Texture2D>(iconPath);
+            }
 
-            var iconPath = EntryPoint.Environment.ExtensionInstallPath.Combine("IconsAndLogos", filename).ToString(SlashMode.Forward);
-            return AssetDatabase.LoadAssetAtPath<Texture2D>(iconPath);
+            if (texture2D != null)
+            {
+                texture2D.hideFlags = HideFlags.HideAndDontSave;
+            }
+
+            return texture2D;
         }
 
         public static Texture2D GetTextureFromColor(Color color)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -156,65 +156,14 @@ namespace GitHub.Unity
 
         private void UpdateTreeIcons()
         {
-            var localsLoaded = false;
-            var remotesLoaded = false;
-
             if (treeLocals != null)
             {
-                if (treeLocals.ActiveNodeIcon == null)
-                {
-                    localsLoaded = true;
-                    treeLocals.ActiveNodeIcon = Styles.ActiveBranchIcon;
-                }
-
-                if (treeLocals.NodeIcon == null)
-                {
-                    localsLoaded = true;
-                    treeLocals.NodeIcon = Styles.BranchIcon;
-                }
-
-                if (treeLocals.FolderIcon == null)
-                {
-                    localsLoaded = true;
-                    treeLocals.FolderIcon = Styles.FolderIcon;
-                }
+                treeLocals.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.RootFolderIcon);
             }
 
             if (treeRemotes != null)
             {
-                if (treeRemotes.ActiveNodeIcon == null)
-                {
-                    remotesLoaded = true;
-                    treeRemotes.ActiveNodeIcon = Styles.ActiveBranchIcon;
-                }
-
-                if (treeRemotes.NodeIcon == null)
-                {
-                    remotesLoaded = true;
-                    treeRemotes.NodeIcon = Styles.BranchIcon;
-                }
-
-                if (treeRemotes.RootFolderIcon == null)
-                {
-                    remotesLoaded = true;
-                    treeRemotes.RootFolderIcon = Styles.RootFolderIcon;
-                }
-
-                if (treeRemotes.FolderIcon == null)
-                {
-                    remotesLoaded = true;
-                    treeRemotes.FolderIcon = Styles.FolderIcon;
-                }
-            }
-
-            if (localsLoaded)
-            {
-                treeLocals.LoadNodeIcons();
-            }
-
-            if (remotesLoaded)
-            {
-                treeRemotes.LoadNodeIcons();
+                treeRemotes.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.RootFolderIcon);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -59,6 +59,7 @@ namespace GitHub.Unity
         public override void OnEnable()
         {
             base.OnEnable();
+            UpdateTreeIcons();
             AttachHandlers(Repository);
             Repository.CheckLocalAndRemoteBranchListChangedEvent(lastLocalAndRemoteBranchListChangedEvent);
         }
@@ -134,23 +135,85 @@ namespace GitHub.Unity
 
         private void BuildTree()
         {
+            if (treeLocals == null)
+            {
+                treeLocals = new Tree();
+
+                treeRemotes = new Tree();
+
+                UpdateTreeIcons();
+            }
+
             localBranches.Sort(CompareBranches);
             remoteBranches.Sort(CompareBranches);
-            treeLocals = new Tree();
-            treeLocals.ActiveNodeIcon = Styles.ActiveBranchIcon;
-            treeLocals.NodeIcon = Styles.BranchIcon;
-            treeLocals.RootFolderIcon = Styles.RootFolderIcon;
-            treeLocals.FolderIcon = Styles.FolderIcon;
-
-            treeRemotes = new Tree();
-            treeRemotes.ActiveNodeIcon = Styles.ActiveBranchIcon;
-            treeRemotes.NodeIcon = Styles.BranchIcon;
-            treeRemotes.RootFolderIcon = Styles.RootFolderIcon;
-            treeRemotes.FolderIcon = Styles.FolderIcon;
 
             treeLocals.Load(localBranches.Cast<ITreeData>(), LocalTitle);
             treeRemotes.Load(remoteBranches.Cast<ITreeData>(), RemoteTitle);
             Redraw();
+        }
+
+        private void UpdateTreeIcons()
+        {
+            var localsLoaded = false;
+            var remotesLoaded = false;
+
+            if (treeLocals != null)
+            {
+                if (treeLocals.ActiveNodeIcon == null)
+                {
+                    localsLoaded = true;
+                    treeLocals.ActiveNodeIcon = Styles.ActiveBranchIcon;
+                }
+
+                if (treeLocals.NodeIcon == null)
+                {
+                    localsLoaded = true;
+                    treeLocals.NodeIcon = Styles.BranchIcon;
+                }
+
+                if (treeLocals.FolderIcon == null)
+                {
+                    localsLoaded = true;
+                    treeLocals.FolderIcon = Styles.FolderIcon;
+                }
+            }
+
+            if (treeRemotes != null)
+            {
+                if (treeRemotes.ActiveNodeIcon == null)
+                {
+                    remotesLoaded = true;
+                    treeRemotes.ActiveNodeIcon = Styles.ActiveBranchIcon;
+                }
+
+                if (treeRemotes.NodeIcon == null)
+                {
+                    remotesLoaded = true;
+                    treeRemotes.NodeIcon = Styles.BranchIcon;
+                }
+
+                if (treeRemotes.RootFolderIcon == null)
+                {
+                    remotesLoaded = true;
+                    treeRemotes.RootFolderIcon = Styles.RootFolderIcon;
+                }
+
+                if (treeRemotes.FolderIcon == null)
+                {
+                    remotesLoaded = true;
+                    treeRemotes.FolderIcon = Styles.FolderIcon;
+                }
+            }
+
+            if (localsLoaded)
+            {
+                treeLocals.LoadNodeIcons();
+            }
+
+            if (remotesLoaded)
+            {
+                treeRemotes.LoadNodeIcons();
+            }
         }
 
         private void OnButtonBarGUI()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -39,8 +39,8 @@ namespace GitHub.Unity
         [NonSerialized] private int listID = -1;
         [NonSerialized] private BranchesMode targetMode;
 
-        [SerializeField] private Tree treeLocals = new Tree();
-        [SerializeField] private Tree treeRemotes = new Tree();
+        [SerializeField] private BranchesTree treeLocals = new BranchesTree();
+        [SerializeField] private BranchesTree treeRemotes = new BranchesTree();
         [SerializeField] private BranchesMode mode = BranchesMode.Default;
         [SerializeField] private string newBranchName;
         [SerializeField] private Vector2 scroll;
@@ -140,9 +140,9 @@ namespace GitHub.Unity
         {
             if (treeLocals == null)
             {
-                treeLocals = new Tree();
+                treeLocals = new BranchesTree();
 
-                treeRemotes = new Tree();
+                treeRemotes = new BranchesTree();
 
                 UpdateTreeIcons();
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -39,8 +39,8 @@ namespace GitHub.Unity
         [NonSerialized] private int listID = -1;
         [NonSerialized] private BranchesMode targetMode;
 
-        [SerializeField] private BranchesTree treeLocals = new BranchesTree();
-        [SerializeField] private BranchesTree treeRemotes = new BranchesTree();
+        [SerializeField] private BranchesTree treeLocals;
+        [SerializeField] private BranchesTree treeRemotes;
         [SerializeField] private BranchesMode mode = BranchesMode.Default;
         [SerializeField] private string newBranchName;
         [SerializeField] private Vector2 scroll;
@@ -141,7 +141,6 @@ namespace GitHub.Unity
             if (treeLocals == null)
             {
                 treeLocals = new BranchesTree();
-
                 treeRemotes = new BranchesTree();
 
                 UpdateTreeIcons();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -17,17 +17,10 @@ namespace GitHub.Unity
         [SerializeField] public Rect Margin = new Rect();
         [SerializeField] public Rect Padding = new Rect();
 
-        [SerializeField] private SerializableTexture2D activeNodeIcon = new SerializableTexture2D();
-        public Texture2D ActiveNodeIcon {  get { return activeNodeIcon.Texture; } set { activeNodeIcon.Texture = value; } }
-
-        [SerializeField] private SerializableTexture2D nodeIcon = new SerializableTexture2D();
-        public Texture2D NodeIcon {  get { return nodeIcon.Texture; } set { nodeIcon.Texture = value; } }
-
-        [SerializeField] private SerializableTexture2D folderIcon = new SerializableTexture2D();
-        public Texture2D FolderIcon {  get { return folderIcon.Texture; } set { folderIcon.Texture = value; } }
-
-        [SerializeField] private SerializableTexture2D rootFolderIcon = new SerializableTexture2D();
-        public Texture2D RootFolderIcon {  get { return rootFolderIcon.Texture; } set { rootFolderIcon.Texture = value; } }
+        [SerializeField] public Texture2D ActiveNodeIcon;
+        [SerializeField] public Texture2D NodeIcon;
+        [SerializeField] public Texture2D FolderIcon;
+        [SerializeField] public Texture2D RootFolderIcon;
 
         [SerializeField] public GUIStyle FolderStyle;
         [SerializeField] public GUIStyle TreeNodeStyle;
@@ -160,7 +153,7 @@ namespace GitHub.Unity
             for (; i < nodes.Count; i++)
             {
                 var node = nodes[i];
-                ResetNodeIcons(node);
+//                ResetNodeIcons(node);
 
                 if (node.Level > level && !node.IsHidden)
                 {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -36,6 +36,40 @@ namespace GitHub.Unity
             }
             return nodeIcon;
         }
+
+        public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D rootFolderIcon)
+        {
+            var localsLoaded = false;
+
+            if (ActiveNodeIcon == null)
+            {
+                localsLoaded = true;
+                ActiveNodeIcon = activeBranchIcon;
+            }
+
+            if (NodeIcon == null)
+            {
+                localsLoaded = true;
+                NodeIcon = branchIcon;
+            }
+
+            if (FolderIcon == null)
+            {
+                localsLoaded = true;
+                FolderIcon = folderIcon;
+            }
+
+            if (RootFolderIcon == null)
+            {
+                localsLoaded = true;
+                RootFolderIcon = rootFolderIcon;
+            }
+
+            if (localsLoaded)
+            {
+                LoadNodeIcons();
+            }
+        }
     }
 
     [Serializable]
@@ -402,7 +436,7 @@ namespace GitHub.Unity
 
         protected abstract Texture2D GetNodeIcon(TreeNode node);
 
-        public void LoadNodeIcons()
+        protected void LoadNodeIcons()
         {
             foreach (var treeNode in nodes)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -9,70 +9,6 @@ using UnityEngine.Profiling;
 namespace GitHub.Unity
 {
     [Serializable]
-    public class BranchesTree: Tree
-    {
-        [NonSerialized] public Texture2D ActiveNodeIcon;
-        [NonSerialized] public Texture2D NodeIcon;
-        [NonSerialized] public Texture2D FolderIcon;
-        [NonSerialized] public Texture2D RootFolderIcon;
-
-        protected override Texture2D GetNodeIcon(TreeNode node)
-        {
-            Texture2D nodeIcon;
-            if (node.IsActive)
-            {
-                nodeIcon = ActiveNodeIcon;
-            }
-            else if (node.IsFolder)
-            {
-                if (node.Level == 1)
-                    nodeIcon = RootFolderIcon;
-                else
-                    nodeIcon = FolderIcon;
-            }
-            else
-            {
-                nodeIcon = NodeIcon;
-            }
-            return nodeIcon;
-        }
-
-        public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D rootFolderIcon)
-        {
-            var localsLoaded = false;
-
-            if (ActiveNodeIcon == null)
-            {
-                localsLoaded = true;
-                ActiveNodeIcon = activeBranchIcon;
-            }
-
-            if (NodeIcon == null)
-            {
-                localsLoaded = true;
-                NodeIcon = branchIcon;
-            }
-
-            if (FolderIcon == null)
-            {
-                localsLoaded = true;
-                FolderIcon = folderIcon;
-            }
-
-            if (RootFolderIcon == null)
-            {
-                localsLoaded = true;
-                RootFolderIcon = rootFolderIcon;
-            }
-
-            if (localsLoaded)
-            {
-                LoadNodeIcons();
-            }
-        }
-    }
-
-    [Serializable]
     public abstract class Tree
     {
         public static float ItemHeight { get { return EditorGUIUtility.singleLineHeight; } }
@@ -511,6 +447,70 @@ namespace GitHub.Unity
         {
             return String.Format("name:{0} label:{1} level:{2} isFolder:{3} isCollapsed:{4} isHidden:{5} isActive:{6}",
                 Name, Label, Level, IsFolder, IsCollapsed, IsHidden, IsActive);
+        }
+    }
+
+    [Serializable]
+    public class BranchesTree: Tree
+    {
+        [NonSerialized] public Texture2D ActiveNodeIcon;
+        [NonSerialized] public Texture2D NodeIcon;
+        [NonSerialized] public Texture2D FolderIcon;
+        [NonSerialized] public Texture2D RootFolderIcon;
+
+        protected override Texture2D GetNodeIcon(TreeNode node)
+        {
+            Texture2D nodeIcon;
+            if (node.IsActive)
+            {
+                nodeIcon = ActiveNodeIcon;
+            }
+            else if (node.IsFolder)
+            {
+                if (node.Level == 1)
+                    nodeIcon = RootFolderIcon;
+                else
+                    nodeIcon = FolderIcon;
+            }
+            else
+            {
+                nodeIcon = NodeIcon;
+            }
+            return nodeIcon;
+        }
+
+        public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D rootFolderIcon)
+        {
+            var localsLoaded = false;
+
+            if (ActiveNodeIcon == null)
+            {
+                localsLoaded = true;
+                ActiveNodeIcon = activeBranchIcon;
+            }
+
+            if (NodeIcon == null)
+            {
+                localsLoaded = true;
+                NodeIcon = branchIcon;
+            }
+
+            if (FolderIcon == null)
+            {
+                localsLoaded = true;
+                FolderIcon = folderIcon;
+            }
+
+            if (RootFolderIcon == null)
+            {
+                localsLoaded = true;
+                RootFolderIcon = rootFolderIcon;
+            }
+
+            if (localsLoaded)
+            {
+                LoadNodeIcons();
+            }
         }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -17,10 +17,10 @@ namespace GitHub.Unity
         [SerializeField] public Rect Margin = new Rect();
         [SerializeField] public Rect Padding = new Rect();
 
-        [SerializeField] public Texture2D ActiveNodeIcon;
-        [SerializeField] public Texture2D NodeIcon;
-        [SerializeField] public Texture2D FolderIcon;
-        [SerializeField] public Texture2D RootFolderIcon;
+        [NonSerialized] public Texture2D ActiveNodeIcon;
+        [NonSerialized] public Texture2D NodeIcon;
+        [NonSerialized] public Texture2D FolderIcon;
+        [NonSerialized] public Texture2D RootFolderIcon;
 
         [SerializeField] public GUIStyle FolderStyle;
         [SerializeField] public GUIStyle TreeNodeStyle;
@@ -82,7 +82,7 @@ namespace GitHub.Unity
                 Level = 0,
                 IsFolder = true
             };
-            titleNode.Load();
+            SetNodeIcons(titleNode);
             nodes.Add(titleNode);
 
             foreach (var d in data)
@@ -110,9 +110,7 @@ namespace GitHub.Unity
                             activeNode = node;
                         }
 
-                        ResetNodeIcons(node);
-
-                        node.Load();
+                        SetNodeIcons(node);
 
                         nodes.Add(node);
                         if (isFolder)
@@ -135,7 +133,6 @@ namespace GitHub.Unity
             rect = new Rect(0f, rect.y, rect.width, ItemHeight);
 
             var titleNode = nodes[0];
-            ResetNodeIcons(titleNode);
             bool selectionChanged = titleNode.Render(rect, 0f, selectedNode == titleNode, FolderStyle, TreeNodeStyle, ActiveTreeNodeStyle);
 
             if (selectionChanged)
@@ -153,8 +150,6 @@ namespace GitHub.Unity
             for (; i < nodes.Count; i++)
             {
                 var node = nodes[i];
-//                ResetNodeIcons(node);
-
                 if (node.Level > level && !node.IsHidden)
                 {
                     Indent();
@@ -368,7 +363,7 @@ namespace GitHub.Unity
             indents.Pop();
         }
 
-        private void ResetNodeIcons(TreeNode node)
+        private void SetNodeIcons(TreeNode node)
         {
             if (node.IsActive)
             {
@@ -385,7 +380,16 @@ namespace GitHub.Unity
             {
                 node.Icon = NodeIcon;
             }
+
             node.Load();
+        }
+
+        public void LoadNodeIcons()
+        {
+            foreach (var treeNode in nodes)
+            {
+                SetNodeIcons(treeNode);
+            }
         }
     }
 
@@ -400,7 +404,7 @@ namespace GitHub.Unity
         public bool IsHidden;
         public bool IsActive;
         public GUIContent content;
-        public Texture2D Icon;
+        [NonSerialized] public Texture2D Icon;
 
         public void Load()
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -481,34 +481,14 @@ namespace GitHub.Unity
 
         public void UpdateIcons(Texture2D activeBranchIcon, Texture2D branchIcon, Texture2D folderIcon, Texture2D rootFolderIcon)
         {
-            var localsLoaded = false;
-
-            if (ActiveNodeIcon == null)
+            var needsLoad = ActiveNodeIcon == null || NodeIcon == null || FolderIcon == null || RootFolderIcon == null;
+            if (needsLoad)
             {
-                localsLoaded = true;
                 ActiveNodeIcon = activeBranchIcon;
-            }
-
-            if (NodeIcon == null)
-            {
-                localsLoaded = true;
                 NodeIcon = branchIcon;
-            }
-
-            if (FolderIcon == null)
-            {
-                localsLoaded = true;
                 FolderIcon = folderIcon;
-            }
-
-            if (RootFolderIcon == null)
-            {
-                localsLoaded = true;
                 RootFolderIcon = rootFolderIcon;
-            }
 
-            if (localsLoaded)
-            {
                 LoadNodeIcons();
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -9,18 +9,43 @@ using UnityEngine.Profiling;
 namespace GitHub.Unity
 {
     [Serializable]
-    public class Tree
+    public class BranchesTree: Tree
+    {
+        [NonSerialized] public Texture2D ActiveNodeIcon;
+        [NonSerialized] public Texture2D NodeIcon;
+        [NonSerialized] public Texture2D FolderIcon;
+        [NonSerialized] public Texture2D RootFolderIcon;
+
+        protected override Texture2D GetNodeIcon(TreeNode node)
+        {
+            Texture2D nodeIcon;
+            if (node.IsActive)
+            {
+                nodeIcon = ActiveNodeIcon;
+            }
+            else if (node.IsFolder)
+            {
+                if (node.Level == 1)
+                    nodeIcon = RootFolderIcon;
+                else
+                    nodeIcon = FolderIcon;
+            }
+            else
+            {
+                nodeIcon = NodeIcon;
+            }
+            return nodeIcon;
+        }
+    }
+
+    [Serializable]
+    public abstract class Tree
     {
         public static float ItemHeight { get { return EditorGUIUtility.singleLineHeight; } }
         public static float ItemSpacing { get { return EditorGUIUtility.standardVerticalSpacing; } }
 
         [SerializeField] public Rect Margin = new Rect();
         [SerializeField] public Rect Padding = new Rect();
-
-        [NonSerialized] public Texture2D ActiveNodeIcon;
-        [NonSerialized] public Texture2D NodeIcon;
-        [NonSerialized] public Texture2D FolderIcon;
-        [NonSerialized] public Texture2D RootFolderIcon;
 
         [SerializeField] public GUIStyle FolderStyle;
         [SerializeField] public GUIStyle TreeNodeStyle;
@@ -82,7 +107,7 @@ namespace GitHub.Unity
                 Level = 0,
                 IsFolder = true
             };
-            SetNodeIcons(titleNode);
+            SetNodeIcon(titleNode);
             nodes.Add(titleNode);
 
             foreach (var d in data)
@@ -110,7 +135,7 @@ namespace GitHub.Unity
                             activeNode = node;
                         }
 
-                        SetNodeIcons(node);
+                        SetNodeIcon(node);
 
                         nodes.Add(node);
                         if (isFolder)
@@ -369,32 +394,19 @@ namespace GitHub.Unity
             indents.Pop();
         }
 
-        private void SetNodeIcons(TreeNode node)
+        private void SetNodeIcon(TreeNode node)
         {
-            if (node.IsActive)
-            {
-                node.Icon = ActiveNodeIcon;
-            }
-            else if (node.IsFolder)
-            {
-                if (node.Level == 1)
-                    node.Icon = RootFolderIcon;
-                else
-                    node.Icon = FolderIcon;
-            }
-            else
-            {
-                node.Icon = NodeIcon;
-            }
-
+            node.Icon = GetNodeIcon(node);
             node.Load();
         }
+
+        protected abstract Texture2D GetNodeIcon(TreeNode node);
 
         public void LoadNodeIcons()
         {
             foreach (var treeNode in nodes)
             {
-                SetNodeIcons(treeNode);
+                SetNodeIcon(treeNode);
             }
         }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -40,6 +40,8 @@ namespace GitHub.Unity
         [SerializeField] private CacheUpdateEvent lastCurrentBranchAndRemoteChangedEvent;
         [NonSerialized] private bool currentBranchAndRemoteHasUpdate;
 
+        [NonSerialized] private Texture2D smallLogo;
+
         [MenuItem(LaunchMenu)]
         public static void Window_GitHub()
         {
@@ -102,7 +104,11 @@ namespace GitHub.Unity
             Selection.activeObject = this;
 #endif
             // Set window title
-            titleContent = new GUIContent(Title, Styles.SmallLogo);
+            if (smallLogo == null)
+            {
+                smallLogo = Styles.SmallLogo;
+                titleContent = new GUIContent(Title, smallLogo);
+            }
 
             if (Repository != null)
                 Repository.CheckCurrentBranchAndRemoteChangedEvent(lastCurrentBranchAndRemoteChangedEvent);


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

- Learned from @CapnRat that it is problematic to attempt to serialize `Texture2D` objects and it is better to provide them `OnEnable`. A large component to this fix is the usage of `HideFlags.HideAndDontSave` which prevents Unity from garbage collecting icons after they load during "game play".
- We also subclassed `Tree` into `BranchesTree` in order to provide custom logic to set the icons for trees that represent a branch
