### PR TITLE
Clearing up focus issues

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -874,35 +874,68 @@ namespace GitHub.Unity
                     treeNode = new GUIStyle(GUI.skin.label);
                     treeNode.name = "Custom TreeNode";
 
-                    var color = new Color(62f / 255f, 125f / 255f, 231f / 255f);
-                    var texture = Utility.GetTextureFromColor(color);
-                    treeNode.focused.background = texture;
-                    treeNode.onFocused.background = texture;
+                    var greyTexture = Utility.GetTextureFromColor(Color.gray);
+
+                    treeNode.focused.background = greyTexture;
                     treeNode.focused.textColor = Color.white;
-                    treeNode.onFocused.textColor = Color.white;
                 }
 
                 return treeNode;
             }
         }
 
-        private static GUIStyle treeNodeActive;
-        public static GUIStyle TreeNodeActive
+        private static GUIStyle activeTreeNode;
+        public static GUIStyle ActiveTreeNode
         {
             get
             {
-                if (treeNodeActive == null)
+                if (activeTreeNode == null)
                 {
-                    treeNodeActive = new GUIStyle(TreeNode);
-                    treeNodeActive.name = "Custom TreeNode Active";
-                    treeNodeActive.fontStyle = FontStyle.Bold;
-                    treeNodeActive.focused.textColor = Color.white;
-                    treeNodeActive.active.textColor = Color.white;
+                    activeTreeNode = new GUIStyle(TreeNode);
+                    activeTreeNode.name = "Custom Active TreeNode";
+
+                    activeTreeNode.fontStyle = FontStyle.Bold;
                 }
 
-                return treeNodeActive;
+                return activeTreeNode;
             }
         }
 
+        private static GUIStyle focusedTreeNode;
+        public static GUIStyle FocusedTreeNode
+        {
+            get
+            {
+                if (focusedTreeNode == null)
+                {
+                    focusedTreeNode = new GUIStyle(TreeNode);
+                    focusedTreeNode.name = "Custom Focused TreeNode";
+
+                    var blueColor = new Color(62f / 255f, 125f / 255f, 231f / 255f);
+                    var blueTexture = Utility.GetTextureFromColor(blueColor);
+
+                    focusedTreeNode.focused.background = blueTexture;
+                }
+
+                return focusedTreeNode;
+            }
+        }
+
+        private static GUIStyle focusedActiveTreeNode;
+        public static GUIStyle FocusedActiveTreeNode
+        {
+            get
+            {
+                if (focusedActiveTreeNode == null)
+                {
+                    focusedActiveTreeNode = new GUIStyle(FocusedTreeNode);
+                    focusedActiveTreeNode.name = "Custom Focused Active TreeNode";
+
+                    focusedActiveTreeNode.fontStyle = FontStyle.Bold;
+                }
+
+                return focusedActiveTreeNode;
+            }
+        }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -62,7 +62,7 @@ namespace GitHub.Unity
         public override void OnEnable()
         {
             base.OnEnable();
-            UpdateTreeIcons();
+            TreeOnEnable();
             AttachHandlers(Repository);
             Repository.CheckLocalAndRemoteBranchListChangedEvent(lastLocalAndRemoteBranchListChangedEvent);
         }
@@ -164,7 +164,7 @@ namespace GitHub.Unity
                 treeRemotes.Title = RemoteTitle;
                 treeRemotes.IsRemote = true;
 
-                UpdateTreeIcons();
+                TreeOnEnable();
             }
 
             localBranches.Sort(CompareBranches);
@@ -175,15 +175,17 @@ namespace GitHub.Unity
             Redraw();
         }
 
-        private void UpdateTreeIcons()
+        private void TreeOnEnable()
         {
             if (treeLocals != null)
             {
+                treeLocals.OnEnable();
                 treeLocals.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.GlobeIcon);
             }
 
             if (treeRemotes != null)
             {
+                treeRemotes.OnEnable();
                 treeRemotes.UpdateIcons(Styles.ActiveBranchIcon, Styles.BranchIcon, Styles.FolderIcon, Styles.GlobeIcon);
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -79,6 +79,12 @@ namespace GitHub.Unity
             MaybeUpdateData();
         }
 
