### PR TITLE
Toggling checked state in Tree view

### DIFF
--- a/src/GitHub.Api/UI/TreeLoader.cs
+++ b/src/GitHub.Api/UI/TreeLoader.cs
@@ -8,7 +8,8 @@ namespace GitHub.Unity
     {
         void AddNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isSelected);
         void Clear();
-        HashSet<string> GetCollapsedFolders();
+        IEnumerable<string> GetCollapsedFolders();
+        IEnumerable<string> GetCheckedFiles();
         string Title { get; }
         bool DisplayRootNode { get; }
         bool IsCheckable { get; }
@@ -20,7 +21,7 @@ namespace GitHub.Unity
     {
         public static void Load(ITree tree, IEnumerable<ITreeData> treeDatas)
         {
-            var collapsedFolders = tree.GetCollapsedFolders();
+            var collapsedFolders = new HashSet<string>(tree.GetCollapsedFolders());
             var selectedNodePath = tree.SelectedNodePath;
             
             tree.Clear();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -59,7 +59,6 @@ namespace GitHub.Unity
             targetMode = mode;
         }
 
-
         public override void OnEnable()
         {
             base.OnEnable();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -30,6 +30,7 @@ namespace GitHub.Unity
         [SerializeField] private List<TreeNode> nodes = new List<TreeNode>();
         [SerializeField] private TreeNode selectedNode = null;
         [SerializeField] private TreeNodeDictionary folders = new TreeNodeDictionary();
+        [SerializeField] private TreeNodeDictionary checkedFileNodes = new TreeNodeDictionary();
 
         [NonSerialized] private Stack<bool> indents = new Stack<bool>();
         [NonSerialized] private Action<TreeNode> rightClickNextRender;
@@ -112,14 +113,19 @@ namespace GitHub.Unity
         public void Clear()
         {
             folders.Clear();
+            checkedFileNodes.Clear();
             nodes.Clear();
             SelectedNode = null;
         }
 
-        public HashSet<string> GetCollapsedFolders()
+        public IEnumerable<string> GetCollapsedFolders()
         {
-            var collapsedFoldersEnumerable = folders.Where(pair => pair.Value.IsCollapsed).Select(pair => pair.Key);
-            return new HashSet<string>(collapsedFoldersEnumerable);
+            return folders.Where(pair => pair.Value.IsCollapsed).Select(pair => pair.Key);
+        }
+
+        public IEnumerable<string> GetCheckedFiles()
+        {
+            return checkedFileNodes.Where(pair => pair.Value.CheckState == CheckState.Checked).Select(pair => pair.Key);
         }
 
         public Rect Render(Rect containingRect, Rect rect, Vector2 scroll, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null, Action<TreeNode> rightClick = null)
@@ -270,6 +276,13 @@ namespace GitHub.Unity
             {
                 ToggleChildrenChecked(idx, node, isChecked);
             }
+            else
+            {
+                if (isChecked)
+                {
+                    checkedFileNodes.Add(node.Path, node);
+                }
+            }
 
             ToggleParentFoldersChecked(idx, node, isChecked);
         }
@@ -289,6 +302,13 @@ namespace GitHub.Unity
                 if (childNode.IsFolder)
                 {
                     ToggleChildrenChecked(i, childNode, isChecked);
+                }
+                else
+                {
+                    if (isChecked)
+                    {
+                        checkedFileNodes.Add(node.Path, node);
+                    }
                 }
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -310,18 +310,22 @@ namespace GitHub.Unity
 
                     for (var i = idx - 1; i > 0 && node.Level <= nodes[i].Level; i--)
                     {
-                        if (node.Level < nodes[i].Level)
+                        var previousNode = nodes[i];
+                        if (node.Level < previousNode.Level)
                         {
                             continue;
                         }
 
                         firstSiblingIndex = i;
-                        var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
 
-                        if (isChecked != siblingIsChecked)
+                        if (siblingsInSameState)
                         {
-                            siblingsInSameState = false;
-                            break;
+                            var previousNodeIsChecked = previousNode.CheckState == CheckState.Checked;
+
+                            if (isChecked != previousNodeIsChecked)
+                            {
+                                siblingsInSameState = false;
+                            }
                         }
                     }
 
@@ -329,14 +333,14 @@ namespace GitHub.Unity
                     {
                         for (var i = idx + 1; i < nodes.Count && node.Level <= nodes[i].Level; i++)
                         {
-                            if (node.Level < nodes[i].Level)
+                            var followingNode = nodes[i];
+                            if (node.Level < followingNode.Level)
                             {
                                 continue;
                             }
 
-                            var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
-
-                            if (isChecked != siblingIsChecked)
+                            var followingNodeIsChecked = followingNode.CheckState == CheckState.Checked;
+                            if (isChecked != followingNodeIsChecked)
                             {
                                 siblingsInSameState = false;
                                 break;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -293,14 +293,9 @@ namespace GitHub.Unity
 
         private void ToggleChildrenChecked(int idx, TreeNode node, bool isChecked)
         {
-            for (var i = idx + 1; i < nodes.Count && node.Level <= nodes[i].Level; i++)
+            for (var i = idx + 1; i < nodes.Count && node.Level < nodes[i].Level; i++)
             {
                 var childNode = nodes[i];
-                if (node.Level == childNode.Level)
-                {
-                    continue;
-                }
-
                 childNode.CheckState = isChecked ? CheckState.Checked : CheckState.Empty;
 
                 if (childNode.IsFolder)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -282,6 +282,10 @@ namespace GitHub.Unity
                 {
                     checkedFileNodes.Add(node.Path, node);
                 }
+                else
+                {
+                    checkedFileNodes.Remove(node.Path);
+                }
             }
 
             ToggleParentFoldersChecked(idx, node, isChecked);
@@ -308,6 +312,10 @@ namespace GitHub.Unity
                     if (isChecked)
                     {
                         checkedFileNodes.Add(node.Path, node);
+                    }
+                    else
+                    {
+                        checkedFileNodes.Remove(node.Path);
                     }
                 }
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -296,6 +296,7 @@ namespace GitHub.Unity
             for (var i = idx + 1; i < nodes.Count && node.Level < nodes[i].Level; i++)
             {
                 var childNode = nodes[i];
+                var wasChecked = childNode.CheckState == CheckState.Checked;
                 childNode.CheckState = isChecked ? CheckState.Checked : CheckState.Empty;
 
                 if (childNode.IsFolder)
@@ -304,11 +305,11 @@ namespace GitHub.Unity
                 }
                 else
                 {
-                    if (isChecked)
+                    if (isChecked && !wasChecked)
                     {
                         checkedFileNodes.Add(childNode.Path, childNode);
                     }
-                    else
+                    else if(!isChecked && wasChecked)
                     {
                         checkedFileNodes.Remove(childNode.Path);
                     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -311,11 +311,11 @@ namespace GitHub.Unity
                 {
                     if (isChecked)
                     {
-                        checkedFileNodes.Add(node.Path, node);
+                        checkedFileNodes.Add(childNode.Path, childNode);
                     }
                     else
                     {
-                        checkedFileNodes.Remove(node.Path);
+                        checkedFileNodes.Remove(childNode.Path);
                     }
                 }
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -391,13 +391,13 @@ namespace GitHub.Unity
 
         private bool HandleInput(Rect rect, TreeNode currentNode, int index, Action<TreeNode> singleClick = null, Action<TreeNode> doubleClick = null, Action<TreeNode> rightClick = null)
         {
-            bool selectionChanged = false;
+            var requiresRepaint = false;
             var clickRect = new Rect(0f, rect.y, rect.width, rect.height);
             if (Event.current.type == EventType.MouseDown && clickRect.Contains(Event.current.mousePosition))
             {
                 Event.current.Use();
                 SelectedNode = currentNode;
-                selectionChanged = true;
+                requiresRepaint = true;
                 var clickCount = Event.current.clickCount;
                 var mouseButton = Event.current.button;
 
@@ -423,24 +423,25 @@ namespace GitHub.Unity
                 int directionX = Event.current.keyCode == KeyCode.LeftArrow ? -1 : Event.current.keyCode == KeyCode.RightArrow ? 1 : 0;
                 if (directionY != 0 || directionX != 0)
                 {
+                    Event.current.Use();
+
                     if (directionY > 0)
                     {
-                        selectionChanged = SelectNext(index, false) != index;
+                        requiresRepaint = SelectNext(index, false) != index;
                     }
                     else if (directionY < 0)
                     {
-                        selectionChanged = SelectPrevious(index, false) != index;
+                        requiresRepaint = SelectPrevious(index, false) != index;
                     }
                     else if (directionX > 0)
                     {
                         if (currentNode.IsFolder && currentNode.IsCollapsed)
                         {
                             ToggleNodeVisibility(index, currentNode);
-                            Event.current.Use();
                         }
                         else
                         {
-                            selectionChanged = SelectNext(index, true) != index;
+                            requiresRepaint = SelectNext(index, true) != index;
                         }
                     }
                     else if (directionX < 0)
@@ -448,16 +449,24 @@ namespace GitHub.Unity
                         if (currentNode.IsFolder && !currentNode.IsCollapsed)
                         {
                             ToggleNodeVisibility(index, currentNode);
-                            Event.current.Use();
                         }
                         else
                         {
-                            selectionChanged = SelectPrevious(index, true) != index;
+                            requiresRepaint = SelectPrevious(index, true) != index;
                         }
                     }
                 }
+
+                if (IsCheckable && Event.current.keyCode == KeyCode.Space)
+                {
+                    Event.current.Use();
+
+                    ToggleNodeChecked(index, currentNode);
+                    requiresRepaint = true;
+                }
             }
-            return selectionChanged;
+
+            return requiresRepaint;
         }
 
         private int SelectNext(int index, bool foldersOnly)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -29,7 +29,6 @@ namespace GitHub.Unity
 
         [SerializeField] private List<TreeNode> nodes = new List<TreeNode>();
         [SerializeField] private TreeNode selectedNode = null;
-        [SerializeField] private TreeNode activeNode = null;
         [SerializeField] private TreeNodeDictionary folders = new TreeNodeDictionary();
 
         [NonSerialized] private Stack<bool> indents = new Stack<bool>();
@@ -98,11 +97,6 @@ namespace GitHub.Unity
 
             SetNodeIcon(node);
             nodes.Add(node);
-
-            if (isActive)
-            {
-                activeNode = node;
-            }
 
             if (isSelected)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -295,8 +295,13 @@ namespace GitHub.Unity
 
                     Debug.LogFormat("Ripple CheckState index:{0} level:{1}", idx, node.Level);
 
-                    for (var i = idx - 1; i > 0 && nodes[i].Level == node.Level; i--)
+                    for (var i = idx - 1; i > 0 && node.Level <= nodes[i].Level; i--)
                     {
+                        if (node.Level < nodes[i].Level)
+                        {
+                            continue;
+                        }
+
                         firstSiblingIndex = i;
                         var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
                         Debug.LogFormat("Previous Sibling - idx:{0} name:{1} checked:{2}", i, nodes[i].Path, siblingIsChecked);
@@ -310,8 +315,13 @@ namespace GitHub.Unity
 
                     //if (siblingsInSameState)
                     {
-                        for (var i = idx + 1; i < nodes.Count && nodes[i].Level == node.Level; i++)
+                        for (var i = idx + 1; i < nodes.Count && node.Level <= nodes[i].Level; i++)
                         {
+                            if (node.Level < nodes[i].Level)
+                            {
+                                continue;
+                            }
+
                             var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
                             Debug.LogFormat("Next Siblings    - idx:{0} name:{1} checked:{2}", i, nodes[i].Path, siblingIsChecked);
                         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -259,24 +259,83 @@ namespace GitHub.Unity
 
         private void ToggleNodeCheck(int idx, TreeNode node)
         {
+            var isChecked = false;
+
+            switch (node.CheckState)
+            {
+                case CheckState.Mixed:
+                case CheckState.Empty:
+                    node.CheckState = CheckState.Checked;
+                    isChecked = true;
+                    break;
+
+                case CheckState.Checked:
+                    node.CheckState = CheckState.Empty;
+                    break;
+            }
+
             if (node.IsFolder)
             {
-                
-            }
-            else
-            {
-                switch (node.CheckState)
-                {
-                    case CheckState.Empty:
-                        node.CheckState = CheckState.Checked;
-                        break;
 
-                    case CheckState.Checked:
-                        node.CheckState = CheckState.Empty;
-                        break;
+            }
+
+            ToggleParentFolders(idx, node, isChecked);
+        }
+
+        private void ToggleParentFolders(int idx, TreeNode node, bool isChecked)
+        {
+            while (true)
+            {
+                if (node.Level > 0)
+                {
+                    Debug.Log("ToggleParentFolders");
+
+                    var siblingsInSameState = true;
+                    var firstSiblingIndex = idx;
+
+                    Debug.LogFormat("Ripple CheckState index:{0} level:{1}", idx, node.Level);
+
+                    for (var i = idx - 1; i > 0 && nodes[i].Level == node.Level; i--)
+                    {
+                        firstSiblingIndex = i;
+                        var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
+                        Debug.LogFormat("Previous Sibling - idx:{0} name:{1} checked:{2}", i, nodes[i].Path, siblingIsChecked);
+
+                        if (isChecked != siblingIsChecked)
+                        {
+                            siblingsInSameState = false;
+                            //break;
+                        }
+                    }
+
+                    //if (siblingsInSameState)
+                    {
+                        for (var i = idx + 1; i < nodes.Count && nodes[i].Level == node.Level; i++)
+                        {
+                            var siblingIsChecked = nodes[i].CheckState == CheckState.Checked;
+                            Debug.LogFormat("Next Siblings    - idx:{0} name:{1} checked:{2}", i, nodes[i].Path, siblingIsChecked);
+                        }
+                    }
+
+                    Debug.LogFormat("Siblings in same state = {0}", siblingsInSameState);
+
+                    var parentIndex = firstSiblingIndex - 1;
+                    var parentNode = nodes[parentIndex];
+                    if (siblingsInSameState)
+                    {
+                        parentNode.CheckState = isChecked ? CheckState.Checked : CheckState.Empty;
+                    }
+                    else
+                    {
+                        parentNode.CheckState = CheckState.Mixed;
+                    }
+
+                    idx = parentIndex;
+                    node = parentNode;
+                    continue;
                 }
 
-                Debug.LogFormat("Ripple CheckState index:{0} level:{1}", idx, node.Level);
+                break;
             }
         }
 


### PR DESCRIPTION
**Note**: This branch targets `enhancements/changes-tree-view-rollup` #471 

Functionality to toggle checked state in `Tree`.
To properly handle checks and unchecks we have two major tasks:
- Ripple checks on folders down to all children recursively
- Ripple checks on items up through their folders recursively

What makes this tricky is that `nodes` is a **flat list**. It is not an object with a Children property that can be traversed.

Also added functionality to perform a check on spacebar.