### PR TITLE
Updating LFS locks list after lock operation

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -50,6 +50,7 @@ namespace GitHub.Unity
             repositoryManager.CurrentBranchUpdated += RepositoryManagerOnCurrentBranchUpdated;
             repositoryManager.GitStatusUpdated += RepositoryManagerOnGitStatusUpdated;
             repositoryManager.GitLogUpdated += RepositoryManagerOnGitLogUpdated;
+            repositoryManager.GitLocksUpdated += RepositoryManagerOnGitLocksUpdated;
             repositoryManager.LocalBranchesUpdated += RepositoryManagerOnLocalBranchesUpdated;
             repositoryManager.RemoteBranchesUpdated += RepositoryManagerOnRemoteBranchesUpdated;
         }
@@ -381,6 +382,14 @@ namespace GitHub.Unity
             new ActionTask(CancellationToken.None, () => {
                 CurrentLog = gitLogEntries;
             }) { Affinity = TaskAffinity.UI }.Start();
+        }
+
+        private void RepositoryManagerOnGitLocksUpdated(List<GitLock> gitLocks)
+        {
+            new ActionTask(CancellationToken.None, () => {
+                    CurrentLocks = gitLocks;
+                })
+                { Affinity = TaskAffinity.UI }.Start();
         }
 
         private void RepositoryManagerOnRemoteBranchesUpdated(Dictionary<string, ConfigRemote> remotes,

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -354,18 +354,18 @@ namespace GitHub.Unity
             new ActionTask(CancellationToken.None, () => {
                 if (!Nullable.Equals(CurrentConfigBranch, branch))
                 {
-                        var currentBranch = branch != null ? (GitBranch?)GetLocalGitBranch(branch.Value) : null;
+                    var currentBranch = branch != null ? (GitBranch?)GetLocalGitBranch(branch.Value) : null;
 
-                        CurrentConfigBranch = branch;
-                        CurrentBranch = currentBranch;
-                        UpdateLocalBranches();
+                    CurrentConfigBranch = branch;
+                    CurrentBranch = currentBranch;
+                    UpdateLocalBranches();
                 }
 
                 if (!Nullable.Equals(CurrentConfigRemote, remote))
                 {
-                        CurrentConfigRemote = remote;
-                        CurrentRemote = GetGitRemote(remote.Value);
-                        ClearRepositoryInfo();
+                    CurrentConfigRemote = remote;
+                    CurrentRemote = remote.HasValue ? (GitRemote?)GetGitRemote(remote.Value) : null;
+                    ClearRepositoryInfo();
                 }
             }) { Affinity = TaskAffinity.UI }.Start();
         }
@@ -412,12 +412,10 @@ namespace GitHub.Unity
 
         private void UpdateLocks()
         {
-            if (string.IsNullOrEmpty(CurrentRemote?.Url))
+            if (CurrentRemote.HasValue)
             {
-                return;
+                repositoryManager?.UpdateLocks();
             }
-
-            repositoryManager?.UpdateLocks();
         }
 
         private void UpdateLocalBranches()

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -267,7 +267,7 @@ namespace GitHub.Unity
                     break;
 
                 case CacheType.GitLocksCache:
-                    repositoryManager?.UpdateLocks();
+                    UpdateLocks();
                     break;
 
                 case CacheType.GitUserCache:
@@ -399,6 +399,16 @@ namespace GitHub.Unity
                 cacheContainer.BranchCache.SetLocals(branches);
                 UpdateLocalBranches();
             }) { Affinity = TaskAffinity.UI }.Start();
+        }
+
+        private void UpdateLocks()
+        {
+            if (string.IsNullOrEmpty(CurrentRemote?.Url))
+            {
+                return;
+            }
+
+            repositoryManager?.UpdateLocks();
         }
 
         private void UpdateLocalBranches()

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -258,13 +258,13 @@ namespace GitHub.Unity
         public ITask LockFile(string file)
         {
             var task = GitClient.Lock(file);
-            return HookupHandlers(task, true, false);
+            return HookupHandlers(task, true, false).Then(UpdateLocks);
         }
 
         public ITask UnlockFile(string file, bool force)
         {
             var task = GitClient.Unlock(file, force);
-            return HookupHandlers(task, true, false);
+            return HookupHandlers(task, true, false).Then(UpdateLocks);
         }
 
         public void UpdateGitLog()


### PR DESCRIPTION
Fixes #480

- Added hook for locks updated event
- Added check for current remote url before checking for locks
- Added explicit check for locks after lock operation
- Added a missing null check