### PR TITLE
History detail tree view

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -39,8 +39,8 @@ namespace GitHub.Unity
         [NonSerialized] private int listID = -1;
         [NonSerialized] private BranchesMode targetMode;
 
-        [SerializeField] private BranchesTree treeLocals;
-        [SerializeField] private BranchesTree treeRemotes;
+        [SerializeField] private BranchesTree treeLocals = new BranchesTree { Title = LocalTitle };
+        [SerializeField] private BranchesTree treeRemotes = new BranchesTree { Title = RemoteTitle, IsRemote = true };
         [SerializeField] private BranchesMode mode = BranchesMode.Default;
         [SerializeField] private string newBranchName;
         [SerializeField] private Vector2 scroll;
@@ -155,18 +155,6 @@ namespace GitHub.Unity
 
         private void BuildTree()
         {
-            if (treeLocals == null)
-            {
-                treeLocals = new BranchesTree();
-                treeLocals.Title = LocalTitle;
-
-                treeRemotes = new BranchesTree();
-                treeRemotes.Title = RemoteTitle;
-                treeRemotes.IsRemote = true;
-
-                TreeOnEnable();
-            }
-
             localBranches.Sort(CompareBranches);
             remoteBranches.Sort(CompareBranches);
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -114,7 +114,7 @@ namespace GitHub.Unity
                 treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
                 treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
-                var treeRenderRect = treeChanges.Render(rect, scroll, 
+                var treeRenderRect = treeChanges.Render(rect, treeScroll, 
                     node => { }, 
                     node => { },
                     node => { });

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -28,7 +28,7 @@ namespace GitHub.Unity
         [SerializeField] private string currentBranch = "[unknown]";
 
         [SerializeField] private Vector2 treeScroll;
-        [SerializeField] private ChangesTree treeChanges;
+        [SerializeField] private ChangesTree treeChanges = new ChangesTree { DisplayRootNode = false, IsCheckable = true };
 
         [SerializeField] private HashSet<string> gitLocks;
         [SerializeField] private List<GitStatusEntry> gitStatusEntries;
@@ -212,17 +212,7 @@ namespace GitHub.Unity
 
         private void BuildTree()
         {
-            if (treeChanges == null)
-            {
-                treeChanges = new ChangesTree();
-                treeChanges.Title = "Changes";
-                treeChanges.DisplayRootNode = false;
-                treeChanges.IsCheckable = true;
-                treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
-
-                TreeOnEnable();
-            }
-
+            treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
             treeChanges.Load(gitStatusEntries.Select(entry => new GitStatusEntryTreeData(entry, gitLocks.Contains(entry.Path))));
             Redraw();
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -484,7 +484,7 @@ namespace GitHub.Unity
                     rect = GUILayoutUtility.GetLastRect();
                     GUILayout.BeginHorizontal(Styles.HistoryFileTreeBoxStyle);
                     {
-                        var treeControlRect = new Rect(0f, 0f, Position.width, Position.height - rect.height + Styles.CommitAreaPadding);
+                        var treeControlRect = new Rect(rect.x, rect.y, Position.width, Position.height - rect.height + Styles.CommitAreaPadding);
                         var treeRect = Rect.zero;
                         if (treeChanges != null)
                         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -483,8 +483,10 @@ namespace GitHub.Unity
 
                     rect = GUILayoutUtility.GetLastRect();
                     GUILayout.BeginHorizontal(Styles.HistoryFileTreeBoxStyle);
+                    GUILayout.BeginVertical();
                     {
-                        var treeControlRect = new Rect(rect.x, rect.y, Position.width, Position.height - rect.height + Styles.CommitAreaPadding);
+                        var borderLeft = Styles.Label.margin.left;
+                        var treeControlRect = new Rect(rect.x + borderLeft, rect.y, Position.width - borderLeft * 2, Position.height - rect.height + Styles.CommitAreaPadding);
                         var treeRect = Rect.zero;
                         if (treeChanges != null)
                         {
@@ -507,6 +509,7 @@ namespace GitHub.Unity
 
                         GUILayout.Space(treeRect.y - treeControlRect.y);
                     }
+                    GUILayout.EndVertical();
                     GUILayout.EndHorizontal();
 
                     GUILayout.Space(EditorGUIUtility.standardVerticalSpacing);
@@ -518,7 +521,7 @@ namespace GitHub.Unity
         private void HistoryDetailsEntry(GitLogEntry entry)
         {
             GUILayout.BeginVertical(Styles.HeaderBoxStyle);
-            GUILayout.Label(entry.Summary, Styles.HistoryDetailsTitleStyle, GUILayout.Width(Position.width));
+            GUILayout.Label(entry.Summary, Styles.HistoryDetailsTitleStyle);
 
             GUILayout.Space(-5);
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -494,7 +494,7 @@ namespace GitHub.Unity
                             treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
                             treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
-                            treeRect = treeChanges.Render(treeControlRect, treeControlRect, detailsScroll,
+                            treeRect = treeChanges.Render(treeControlRect, detailsScroll,
                                 node => { },
                                 node => {
                                 },

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -730,6 +730,7 @@ namespace GitHub.Unity
             {
                 treeChanges = new ChangesTree();
                 treeChanges.Title = "Changes";
+                treeChanges.IsSelectable = false;
                 treeChanges.DisplayRootNode = false;
                 treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -350,7 +350,6 @@ namespace GitHub.Unity
         [SerializeField] private int statusAhead;
         [SerializeField] private int statusBehind;
 
-        [SerializeField] private Vector2 treeScroll;
         [SerializeField] private ChangesTree treeChanges;
         
         [SerializeField] private CacheUpdateEvent lastCurrentRemoteChangedEvent;
@@ -493,32 +492,28 @@ namespace GitHub.Unity
                     rect = GUILayoutUtility.GetLastRect();
                     GUILayout.BeginHorizontal(Styles.HistoryFileTreeBoxStyle);
                     {
-                        treeScroll = GUILayout.BeginScrollView(treeScroll);
+                        var treeControlRect = new Rect(0f, 0f, Position.width, Position.height - rect.height + Styles.CommitAreaPadding);
+                        var treeRect = Rect.zero;
+                        if (treeChanges != null)
                         {
-                            var treeControlRect = new Rect(0f, 0f, Position.width, Position.height - rect.height + Styles.CommitAreaPadding);
-                            var treeRect = Rect.zero;
-                            if (treeChanges != null)
-                            {
-                                treeChanges.FolderStyle = Styles.Foldout;
-                                treeChanges.TreeNodeStyle = Styles.TreeNode;
-                                treeChanges.ActiveTreeNodeStyle = Styles.ActiveTreeNode;
-                                treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
-                                treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
+                            treeChanges.FolderStyle = Styles.Foldout;
+                            treeChanges.TreeNodeStyle = Styles.TreeNode;
+                            treeChanges.ActiveTreeNodeStyle = Styles.ActiveTreeNode;
+                            treeChanges.FocusedTreeNodeStyle = Styles.FocusedTreeNode;
+                            treeChanges.FocusedActiveTreeNodeStyle = Styles.FocusedActiveTreeNode;
 
-                                treeRect = treeChanges.Render(treeControlRect, treeControlRect, treeScroll,
-                                    node => { },
-                                    node => {
-                                    },
-                                    node => {
-                                    });
+                            treeRect = treeChanges.Render(treeControlRect, treeControlRect, detailsScroll,
+                                node => { },
+                                node => {
+                                },
+                                node => {
+                                });
 
-                                if (treeChanges.RequiresRepaint)
-                                    Redraw();
-                            }
-
-                            GUILayout.Space(treeRect.y - treeControlRect.y);
+                            if (treeChanges.RequiresRepaint)
+                                Redraw();
                         }
-                        GUILayout.EndScrollView();
+
+                        GUILayout.Space(treeRect.y - treeControlRect.y);
                     }
                     GUILayout.EndHorizontal();
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -342,7 +342,7 @@ namespace GitHub.Unity
         [SerializeField] private int statusAhead;
         [SerializeField] private int statusBehind;
 
-        [SerializeField] private ChangesTree treeChanges;
+        [SerializeField] private ChangesTree treeChanges = new ChangesTree { IsSelectable = false, DisplayRootNode = false };
         
         [SerializeField] private CacheUpdateEvent lastCurrentRemoteChangedEvent;
         [SerializeField] private CacheUpdateEvent lastLogChangedEvent;
@@ -716,17 +716,7 @@ namespace GitHub.Unity
 
         private void BuildTree()
         {
-            if (treeChanges == null)
-            {
-                treeChanges = new ChangesTree();
-                treeChanges.Title = "Changes";
-                treeChanges.IsSelectable = false;
-                treeChanges.DisplayRootNode = false;
-                treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
-
-                TreeOnEnable();
-            }
-
+            treeChanges.PathSeparator = Environment.FileSystem.DirectorySeparatorChar.ToString();
             treeChanges.Load(selectedEntry.changes.Select(entry => new GitStatusEntryTreeData(entry)));
             Redraw();
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -424,7 +424,7 @@ namespace GitHub.Unity
                 return renderResult;
 
             var fillRect = rect;
-            var nodeStartX = Level * indentation;
+            var nodeStartX = Level * indentation + rect.x;
             nodeStartX += 2 * level;
 
             var nodeRect = new Rect(nodeStartX, rect.y, fillRect.width - nodeStartX, rect.height);


### PR DESCRIPTION
**Note**: This PR targets `enhancements/history-detail-tree-view-rollup` #528

- Added functionality to display a `Tree` control at the bottom of the `HistoryView`
- Fixed placement issues in the `HistoryControl` and `Tree` controls
- Initialized Tree controls in field initializers to fix an issue where `Tree` controls were instantiated without their properties set