### PR TITLE
Refactoring history display into HistoryControl

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -64,6 +64,7 @@ namespace GitHub.Unity
                                 headerDescriptionStyle,
                                 historyToolbarButtonStyle,
                                 historyLockStyle,
+                                historyEntrySummaryStyle,
                                 historyEntryDetailsStyle,
                                 historyEntryDetailsRightStyle,
                                 historyFileTreeBoxStyle,
@@ -396,6 +397,20 @@ namespace GitHub.Unity
                 return historyLockStyle;
             }
         }
+        public static GUIStyle HistoryEntrySummaryStyle
+        {
+            get
+            {
+                if (historyEntrySummaryStyle == null)
+                {
+                    historyEntrySummaryStyle = new GUIStyle(Label);
+                    historyEntrySummaryStyle.name = "HistoryEntrySummaryStyle";
+
+                    historyEntrySummaryStyle.contentOffset = new Vector2(BaseSpacing * 2, 0);
+                }
+                return historyEntrySummaryStyle;
+            }
+        }
 
         public static GUIStyle HistoryEntryDetailsStyle
         {
@@ -412,6 +427,8 @@ namespace GitHub.Unity
                     historyEntryDetailsStyle.onNormal.textColor = Label.onNormal.textColor;
                     historyEntryDetailsStyle.onFocused.background = Label.onFocused.background;
                     historyEntryDetailsStyle.onFocused.textColor = Label.onFocused.textColor;
+
+                    historyEntryDetailsStyle.contentOffset = new Vector2(BaseSpacing * 2, 0);
                 }
                 return historyEntryDetailsStyle;
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -25,12 +25,16 @@ namespace GitHub.Unity
         [SerializeField] private string commitBody = "";
         [SerializeField] private string commitMessage = "";
         [SerializeField] private string currentBranch = "[unknown]";
-        [SerializeField] private Vector2 scroll;
+
+        [SerializeField] private Vector2 treeScroll;
+        [SerializeField] private ChangesTree treeChanges;
+
+        [SerializeField] private List<GitStatusEntry> gitStatusEntries;
+
+        [SerializeField] private string changedFilesText = NoChangedFilesLabel;
+
         [SerializeField] private CacheUpdateEvent lastCurrentBranchChangedEvent;
         [SerializeField] private CacheUpdateEvent lastStatusEntriesChangedEvent;
