### PR TITLE
Adding functionality to make tree nodes non-selectable

### DIFF
--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -36,7 +36,7 @@ namespace GitHub.Unity
 
             var displayRootLevel = DisplayRootNode ? 1 : 0;
 
-            var isSelected = selectedNodePath != null && Title == selectedNodePath;
+            var isSelected = IsSelectable && selectedNodePath != null && Title == selectedNodePath;
             AddNode(Title, Title, -1 + displayRootLevel, true, false, false, false, isSelected, null);
 
             var hideChildren = false;
@@ -318,6 +318,7 @@ namespace GitHub.Unity
         protected abstract List<TNode> Nodes { get; }
         public abstract string Title { get; set; }
         public abstract bool DisplayRootNode { get; set; }
+        public abstract bool IsSelectable { get; set; }
         public abstract bool IsCheckable { get; set; }
         public abstract string PathSeparator { get; set; }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -38,6 +38,7 @@ namespace GitHub.Unity
         [SerializeField] public string title = string.Empty;
         [SerializeField] public string pathSeparator = "/";
         [SerializeField] public bool displayRootNode = true;
+        [SerializeField] public bool isSelectable = true;
         [SerializeField] public bool isCheckable = false;
         [SerializeField] private List<ChangesTreeNode> nodes = new List<ChangesTreeNode>();
         [SerializeField] private ChangesTreeNode selectedNode = null;
@@ -58,6 +59,12 @@ namespace GitHub.Unity
         {
             get { return isCheckable; }
             set { isCheckable = value; }
+        }
+
+        public override bool IsSelectable
+        {
+            get { return isSelectable; }
+            set { isSelectable = value; }
         }
 
         public override string PathSeparator

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -157,7 +157,7 @@ namespace GitHub.Unity
         public void Focus()
         {
             bool selectionChanged = false;
-            if (Event.current.type == EventType.KeyDown)
+            if (IsSelectable && Event.current.type == EventType.KeyDown)
             {
                 int directionY = Event.current.keyCode == KeyCode.UpArrow ? -1 : Event.current.keyCode == KeyCode.DownArrow ? 1 : 0;
                 int directionX = Event.current.keyCode == KeyCode.LeftArrow ? -1 : Event.current.keyCode == KeyCode.RightArrow ? 1 : 0;
@@ -191,7 +191,11 @@ namespace GitHub.Unity
                 Event.current.Use();
                 GUIUtility.keyboardControl = controlId;
 
-                SelectedNode = currentNode;
+                if (IsSelectable)
+                {
+                    SelectedNode = currentNode;
+                }
+
                 requiresRepaint = true;
                 var clickCount = Event.current.clickCount;
                 var mouseButton = Event.current.button;
@@ -212,7 +216,7 @@ namespace GitHub.Unity
             }
 
             // Keyboard navigation if this child is the current selection
-            if (GUIUtility.keyboardControl == controlId && currentNode == SelectedNode && Event.current.type == EventType.KeyDown)
+            if (IsSelectable && GUIUtility.keyboardControl == controlId && currentNode == SelectedNode && Event.current.type == EventType.KeyDown)
             {
                 int directionY = Event.current.keyCode == KeyCode.UpArrow ? -1 : Event.current.keyCode == KeyCode.DownArrow ? 1 : 0;
                 int directionX = Event.current.keyCode == KeyCode.LeftArrow ? -1 : Event.current.keyCode == KeyCode.RightArrow ? 1 : 0;
@@ -529,6 +533,7 @@ namespace GitHub.Unity
         [SerializeField] public string title = string.Empty;
         [SerializeField] public string pathSeparator = "/";
         [SerializeField] public bool displayRootNode = true;
+        [SerializeField] public bool isSelectable = true;
         [SerializeField] public bool isCheckable = false;
         [SerializeField] private List<TreeNode> nodes = new List<TreeNode>();
         [SerializeField] private TreeNode selectedNode = null;
@@ -549,6 +554,12 @@ namespace GitHub.Unity
         {
             get { return isCheckable; }
             set { isCheckable = value; }
+        }
+
+        public override bool IsSelectable
+        {
+            get { return isSelectable; }
+            set { isSelectable = value; }
         }
 
         public override string PathSeparator


### PR DESCRIPTION
In order to make a read-only Tree we need to disable the functionality to "Select" nodes.
Here we are adding `IsSelectable` as a new configuration and defaulting it to `true` for existing implementations.