### PR TITLE
Updating the git log when the head changes

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -360,6 +360,7 @@ namespace GitHub.Unity
             var head = repositoryPaths.DotGitHead.ReadAllLines().FirstOrDefault();
             Logger.Trace("UpdateHead: {0}", head ?? "[NULL]");
             UpdateCurrentBranchAndRemote(head);
+            UpdateGitLog();
         }
 
         private void UpdateCurrentBranchAndRemote(string head)


### PR DESCRIPTION
Fixes #484 

When the `HEAD` is updated, we know some sort of checkout operation occurred, so we need to update the git log.