### PR TITLE
Functionality to retain the checked state of nodes when loading data

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -153,7 +153,7 @@ namespace GitHub.Unity
             return Styles.GetFileStatusIcon(gitFileStatus, false);
         }
 
-        protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitStatusEntryTreeData? treeData)
+        protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitStatusEntryTreeData? treeData)
         {
             var node = new ChangesTreeNode
             {
@@ -165,11 +165,12 @@ namespace GitHub.Unity
                 IsHidden = isHidden,
                 IsCollapsed = isCollapsed,
                 TreeIsCheckable = IsCheckable,
+                CheckState = isChecked ? CheckState.Checked : CheckState.Empty,
                 GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None,
                 ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null
             };
 
-            if (isFolder)
+            if (isFolder && level >= 0)
             {
                 folders.Add(node.Path, node);
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -632,7 +632,7 @@ namespace GitHub.Unity
             return nodeIcon;
         }
 
-        protected override TreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitBranchTreeData? treeData)
+        protected override TreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitBranchTreeData? treeData)
         {
             var node = new TreeNode {
                 Path = path,
@@ -642,10 +642,11 @@ namespace GitHub.Unity
                 IsActive = isActive,
                 IsHidden = isHidden,
                 IsCollapsed = isCollapsed,
-                TreeIsCheckable = IsCheckable
+                TreeIsCheckable = IsCheckable,
+                CheckState = isChecked ? CheckState.Checked: CheckState.Empty
             };
 
-            if (isFolder)
+            if (isFolder && level >= 0)
             {
                 folders.Add(node.Path, node);
             }


### PR DESCRIPTION
- Functionality to retained the checked state of files during loading of data.
- Functionality to recalculate the checked state of folders during the loading of data.

We intentionally do not retained the checked state of folders, as files may have been added or removed between reloads and the folder's checked state must be recalculated.