### PR TITLE
Last few fixes

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -323,6 +323,9 @@ namespace GitHub.Unity
                     if (node.IsFolder)
                         return;
 
+                    if(node.IsActive)
+                        return;
+
                     SwitchBranch(node.Name);
                 },
                 node => {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -56,6 +56,12 @@ namespace GitHub.Unity
         {
             var collapsedFoldersEnumerable = folders.Where(pair => pair.Value.IsCollapsed).Select(pair => pair.Key);
             var collapsedFolders = new HashSet<string>(collapsedFoldersEnumerable);
+            string selectedNodeName = null;
+            if (SelectedNode != null)
+            {
+                selectedNodeName = SelectedNode.Name;
+                SelectedNode = null;
+            }
 
             folders.Clear();
             nodes.Clear();
@@ -93,6 +99,11 @@ namespace GitHub.Unity
                             Level = level,
                             IsFolder = isFolder
                         };
+
+                        if (selectedNodeName != null && name == selectedNodeName)
+                        {
+                            SelectedNode = node;
+                        }
 
                         if (node.IsActive)
                         {


### PR DESCRIPTION
**Note:** This branch targets `enhancements/branches-view-rollup` #464 

- Preventing checkout request when branch is already checked out
- Remembering the last selected node when reloading the tree 