### PR TITLE
Checking for the final node to make sure it is active

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -91,10 +91,16 @@ namespace GitHub.Unity
                     var alreadyExists = folders.ContainsKey(name);
                     if (!alreadyExists)
                     {
+                        var isActive = false;
+                        if (name == d.Name)
+                        {
+                            isActive = d.IsActive;
+                        }
+
                         var node = new TreeNode
                         {
                             Name = name,
-                            IsActive = d.IsActive,
+                            IsActive = isActive,
                             Label = label,
                             Level = level,
                             IsFolder = isFolder


### PR DESCRIPTION
When loading nodes we need to populate the parent folders of any given path.
We have to be careful to make sure we are only marking the final path as "active" not every parent folder.

Preventing this bug..
![](https://i.imgur.com/PNrIXxV.gif)