-        [SerializeField] private ChangesTree treeChanges;
-        [SerializeField] private List<GitStatusEntry> gitStatusEntries;
-        [SerializeField] private string changedFilesText = NoChangedFilesLabel;
 
         public override void OnEnable()
         {
@@ -81,7 +85,7 @@ namespace GitHub.Unity
             GUILayout.BeginHorizontal();
             GUILayout.BeginVertical(Styles.CommitFileAreaStyle);
             {
-                scroll = GUILayout.BeginScrollView(scroll);
+                treeScroll = GUILayout.BeginScrollView(treeScroll);
                 {
                     OnTreeGUI(new Rect(0f, 0f, Position.width, Position.height - rect.height + Styles.CommitAreaPadding));
                 }
@@ -111,7 +115,7 @@ namespace GitHub.Unity
                 treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
                 treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
-                rect = treeChanges.Render(initialRect, rect, scroll,
+                rect = treeChanges.Render(initialRect, rect, treeScroll,
                     node => { },
                     node => {
                     },

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -304,12 +304,6 @@ namespace GitHub.Unity
         }
     }
 
-    enum LogEntryState
-    {
-        Normal,
-        Local
-    }
-
     [Serializable]
     class HistoryView : Subview
     {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -35,8 +35,6 @@ namespace GitHub.Unity
             Action<GitLogEntry> doubleClick = null, Action<GitLogEntry> rightClick = null)
         {
             var requiresRepaint = false;
-            var rect = Rect.zero;
-
             scroll = GUILayout.BeginScrollView(scroll);
             {
                 controlId = GUIUtility.GetControlID(FocusType.Keyboard);
@@ -54,7 +52,7 @@ namespace GitHub.Unity
                 var startDisplay = scroll.y;
                 var endDisplay = scroll.y + containingRect.height;
 
-                rect = new Rect(containingRect.x, containingRect.y, containingRect.width, 0);
+                var rect = new Rect(containingRect.x, containingRect.y, containingRect.width, 0);
 
                 for (var index = 0; index < entries.Count; index++)
                 {
@@ -68,15 +66,15 @@ namespace GitHub.Unity
                         RenderEntry(entryRect, entry, index);
                     }
 
-                    var entryRequiresRepaint = HandleInput(entryRect, entry, index, singleClick, doubleClick, rightClick);
+                    var entryRequiresRepaint =
+                        HandleInput(entryRect, entry, index, singleClick, doubleClick, rightClick);
                     requiresRepaint = requiresRepaint || entryRequiresRepaint;
 
                     rect.y += Styles.HistoryEntryHeight;
                 }
+
+                GUILayout.Space(rect.y - containingRect.y);
             }
-
-            GUILayout.Space(rect.y - containingRect.y);
-
             GUILayout.EndScrollView();
 
             return requiresRepaint;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -225,25 +225,44 @@ namespace GitHub.Unity
         public void Load(int loadAhead, List<GitLogEntry> loadEntries)
         {
             var selectedCommitId = SelectedGitLogEntry.CommitID;
+            var scrollValue = scroll.y;
+
+            var previousCount = entries.Count;
+
+            var scrollIndex = (int)(scrollValue / Styles.HistoryEntryHeight);
 
             statusAhead = loadAhead;
             entries = loadEntries;
 
-            var changed = false;
+            var selectionPresent = false;
             for (var index = 0; index < entries.Count; index++)
             {
                 var gitLogEntry = entries[index];
                 if (gitLogEntry.CommitID.Equals(selectedCommitId))
                 {
                     selectedIndex = index;
-                    changed = true;
+                    selectionPresent = true;
                     break;
                 }
             }
 
-            if (!changed)
+            if (!selectionPresent)
             {
                 selectedIndex = -1;
+            }
+
+            if (scrollIndex > entries.Count)
+            {
+                ScrollTo(0);
+            }
+            else
+            {
+                var scrollOffset = scrollValue % Styles.HistoryEntryHeight;
+
+                var scrollIndexFromBottom = previousCount - scrollIndex;
+                var newScrollIndex = entries.Count - scrollIndexFromBottom;
+
+                ScrollTo(newScrollIndex, scrollOffset);
             }
         }
 
@@ -279,9 +298,9 @@ namespace GitHub.Unity
             return index;
         }
 
-        public void ScrollTo(int index)
+        public void ScrollTo(int index, float offset = 0f)
         {
-            scroll.Set(scroll.x, Styles.HistoryEntryHeight * index);
+            scroll.Set(scroll.x, Styles.HistoryEntryHeight * index + offset);
         }
     }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -6,6 +6,252 @@ using UnityEngine;
 
 namespace GitHub.Unity
 {
+    struct HistoryControlRenderResult
+    {
+        public Rect Rect;
+        public bool RequiresRepaint;
+    }
+
+    [Serializable]
+    class HistoryControl
+    {
+        private const string HistoryEntryDetailFormat = "{0}     {1}";
+
+        [SerializeField] private List<GitLogEntry> entries = new List<GitLogEntry>();
+        [SerializeField] private int statusAhead;
+        [SerializeField] private int selectedIndex;
+
+        [NonSerialized] private Action<GitLogEntry> rightClickNextRender;
+        [NonSerialized] private GitLogEntry rightClickNextRenderEntry;
+        [NonSerialized] private int controlId;
+
+        public HistoryControlRenderResult Render(Rect containingRect, Rect rect, Vector2 scroll, Action<GitLogEntry> singleClick = null,
+            Action<GitLogEntry> doubleClick = null, Action<GitLogEntry> rightClick = null)
+        {
+            var requiresRepaint = false;
+
+            controlId = GUIUtility.GetControlID(FocusType.Keyboard);
+
+            var treeHasFocus = GUIUtility.keyboardControl == controlId;
+            if (Event.current.type != EventType.Repaint)
+            {
+                if (rightClickNextRender != null)
+                {
+                    rightClickNextRender.Invoke(rightClickNextRenderEntry);
+                    rightClickNextRender = null;
+                    //TODO: Default GitLogEntry
+                    rightClickNextRenderEntry = new GitLogEntry();
+                }
+            }
+
+            rect = new Rect(rect.x, rect.y, rect.width, 0);
+
+            for (var index = 0; index < entries.Count; index++)
+            {
+                var entry = entries[index];
+                var isLocalCommit = index < statusAhead;
+
+                var entryRect = new Rect(rect.x, rect.y, rect.width, Styles.HistoryEntryHeight);
+
+                RenderEntry(entryRect, entry, isLocalCommit, index == selectedIndex);
+
+                var entryRequiresRepaint = HandleInput(entryRect, entry, index, singleClick, doubleClick, rightClick);
+                requiresRepaint = requiresRepaint || entryRequiresRepaint;
+
+                rect.y += Styles.HistoryEntryHeight;
+            }
+
+            return new HistoryControlRenderResult {
+                Rect = rect,
+                RequiresRepaint = requiresRepaint
+            };
+        }
+
+        private bool HandleInput(Rect rect, GitLogEntry entry, int index, Action<GitLogEntry> singleClick = null,
+            Action<GitLogEntry> doubleClick = null, Action<GitLogEntry> rightClick = null)
+        {
+            var requiresRepaint = false;
+            var clickRect = new Rect(0f, rect.y, rect.width, rect.height);
+            if (Event.current.type == EventType.MouseDown && clickRect.Contains(Event.current.mousePosition))
+            {
+                Event.current.Use();
+                GUIUtility.keyboardControl = controlId;
+
+                selectedIndex = index;
+                requiresRepaint = true;
+                var clickCount = Event.current.clickCount;
+                var mouseButton = Event.current.button;
+
+                if (mouseButton == 0 && clickCount == 1 && singleClick != null)
+                {
+                    singleClick(entry);
+                }
+                if (mouseButton == 0 && clickCount > 1 && doubleClick != null)
+                {
+                    doubleClick(entry);
+                }
+                if (mouseButton == 1 && clickCount == 1 && rightClick != null)
+                {
+                    rightClickNextRender = rightClick;
+                    rightClickNextRenderEntry = entry;
+                }
+            }
+
+            // Keyboard navigation if this child is the current selection
+            if (GUIUtility.keyboardControl == controlId && index == selectedIndex && Event.current.type == EventType.KeyDown)
+            {
+                var directionY = Event.current.keyCode == KeyCode.UpArrow ? -1 : Event.current.keyCode == KeyCode.DownArrow ? 1 : 0;
+                if (directionY != 0)
+                {
+                    Event.current.Use();
+
+                    if (directionY > 0)
+                    {
+                        requiresRepaint = SelectNext(index) != index;
+                    }
+                    else
+                    {
+                        requiresRepaint = SelectPrevious(index) != index;
+                    }
+                }
+            }
+
+            return requiresRepaint;
+        }
+
+        private void RenderEntry(Rect entryRect, GitLogEntry entry, bool isLocalCommit, bool isSelected)
+        {
+            if (Event.current.type == EventType.Repaint)
+            {
+                var summaryRect = new Rect(entryRect.x, entryRect.y + Styles.BaseSpacing / 2, entryRect.width, Styles.HistorySummaryHeight + Styles.BaseSpacing);
+                var timestampRect = new Rect(entryRect.x, entryRect.yMax - Styles.HistoryDetailsHeight - Styles.BaseSpacing / 2, entryRect.width, Styles.HistoryDetailsHeight);
+
+                var hasKeyboardFocus = false;
+
+                Styles.Label.Draw(entryRect, GUIContent.none, false, false, isSelected, hasKeyboardFocus);
+                Styles.HistoryEntrySummaryStyle.Draw(summaryRect, entry.Summary, false, false, isSelected, hasKeyboardFocus);
+
+                var historyEntryDetail = string.Format(HistoryEntryDetailFormat, entry.PrettyTimeString, entry.AuthorName);
+                Styles.HistoryEntryDetailsStyle.Draw(timestampRect, historyEntryDetail, false, false, isSelected, hasKeyboardFocus);
+
+                if (!string.IsNullOrEmpty(entry.MergeA))
+                {
+                    const float MergeIndicatorWidth = 10.28f;
+                    const float MergeIndicatorHeight = 12f;
+                    var mergeIndicatorRect = new Rect(entryRect.x + 7, summaryRect.y, MergeIndicatorWidth, MergeIndicatorHeight);
+
+                    GUI.DrawTexture(mergeIndicatorRect, Styles.MergeIcon);
+
+                    DrawTimelineRectAroundIconRect(entryRect, mergeIndicatorRect);
+
+                    summaryRect.Set(mergeIndicatorRect.xMax, summaryRect.y, summaryRect.width - MergeIndicatorWidth,
+                        summaryRect.height);
+                }
+
+                if (isLocalCommit && string.IsNullOrEmpty(entry.MergeA))
+                {
+                    const float LocalIndicatorSize = 6f;
+                    var localIndicatorRect = new Rect(entryRect.x + (Styles.BaseSpacing - 2), summaryRect.y + 5, LocalIndicatorSize,
+                        LocalIndicatorSize);
+
+                    DrawTimelineRectAroundIconRect(entryRect, localIndicatorRect);
+
+                    GUI.DrawTexture(localIndicatorRect, Styles.LocalCommitIcon);
+
+                    summaryRect.Set(localIndicatorRect.xMax, summaryRect.y, summaryRect.width - LocalIndicatorSize,
+                        summaryRect.height);
+                }
+
+                if (!isLocalCommit && string.IsNullOrEmpty(entry.MergeA))
+                {
+                    const float NormalIndicatorWidth = 6f;
+                    const float NormalIndicatorHeight = 6f;
+
+                    Rect normalIndicatorRect = new Rect(entryRect.x + (Styles.BaseSpacing - 2), summaryRect.y + 5,
+                        NormalIndicatorWidth, NormalIndicatorHeight);
+
+                    DrawTimelineRectAroundIconRect(entryRect, normalIndicatorRect);
+
+                    GUI.DrawTexture(normalIndicatorRect, Styles.DotIcon);
+                }
+            }
+        }
+
+        private void DrawTimelineRectAroundIconRect(Rect parentRect, Rect iconRect)
+        {
+            Color timelineBarColor = new Color(0.51F, 0.51F, 0.51F, 0.2F);
+
+            // Draw them lines
+            //
+            // First I need to figure out how large to make the top one:
+            // I'll subtract the entryRect.y from the mergeIndicatorRect.y to
+            // get the difference in length. then subtract a little more for padding
+            float topTimelineRectHeight = iconRect.y - parentRect.y - 2;
+            // Now let's create the rect
+            Rect topTimelineRect = new Rect(
+                parentRect.x + Styles.BaseSpacing,
+                parentRect.y,
+                2,
+                topTimelineRectHeight);
+
+            // And draw it
+            EditorGUI.DrawRect(topTimelineRect, timelineBarColor);
+
+            // Let's do the same for the bottom
+            float bottomTimelineRectHeight = parentRect.yMax - iconRect.yMax - 2;
+            Rect bottomTimelineRect = new Rect(
+                parentRect.x + Styles.BaseSpacing,
+                parentRect.yMax - bottomTimelineRectHeight,
+                2,
+                bottomTimelineRectHeight);
+            EditorGUI.DrawRect(bottomTimelineRect, timelineBarColor);
+        }
+
+        public void Load(int loadAhead, List<GitLogEntry> loadEntries)
+        {
+            statusAhead = loadAhead;
+            entries = loadEntries;
+        }
+
+        private int SelectNext(int index)
+        {
+            index++;
+
+            if (index < entries.Count)
+            {
+                selectedIndex = index;
+            }
+            else
+            {
+                index = -1;
+            }
+
+            return index;
+        }
+
+        private int SelectPrevious(int index)
+        {
+            index--;
+
+            if (index >= 0)
+            {
+                selectedIndex = index;
+            }
+            else
+            {
+                selectedIndex = -1;
+            }
+
+            return index;
+        }
+    }
+
+    enum LogEntryState
+    {
+        Normal,
+        Local
+    }
+
     [Serializable]
     class HistoryView : Subview
     {
@@ -33,38 +279,22 @@ namespace GitHub.Unity
         [NonSerialized] private bool currentLogHasUpdate;
         [NonSerialized] private bool currentRemoteHasUpdate;
         [NonSerialized] private bool currentTrackingStatusHasUpdate;
-        [NonSerialized] private int historyStartIndex;
-        [NonSerialized] private int historyStopIndex;
-        [NonSerialized] private int listID;
-        [NonSerialized] private int newSelectionIndex;
-        [NonSerialized] private float scrollOffset;
-        [NonSerialized] private DateTimeOffset scrollTime = DateTimeOffset.Now;
-        [NonSerialized] private int selectionIndex;
-        [NonSerialized] private bool useScrollTime;
 
-        [SerializeField] private ChangesetTreeView changesetTree = new ChangesetTreeView();
-        [SerializeField] private string currentRemoteName;
-        [SerializeField] private Vector2 detailsScroll;
         [SerializeField] private bool hasItemsToCommit;
         [SerializeField] private bool hasRemote;
-        [SerializeField] private List<GitLogEntry> history = new List<GitLogEntry>();
+        [SerializeField] private string currentRemoteName;
+
+        [SerializeField] private Vector2 historyScroll;
+        [SerializeField] private HistoryControl historyControl;
+
+        [SerializeField] private List<GitLogEntry> logEntries = new List<GitLogEntry>();
+
+        [SerializeField] private int statusAhead;
+        [SerializeField] private int statusBehind;
+        
         [SerializeField] private CacheUpdateEvent lastCurrentRemoteChangedEvent;
         [SerializeField] private CacheUpdateEvent lastLogChangedEvent;
         [SerializeField] private CacheUpdateEvent lastTrackingStatusChangedEvent;
-        [SerializeField] private Vector2 scroll;
-        [SerializeField] private string selectionID;
-        [SerializeField] private int statusAhead;
-        [SerializeField] private int statusBehind;
-
-        public override void InitializeView(IView parent)
-        {
-            base.InitializeView(parent);
-
-            selectionIndex = newSelectionIndex = -1;
-
-            changesetTree.InitializeView(this);
-            changesetTree.Readonly = true;
-        }
 
         public override void OnEnable()
         {
@@ -160,136 +390,31 @@ namespace GitHub.Unity
             }
             GUILayout.EndHorizontal();
 
-            // When history scroll actually changes, store time value of topmost visible entry. This is the value we use to reposition scroll on log update - not the pixel value.
-            if (history.Any())
+            var rect = GUILayoutUtility.GetLastRect();
+            historyScroll = GUILayout.BeginScrollView(historyScroll);
             {
-                listID = GUIUtility.GetControlID(FocusType.Keyboard);
-
-                // Only update time scroll
-                var lastScroll = scroll;
-                scroll = GUILayout.BeginScrollView(scroll);
-                if (lastScroll != scroll && !currentLogHasUpdate)
-                {
-                    scrollTime = history[historyStartIndex].Time;
-                    scrollOffset = scroll.y - historyStartIndex * EntryHeight;
-                    useScrollTime = true;
-                }
-                // Handle only the selected range of history items - adding spacing for the rest
-                var start = Mathf.Max(0, historyStartIndex - HistoryExtraItemCount);
-                var stop = Mathf.Min(historyStopIndex + HistoryExtraItemCount, history.Count);
-                GUILayout.Space(start * EntryHeight);
-                for (var index = start; index < stop; ++index)
-                {
-                    if (HistoryEntry(history[index], GetEntryState(index), selectionIndex == index))
-                    {
-                        newSelectionIndex = index;
-                        GUIUtility.keyboardControl = listID;
-                    }
-                }
-
-                GUILayout.Space((history.Count - stop) * EntryHeight);
-
-                // Keyboard control
-                if (GUIUtility.keyboardControl == listID && Event.current.type == EventType.KeyDown)
-                {
-                    var change = 0;
-
-                    if (Event.current.keyCode == KeyCode.DownArrow)
-                    {
-                        change = 1;
-                    }
-                    else if (Event.current.keyCode == KeyCode.UpArrow)
-                    {
-                        change = -1;
-                    }
-
-                    if (change != 0)
-                    {
-                        newSelectionIndex = (selectionIndex + change) % history.Count;
-                        if (newSelectionIndex < historyStartIndex || newSelectionIndex > historyStopIndex)
-                        {
-                            ScrollTo(newSelectionIndex,
-                                (Position.height - Position.height * MaxChangelistHeightRatio - 30f - EntryHeight) * -.5f);
-                        }
-                        Event.current.Use();
-                    }
-                }
+                OnHistoryGUI(new Rect(0f, 0f, Position.width, Position.height - rect.height));
             }
-            else
-            {
-                GUILayout.BeginScrollView(scroll);
-            }
-
             GUILayout.EndScrollView();
+        }
 
-            // Selection info
-            if (selectionIndex >= 0 && history.Count > selectionIndex)
+        private void OnHistoryGUI(Rect rect)
+        {
+            var initialRect = rect;
+            if (historyControl != null)
             {
-                var selection = history[selectionIndex];
+                var renderResult = historyControl.Render(initialRect, rect, historyScroll,
+                    entry => { },
+                    entry => { },
+                    entry => { });
 
-                // Top bar for scrolling to selection or clearing it
-                GUILayout.BeginHorizontal(EditorStyles.toolbar);
-                {
-                    if (GUILayout.Button(CommitDetailsTitle, Styles.HistoryToolbarButtonStyle))
-                    {
-                        ScrollTo(selectionIndex);
-                    }
-                    if (GUILayout.Button(ClearSelectionButton, Styles.HistoryToolbarButtonStyle, GUILayout.ExpandWidth(false)))
-                    {
-                        newSelectionIndex = -2;
-                    }
-                }
-                GUILayout.EndHorizontal();
+                rect = renderResult.Rect;
 
-                // Log entry details - including changeset tree (if any changes are found)
-                if (changesetTree.Entries.Any())
-                {
-                    detailsScroll = GUILayout.BeginScrollView(detailsScroll, GUILayout.Height(250));
-                    {
-                        HistoryDetailsEntry(selection);
-
-                        GUILayout.Space(EditorGUIUtility.standardVerticalSpacing);
-                        GUILayout.Label("Files changed", EditorStyles.boldLabel);
-                        GUILayout.Space(-5);
-
-                        GUILayout.BeginHorizontal(Styles.HistoryFileTreeBoxStyle);
-                        {
-                            changesetTree.OnGUI();
-                        }
-                        GUILayout.EndHorizontal();
-
-                        GUILayout.Space(EditorGUIUtility.standardVerticalSpacing);
-                    }
-                    GUILayout.EndScrollView();
-                }
-                else
-                {
-                    detailsScroll = GUILayout.BeginScrollView(detailsScroll, GUILayout.Height(246));
-                    HistoryDetailsEntry(selection);
-                    GUILayout.EndScrollView();
-                }
-            }
-
-            // Handle culling and selection changes at the end of the last GUI frame
-            if (Event.current.type == EventType.Repaint)
-            {
-                CullHistory();
-                currentLogHasUpdate = false;
-
-                if (newSelectionIndex >= 0 || newSelectionIndex == -2)
-                {
-                    selectionIndex = newSelectionIndex == -2 ? -1 : newSelectionIndex;
-                    newSelectionIndex = -1;
-                    detailsScroll = Vector2.zero;
-
-                    if (selectionIndex >= 0)
-                    {
-                        changesetTree.UpdateEntries(history[selectionIndex].Changes);
-                    }
-
+                if (renderResult.RequiresRepaint)
                     Redraw();
-                }
             }
+
+            GUILayout.Space(rect.y - initialRect.y);
         }
 
         private void RepositoryTrackingOnStatusChanged(CacheUpdateEvent cacheUpdateEvent)
@@ -378,186 +503,20 @@ namespace GitHub.Unity
             {
                 currentLogHasUpdate = false;
 
-                history = Repository.CurrentLog;
+                logEntries = Repository.CurrentLog;
 
-                if (history.Any())
-                {
-                    // Make sure that scroll as much as possible focuses the same time period in the new entry list
-                    if (useScrollTime)
-                    {
-                        var closestIndex = -1;
-                        double closestDifference = Mathf.Infinity;
-                        for (var index = 0; index < history.Count; ++index)
-                        {
-                            var diff = Math.Abs((history[index].Time - scrollTime).TotalSeconds);
-                            if (diff < closestDifference)
-                            {
-                                closestDifference = diff;
-                                closestIndex = index;
-                            }
-                        }
-
-                        ScrollTo(closestIndex, scrollOffset);
-                    }
-
-                    CullHistory();
-                }
-
-                // Restore selection index or clear it
-                newSelectionIndex = -1;
-                if (!string.IsNullOrEmpty(selectionID))
-                {
-                    selectionIndex = Enumerable.Range(1, history.Count + 1)
-                                               .FirstOrDefault(
-                                                   index => history[index - 1].CommitID.Equals(selectionID)) - 1;
-
-                    if (selectionIndex < 0)
-                    {
-                        selectionID = string.Empty;
-                    }
-                }
+                BuildHistoryControl();
             }
         }
 
