### PR TITLE
Removing forced update of config data on a mac

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -209,12 +209,6 @@ namespace GitHub.Unity
         {
             var task = GitClient.RemoteAdd(remote, url);
             task = HookupHandlers(task, true, false);
-            if (!platform.Environment.IsWindows)
-            {
-                task.Then(_ => {
-                    UpdateConfigData(true);
-                });
-            }
             return task;
         }
 
@@ -222,12 +216,6 @@ namespace GitHub.Unity
         {
             var task = GitClient.RemoteRemove(remote);
             task = HookupHandlers(task, true, false);
-            if (!platform.Environment.IsWindows)
-            {
-                task.Then(_ => {
-                    UpdateConfigData(true);
-                });
-            }
             return task;
         }
 


### PR DESCRIPTION
These lines of code should not be needed, it's explicit to mac and forcing an re-read of config data.
But there is already a watcher on the config file that will cause a re-read on the data.