### PR TITLE
Functionality to use lock data in ChangesTreeView Icons

### DIFF
--- a/src/GitHub.Api/Git/TreeData.cs
+++ b/src/GitHub.Api/Git/TreeData.cs
@@ -30,9 +30,11 @@ namespace GitHub.Unity
         public static GitStatusEntryTreeData Default = new GitStatusEntryTreeData(GitStatusEntry.Default);
 
         public GitStatusEntry gitStatusEntry;
+        public bool isLocked;
 
-        public GitStatusEntryTreeData(GitStatusEntry gitStatusEntry)
+        public GitStatusEntryTreeData(GitStatusEntry gitStatusEntry, bool isLocked = false)
         {
+            this.isLocked = isLocked;
             this.gitStatusEntry = gitStatusEntry;
         }
 
@@ -40,7 +42,7 @@ namespace GitHub.Unity
         public string ProjectPath => gitStatusEntry.ProjectPath;
         public bool IsActive => false;
         public GitStatusEntry GitStatusEntry => gitStatusEntry;
-
         public GitFileStatus FileStatus => gitStatusEntry.Status;
+        public bool IsLocked => isLocked;
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -14,6 +14,7 @@ namespace GitHub.Unity
     {
         public string projectPath;
         public GitFileStatus gitFileStatus;
+        public bool isLocked;
 
         public string ProjectPath
         {
@@ -25,6 +26,12 @@ namespace GitHub.Unity
         {
             get { return gitFileStatus; }
             set { gitFileStatus = value; }
+        }
+
+        public bool IsLocked
+        {
+            get { return isLocked; }
+            set { isLocked = value; }
         }
     }
 
@@ -150,11 +157,22 @@ namespace GitHub.Unity
             }
 
             var gitFileStatus = node.GitFileStatus;
-            return Styles.GetFileStatusIcon(gitFileStatus, false);
+            return Styles.GetFileStatusIcon(gitFileStatus, node.IsLocked);
         }
 
         protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, GitStatusEntryTreeData? treeData)
         {
+            var gitFileStatus = GitFileStatus.None;
+            var projectPath = (string) null;
+            var isLocked = false;
+
+            if (treeData.HasValue)
+            {
+                isLocked = treeData.Value.IsLocked;
+                gitFileStatus = treeData.Value.FileStatus;
+                projectPath = treeData.Value.ProjectPath;
+            }
+
             var node = new ChangesTreeNode
             {
                 Path = path,
@@ -165,8 +183,9 @@ namespace GitHub.Unity
                 IsHidden = isHidden,
                 IsCollapsed = isCollapsed,
                 TreeIsCheckable = IsCheckable,
-                GitFileStatus = treeData.HasValue ? treeData.Value.FileStatus : GitFileStatus.None,
-                ProjectPath = treeData.HasValue ? treeData.Value.ProjectPath : null
+                GitFileStatus = gitFileStatus,
+                ProjectPath = projectPath,
+                IsLocked = isLocked
             };
 
             if (isFolder)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -185,6 +185,7 @@ namespace GitHub.Unity
             {
                 currentLocksHasUpdate = false;
                 var repositoryCurrentLocks = Repository.CurrentLocks;
+                lockedFileSelection = -1;
                 lockedFiles = repositoryCurrentLocks != null
                     ? repositoryCurrentLocks.ToList()
                     : new List<GitLock>();


### PR DESCRIPTION
- Adding functionality to convey lock status in input data for `ChangesTreeView`
- Adding functionality to `ChangesView` to redraw on lock status changes
- Fixing error where the selected lock is not reset when the lock list changes in the `SettingsView`