-        private void ScrollTo(int index, float offset = 0f)
+        private void BuildHistoryControl()
         {
-            scroll.Set(scroll.x, EntryHeight * index + offset);
-        }
-
-        private LogEntryState GetEntryState(int index)
-        {
-            return index < statusAhead ? LogEntryState.Local : LogEntryState.Normal;
-        }
-
-        /// <summary>
-        /// Recalculate the range of history items to handle - based on what is visible, plus a bit of padding for fast scrolling
-        /// </summary>
-        private void CullHistory()
-        {
-            historyStartIndex = (int)Mathf.Clamp(scroll.y / EntryHeight, 0, history.Count);
-            historyStopIndex =
-                (int)
-                    Mathf.Clamp(
-                        historyStartIndex +
-                            (Position.height - 2f * Mathf.Min(changesetTree.Height, Position.height * MaxChangelistHeightRatio)) /
-                                EntryHeight + 1, 0, history.Count);
-        }
-
-        private void RevertCommit()
-        {
-            var selection = history[selectionIndex];
-
-            var dialogTitle = "Revert commit";
-            var dialogBody = string.Format(@"Are you sure you want to revert the following commit:""{0}""", selection.Summary);
-
-            if (EditorUtility.DisplayDialog(dialogTitle, dialogBody, "Revert", "Cancel"))
+            if (historyControl == null)
             {
-                Repository
-                    .Revert(selection.CommitID)
-                    .FinallyInUI((success, e) => {
-                        if (!success)
-                        {
-                            EditorUtility.DisplayDialog(dialogTitle,
-                                "Error reverting commit: " + e.Message, Localization.Cancel);
-                        }
-                    })
-                    .Start();
-            }
-        }
-
-        private bool HistoryEntry(GitLogEntry entry, LogEntryState state, bool selected)
-        {
-            var entryRect = GUILayoutUtility.GetRect(Styles.HistoryEntryHeight, Styles.HistoryEntryHeight);
-
-            if (Event.current.type == EventType.Repaint)
-            {
-                var keyboardFocus = GUIUtility.keyboardControl == listID;
-
-                var summaryRect = new Rect(entryRect.x, entryRect.y + (Styles.BaseSpacing / 2), entryRect.width, Styles.HistorySummaryHeight + Styles.BaseSpacing);
-                var timestampRect = new Rect(entryRect.x, entryRect.yMax - Styles.HistoryDetailsHeight - (Styles.BaseSpacing / 2), entryRect.width, Styles.HistoryDetailsHeight);
-
-                var contentOffset = new Vector2(Styles.BaseSpacing * 2, 0);
-
-                Styles.Label.Draw(entryRect, "", false, false, selected, keyboardFocus);
-
-                Styles.Label.contentOffset = contentOffset;
-                Styles.HistoryEntryDetailsStyle.contentOffset = contentOffset;
-
-                Styles.Label.Draw(summaryRect, entry.Summary, false, false, selected, keyboardFocus);
-                Styles.HistoryEntryDetailsStyle.Draw(timestampRect, entry.PrettyTimeString + "     " + entry.AuthorName, false, false, selected, keyboardFocus);
-
-                if (!string.IsNullOrEmpty(entry.MergeA))
-                {
-                    const float MergeIndicatorWidth = 10.28f;
-                    const float MergeIndicatorHeight = 12f;
-                    var mergeIndicatorRect = new Rect(entryRect.x + 7, summaryRect.y, MergeIndicatorWidth, MergeIndicatorHeight);
-
-                    GUI.DrawTexture(mergeIndicatorRect, Styles.MergeIcon);
-
-                    DrawTimelineRectAroundIconRect(entryRect, mergeIndicatorRect);
-
-                    summaryRect.Set(mergeIndicatorRect.xMax, summaryRect.y, summaryRect.width - MergeIndicatorWidth, summaryRect.height);
-                }
-
-                if (state == LogEntryState.Local && string.IsNullOrEmpty(entry.MergeA))
-                {
-                    const float LocalIndicatorSize = 6f;
-                    var localIndicatorRect = new Rect(entryRect.x + (Styles.BaseSpacing - 2), summaryRect.y + 5, LocalIndicatorSize, LocalIndicatorSize);
-
-                    DrawTimelineRectAroundIconRect(entryRect, localIndicatorRect);
-
-                    GUI.DrawTexture(localIndicatorRect, Styles.LocalCommitIcon);
-
-                    summaryRect.Set(localIndicatorRect.xMax, summaryRect.y, summaryRect.width - LocalIndicatorSize, summaryRect.height);
-                }
-
-                if (state == LogEntryState.Normal && string.IsNullOrEmpty(entry.MergeA))
-                {
-                    const float NormalIndicatorWidth = 6f;
-                    const float NormalIndicatorHeight = 6f;
-
-                    Rect normalIndicatorRect = new Rect(entryRect.x + (Styles.BaseSpacing - 2),
-                        summaryRect.y + 5,
-                        NormalIndicatorWidth,
-                        NormalIndicatorHeight);
-
-                    DrawTimelineRectAroundIconRect(entryRect, normalIndicatorRect);
-
-                    GUI.DrawTexture(normalIndicatorRect, Styles.DotIcon);
-                }
-            }
-            else if (Event.current.type == EventType.ContextClick && entryRect.Contains(Event.current.mousePosition))
-            {
-                GenericMenu menu = new GenericMenu();
-                menu.AddItem(new GUIContent("Revert"), false, RevertCommit);
-                menu.ShowAsContext();
-
-                Event.current.Use();
-            }
-            else if (Event.current.type == EventType.MouseDown && entryRect.Contains(Event.current.mousePosition))
-            {
-                Event.current.Use();
-                return true;
+                historyControl = new HistoryControl();
             }
 
-            return false;
-        }
-
-        private void HistoryDetailsEntry(GitLogEntry entry)
-        {
-            GUILayout.BeginVertical(Styles.HeaderBoxStyle);
-            GUILayout.Label(entry.Summary, Styles.HistoryDetailsTitleStyle, GUILayout.Width(Position.width));
-
-            GUILayout.Space(-5);
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label(entry.PrettyTimeString, Styles.HistoryDetailsMetaInfoStyle);
-            GUILayout.Label(entry.AuthorName, Styles.HistoryDetailsMetaInfoStyle);
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
-
-            GUILayout.Space(3);
-            GUILayout.EndVertical();
+            historyControl.Load(statusAhead, logEntries);
         }
 
         private void Pull()