+        public override void OnSelectionChange()
+        {
+            base.OnSelectionChange();
+            Redraw();
+        }
+
         private void RepositoryOnLocalAndRemoteBranchListChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             if (!lastLocalAndRemoteBranchListChangedEvent.Equals(cacheUpdateEvent))

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -301,11 +301,15 @@ namespace GitHub.Unity
             {
                 treeLocals.FolderStyle = Styles.Foldout;
                 treeLocals.TreeNodeStyle = Styles.TreeNode;
-                treeLocals.ActiveTreeNodeStyle = Styles.TreeNodeActive;
+                treeLocals.ActiveTreeNodeStyle = Styles.ActiveTreeNode;
+                treeLocals.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
+                treeLocals.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
                 treeRemotes.FolderStyle = Styles.Foldout;
                 treeRemotes.TreeNodeStyle = Styles.TreeNode;
-                treeRemotes.ActiveTreeNodeStyle = Styles.TreeNodeActive;
+                treeRemotes.ActiveTreeNodeStyle = Styles.ActiveTreeNode;
+                treeRemotes.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
+                treeRemotes.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
                 var treeHadFocus = treeLocals.SelectedNode != null;
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -78,6 +78,10 @@ namespace GitHub.Unity
             set
             {
                 selectedNode = value;
+                if (value != null && selectionObject)
+                {
+                    Selection.activeObject = selectionObject;
+                }
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -94,19 +94,17 @@ namespace GitHub.Unity
 
         protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitStatusEntryTreeData? treeData)
         {
-            var node = new ChangesTreeNode
-            {
-                Path = path,
-                Label = label,
-                Level = level,
-                IsFolder = isFolder,
-                IsActive = isActive,
-                IsHidden = isHidden,
-                IsCollapsed = isCollapsed,
-                TreeIsCheckable = IsCheckable,
-                GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None,
-                ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null
-            };
+            var node = ScriptableObject.CreateInstance<ChangesTreeNode>();
+            node.Path = path;
+            node.Label = label;
+            node.Level = level;
+            node.IsFolder = isFolder;
+            node.IsActive = isActive;
+            node.IsHidden = isHidden;
+            node.IsCollapsed = isCollapsed;
+            node.TreeIsCheckable = IsCheckable;
+            node.GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None;
+            node.ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null;
 
             if (isFolder)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -94,17 +94,19 @@ namespace GitHub.Unity
 
         protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitStatusEntryTreeData? treeData)
         {
-            var node = ScriptableObject.CreateInstance<ChangesTreeNode>();
-            node.Path = path;
-            node.Label = label;
-            node.Level = level;
-            node.IsFolder = isFolder;
-            node.IsActive = isActive;
-            node.IsHidden = isHidden;
-            node.IsCollapsed = isCollapsed;
-            node.TreeIsCheckable = IsCheckable;
-            node.GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None;
-            node.ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null;
+            var node = new ChangesTreeNode
+            {
+                Path = path,
+                Label = label,
+                Level = level,
+                IsFolder = isFolder,
+                IsActive = isActive,
+                IsHidden = isHidden,
+                IsCollapsed = isCollapsed,
+                TreeIsCheckable = IsCheckable,
+                GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None,
+                ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null
+            };
 
             if (isFolder)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -35,7 +35,7 @@ namespace GitHub.Unity
         public override void OnEnable()
         {
             base.OnEnable();
-            UpdateTreeIcons();
+            TreeOnEnable();
             AttachHandlers(Repository);
             Repository.CheckCurrentBranchChangedEvent(lastCurrentBranchChangedEvent);
             Repository.CheckStatusEntriesChangedEvent(lastStatusEntriesChangedEvent);
@@ -200,17 +200,18 @@ namespace GitHub.Unity
                 treeChanges.IsCheckable = true;
                 treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
 
-                UpdateTreeIcons();
+                TreeOnEnable();
             }
 
             treeChanges.Load(gitStatusEntries.Select(entry => new GitStatusEntryTreeData(entry)));
             Redraw();
         }
 
-        private void UpdateTreeIcons()
+        private void TreeOnEnable()
         {
             if (treeChanges != null)
             {
+                treeChanges.OnEnable();
                 treeChanges.UpdateIcons(Styles.FolderIcon);
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -101,7 +101,9 @@ namespace GitHub.Unity
             {
                 treeChanges.FolderStyle = Styles.Foldout;
                 treeChanges.TreeNodeStyle = Styles.TreeNode;
-                treeChanges.ActiveTreeNodeStyle = Styles.TreeNodeActive;
+                treeChanges.ActiveTreeNodeStyle = Styles.ActiveTreeNode;
+                treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
+                treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
                 rect = treeChanges.Render(initialRect, rect, scroll,
                     node => { },

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -94,6 +94,12 @@ namespace GitHub.Unity
             OnCommitDetailsAreaGUI();
         }
 
+        public override void OnSelectionChange()
+        {
+            base.OnSelectionChange();
+            Redraw();
+        }
+
         private void OnTreeGUI(Rect rect)
         {
             var initialRect = rect;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -37,8 +37,13 @@ namespace GitHub.Unity
 
         public Rect Render(Rect containingRect, Rect rect, Vector2 scroll, Action<TNode> singleClick = null, Action<TNode> doubleClick = null, Action<TNode> rightClick = null)
         {
+            if (Selection.activeObject != selectionObject)
+            {
+                SelectedNode = null;
+            }
+
             controlId = GUIUtility.GetControlID(FocusType.Keyboard);
-            var treeHasFocus = GUIUtility.keyboardControl == controlId && Selection.activeObject == selectionObject;
+            var treeHasFocus = GUIUtility.keyboardControl == controlId;
 
             if (!Nodes.Any())
                 return new Rect(0f, rect.y, 0f, 0f);
@@ -78,7 +83,7 @@ namespace GitHub.Unity
                 var titleDisplay = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (titleDisplay)
                 {
-                    var isSelected = SelectedNode == titleNode && treeHasFocus;
+                    var isSelected = SelectedNode == titleNode;
                     renderResult = titleNode.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 
@@ -112,7 +117,7 @@ namespace GitHub.Unity
                 var display = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (display)
                 {
-                    var isSelected = SelectedNode == node && treeHasFocus;
+                    var isSelected = SelectedNode == node;
                     renderResult = node.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -25,13 +25,12 @@ namespace GitHub.Unity
         [NonSerialized] public GUIStyle FocusedTreeNodeStyle;
         [NonSerialized] public GUIStyle FocusedActiveTreeNodeStyle;
 
-
         [NonSerialized] private Stack<bool> indents = new Stack<bool>();
         [NonSerialized] private Action<TNode> rightClickNextRender;
         [NonSerialized] private TNode rightClickNextRenderNode;
 
         [NonSerialized] private int controlId;
-        [NonSerialized] private TreeSelection selectionObject;
+        [NonSerialized] protected TreeSelection selectionObject;
 
         public bool IsInitialized { get { return Nodes != null && Nodes.Count > 0 && !String.IsNullOrEmpty(Nodes[0].Path); } }
         public bool RequiresRepaint { get; private set; }
@@ -79,7 +78,8 @@ namespace GitHub.Unity
                 var titleDisplay = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (titleDisplay)
                 {
-                    renderResult = titleNode.Render(rect, Styles.TreeIndentation, SelectedNode == titleNode, FolderStyle, TreeNodeStyle, ActiveTreeNodeStyle);
+                    var isSelected = SelectedNode == titleNode && treeHasFocus;
+                    renderResult = titleNode.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 
                 if (renderResult == TreeNodeRenderResult.VisibilityChange)
@@ -112,7 +112,8 @@ namespace GitHub.Unity
                 var display = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (display)
                 {
-                    renderResult = node.Render(rect, Styles.TreeIndentation, SelectedNode == node, FolderStyle, TreeNodeStyle, ActiveTreeNodeStyle);
+                    var isSelected = SelectedNode == node && treeHasFocus;
+                    renderResult = node.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 
                 if (renderResult == TreeNodeRenderResult.VisibilityChange)
@@ -206,7 +207,7 @@ namespace GitHub.Unity
             }
 
             // Keyboard navigation if this child is the current selection
-            if (currentNode == SelectedNode && Event.current.type == EventType.KeyDown)
+            if (GUIUtility.keyboardControl == controlId && currentNode == SelectedNode && Event.current.type == EventType.KeyDown)
             {
                 int directionY = Event.current.keyCode == KeyCode.UpArrow ? -1 : Event.current.keyCode == KeyCode.DownArrow ? 1 : 0;
                 int directionX = Event.current.keyCode == KeyCode.LeftArrow ? -1 : Event.current.keyCode == KeyCode.RightArrow ? 1 : 0;
@@ -563,6 +564,10 @@ namespace GitHub.Unity
             set
             {
                 selectedNode = value;
+                if (value != null && selectionObject)
+                {
+                    Selection.activeObject = selectionObject;
+                }
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -41,7 +41,7 @@ namespace GitHub.Unity
         [NonSerialized] private TNode rightClickNextRenderNode;
         [NonSerialized] private int controlId;
 
-        [SerializeField] private TreeSelection selectionObject = ScriptableObject.CreateInstance<TreeSelection>();
+        [NonSerialized] private TreeSelection selectionObject;
 
         public bool IsInitialized { get { return Nodes != null && Nodes.Count > 0 && !String.IsNullOrEmpty(Nodes[0].Path); } }
         public bool RequiresRepaint { get; private set; }
@@ -52,12 +52,16 @@ namespace GitHub.Unity
             {
                 if (selectedNode != null && String.IsNullOrEmpty(selectedNode.Path))
                     selectedNode = null;
+
                 return selectedNode;
             }
             set
             {
                 selectedNode = value;
-                Selection.activeObject = selectionObject;
+                if (value != null && selectionObject)
+                {
+                    Selection.activeObject = selectionObject;
+                }
             }
         }
 
@@ -133,7 +137,7 @@ namespace GitHub.Unity
                 var titleDisplay = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (titleDisplay)
                 {
-                    var isSelected = selectedNode == titleNode;
+                    var isSelected = selectedNode == titleNode && treeHasFocus;
                     renderResult = titleNode.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 
@@ -167,7 +171,8 @@ namespace GitHub.Unity
                 var display = !(rect.y > endDisplay || rect.yMax < startDisplay);
                 if (display)
                 {
-                    renderResult = node.Render(rect, Styles.TreeIndentation, selectedNode == node, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
+                    var isSelected = selectedNode == node && treeHasFocus;
+                    renderResult = node.Render(rect, Styles.TreeIndentation, isSelected, FolderStyle, treeNodeStyle, activeTreeNodeStyle);
                 }
 
                 if (renderResult == TreeNodeRenderResult.VisibilityChange)
@@ -372,6 +377,14 @@ namespace GitHub.Unity
             foreach (var treeNode in Nodes)
             {
                 SetNodeIcon(treeNode);
+            }
+        }
+
+        public void OnEnable()
+        {
+            if (!selectionObject)
+            {
+                selectionObject = ScriptableObject.CreateInstance<TreeSelection>();
             }
         }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -53,6 +53,7 @@ namespace GitHub.Unity
             set
             {
                 selectedNode = value;
+                Selection.activeObject = value;
             }
         }
 
@@ -88,11 +89,14 @@ namespace GitHub.Unity
         public Rect Render(Rect containingRect, Rect rect, Vector2 scroll, Action<TNode> singleClick = null, Action<TNode> doubleClick = null, Action<TNode> rightClick = null)
         {
             controlId = GUIUtility.GetControlID(FocusType.Keyboard);
+            var treeHasFocus = GUIUtility.keyboardControl == controlId && Selection.activeObject == selectedNode;
+
+            if (!Nodes.Any())
+                return new Rect(0f, rect.y, 0f, 0f);
 
             var treeNodeStyle = TreeNodeStyle;
             var activeTreeNodeStyle = ActiveTreeNodeStyle;
 
-            var treeHasFocus = GUIUtility.keyboardControl == controlId;
             if (treeHasFocus)
             {
                 treeNodeStyle = FocusedTreeNodeStyle;
@@ -359,7 +363,6 @@ namespace GitHub.Unity
             indents.Pop();
         }
 
-
         protected void LoadNodeIcons()
         {
             foreach (var treeNode in Nodes)
@@ -370,7 +373,7 @@ namespace GitHub.Unity
     }
 
     [Serializable]
-    public class TreeNode : ITreeNode
+    public class TreeNode : ScriptableObject, ITreeNode
     {
         public string path;
         public string label;
@@ -603,16 +606,15 @@ namespace GitHub.Unity
 
         protected override TreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitBranchTreeData? treeData)
         {
-            var node = new TreeNode {
-                Path = path,
-                Label = label,
-                Level = level,
-                IsFolder = isFolder,
-                IsActive = isActive,
-                IsHidden = isHidden,
-                IsCollapsed = isCollapsed,
-                TreeIsCheckable = IsCheckable
-            };
+            var node = ScriptableObject.CreateInstance<TreeNode>();
+            node.Path = path;
+            node.Label = label;
+            node.Level = level;
+            node.IsFolder = isFolder;
+            node.IsActive = isActive;
+            node.IsHidden = isHidden;
+            node.IsCollapsed = isCollapsed;
+            node.TreeIsCheckable = IsCheckable;
 
             if (isFolder)
             {


### PR DESCRIPTION
**Note**: This branch targets `enhancements/changes-tree-view-rollup` #471 

- Separating the style objects that convey "Active" nodes vs "Selected" nodes when the Tree has focus or not
- Using a `ScriptableObject` in `Selection` to track the selection of a tree node
- Using a keyboard `controlId` to distinguish focus on the tree vs another control in the `ChangesView`