### PR TITLE
Properly identifying GitRemote.Default

### DIFF
--- a/src/GitHub.Api/Git/GitRemote.cs
+++ b/src/GitHub.Api/Git/GitRemote.cs
@@ -14,7 +14,7 @@ namespace GitHub.Unity
     [Serializable]
     public struct GitRemote
     {
-        public static GitRemote Default = new GitRemote();
+        public static GitRemote Default = new GitRemote(String.Empty, String.Empty, String.Empty, GitRemoteFunction.Unknown, string.Empty, string.Empty, string.Empty);
 
         public string name;
         public string url;


### PR DESCRIPTION
Fixes #483 

Changing how `GitRemote.Default` is defined.

Unity has issues serializing "NULL". For instance, null strings actually get serialized as empty.
We use a lot of structs.

In order to to help us identify a null struct, we use the Null Object Pattern.
Our default object for GitRemote was not correctly defined.
Some strings were null when they should be empty, in order to properly identify it as `Default` after deserialization.