@@ -632,51 +591,9 @@ namespace GitHub.Unity
                 .Start();
         }
 
-        private void DrawTimelineRectAroundIconRect(Rect parentRect, Rect iconRect)
-        {
-            Color timelineBarColor = new Color(0.51F, 0.51F, 0.51F, 0.2F);
-
-            // Draw them lines
-            //
-            // First I need to figure out how large to make the top one:
-            // I'll subtract the entryRect.y from the mergeIndicatorRect.y to
-            // get the difference in length. then subtract a little more for padding
-            float topTimelineRectHeight = iconRect.y - parentRect.y - 2;
-            // Now let's create the rect
-            Rect topTimelineRect = new Rect(
-                parentRect.x + Styles.BaseSpacing,
-                parentRect.y,
-                2,
-                topTimelineRectHeight);
-
-            // And draw it
-            EditorGUI.DrawRect(topTimelineRect, timelineBarColor);
-
-            // Let's do the same for the bottom
-            float bottomTimelineRectHeight = parentRect.yMax - iconRect.yMax - 2;
-            Rect bottomTimelineRect = new Rect(
-                parentRect.x + Styles.BaseSpacing,
-                parentRect.yMax - bottomTimelineRectHeight,
-                2,
-                bottomTimelineRectHeight);
-            EditorGUI.DrawRect(bottomTimelineRect, timelineBarColor);
-        }
-
         public override bool IsBusy
         {
             get { return false; }
-        }
-
-        private float EntryHeight
-        {
-            get { return Styles.HistoryEntryHeight + Styles.HistoryEntryPadding; }
-        }
-
-        private enum LogEntryState
-        {
-            Normal,
-            Local,
-            Remote
         }
     }
 }


### PR DESCRIPTION
**Note**: This PR targets `enhancements/history-detail-tree-view-rollup` #528

Fixes: #180

The `HistoryView` implemented a lot of functionality to handle virtual scrolling that was different to how they were approached in the `Tree` control. It was also hard to isolate code that handled the log from the code that handled the log entries.

In order to resolve this I refactored the `HistoryView`'s handling of the list to `HistoryControl`.

- Resolved issues that attempt to control the visible area
- Maintains scroll position if possible when loading entries
- Maintains selected entry if possible when loading entries

**Before**:
![](https://i.imgur.com/wyDZlhZ.gif)
![](https://i.imgur.com/18u2DXv.gif)

**After:**
![](https://i.imgur.com/5Dg5awB.gif)
![](https://i.imgur.com/ZQrPZgj.gif)