### PR TITLE
Creating a ZipHelper singleton and UnzipTask

### DIFF
--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Application\ApplicationManagerBase.cs" />
     <Compile Include="Helpers\Constants.cs" />
     <Compile Include="Helpers\Validation.cs" />
+    <Compile Include="Installer\UnzipTask.cs" />
     <Compile Include="OutputProcessors\GitAheadBehindStatusOutputProcessor.cs" />
     <Compile Include="OutputProcessors\LfsVersionOutputProcessor.cs" />
     <Compile Include="OutputProcessors\VersionOutputProcessor.cs" />

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -18,17 +18,14 @@ namespace GitHub.Unity
         private readonly CancellationToken cancellationToken;
         private readonly IEnvironment environment;
         private readonly ILogging logger;
-
-        private delegate void ExtractZipFile(string archive, string outFolder, CancellationToken cancellationToken,
-            IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null);
-        private ExtractZipFile extractCallback;
+        private readonly IZipHelper zipHelper;
 
         public GitInstaller(IEnvironment environment, CancellationToken cancellationToken)
-            : this(environment, null, cancellationToken)
+            : this(environment, ZipHelper.Instance, cancellationToken)
         {
         }
 
-        public GitInstaller(IEnvironment environment, IZipHelper sharpZipLibHelper, CancellationToken cancellationToken)
+        public GitInstaller(IEnvironment environment, IZipHelper zipHelper, CancellationToken cancellationToken)
         {
             Guard.ArgumentNotNull(environment, nameof(environment));
 
@@ -36,10 +33,7 @@ namespace GitHub.Unity
             this.cancellationToken = cancellationToken;
 
             this.environment = environment;
-            this.extractCallback = sharpZipLibHelper != null
-                 ? (ExtractZipFile)sharpZipLibHelper.Extract
-                 : ZipHelper.ExtractZipFile;
-
+            this.zipHelper = zipHelper;
 
             GitInstallationPath = environment.GetSpecialFolder(Environment.SpecialFolder.LocalApplicationData)
                 .ToNPath().Combine(ApplicationInfo.ApplicationName, PackageNameWithVersion);
@@ -184,7 +178,7 @@ namespace GitHub.Unity
             {
                 logger.Trace("Extracting \"{0}\" to \"{1}\"", archiveFilePath, unzipPath);
 
-                extractCallback(archiveFilePath, unzipPath, cancellationToken, zipFileProgress,
+                zipHelper.Extract(archiveFilePath, unzipPath, cancellationToken, zipFileProgress,
                     estimatedDurationProgress);
             }
             catch (Exception ex)
@@ -249,7 +243,7 @@ namespace GitHub.Unity
             {
                 logger.Trace("Extracting \"{0}\" to \"{1}\"", archiveFilePath, unzipPath);
 
-                extractCallback(archiveFilePath, unzipPath, cancellationToken, zipFileProgress,
+                zipHelper.Extract(archiveFilePath, unzipPath, cancellationToken, zipFileProgress,
                     estimatedDurationProgress);
             }
             catch (Exception ex)

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -8,14 +8,23 @@ namespace GitHub.Unity
     {
         private readonly string archiveFilePath;
         private readonly string extractedPath;
+        private readonly IZipHelper zipHelper;
         private readonly IProgress<float> zipFileProgress;
         private readonly IProgress<long> estimatedDurationProgress;
 
-        public UnzipTask(CancellationToken token, string archiveFilePath, string extractedPath, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null)
+        public UnzipTask(CancellationToken token, string archiveFilePath, string extractedPath,
+            IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null) :
+            this(token, archiveFilePath, extractedPath, ZipHelper.Instance, zipFileProgress, estimatedDurationProgress)
+        {
+            
+        }
+
+        public UnzipTask(CancellationToken token, string archiveFilePath, string extractedPath, IZipHelper zipHelper, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null)
             : base(token)
         {
             this.archiveFilePath = archiveFilePath;
             this.extractedPath = extractedPath;
+            this.zipHelper = zipHelper;
             this.zipFileProgress = zipFileProgress;
             this.estimatedDurationProgress = estimatedDurationProgress;
         }
@@ -32,7 +41,7 @@ namespace GitHub.Unity
             Logger.Trace("Zip File: {0}", archiveFilePath);
             Logger.Trace("Target Path: {0}", extractedPath);
 
-            ZipHelper.ExtractZipFile(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
+            zipHelper.Extract(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
 
             Logger.Trace("Completed");
         }

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -6,12 +6,10 @@ namespace GitHub.Unity
 {
     class UnzipTask: TaskBase
     {
-        protected static ILogging Logger { get; } = Logging.GetLogger<UnzipTask>();
-
-        private string archiveFilePath;
-        private string extractedPath;
-        private IProgress<float> zipFileProgress;
-        private IProgress<long> estimatedDurationProgress;
+        private readonly string archiveFilePath;
+        private readonly string extractedPath;
+        private readonly IProgress<float> zipFileProgress;
+        private readonly IProgress<long> estimatedDurationProgress;
 
         public UnzipTask(CancellationToken token, string archiveFilePath, string extractedPath, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null)
             : base(token)

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitHub.Unity
+{
+    class UnzipTask: TaskBase
+    {
+        protected static ILogging Logger { get; } = Logging.GetLogger<UnzipTask>();
+
+        private string archiveFilePath;
+        private string extractedPath;
+        private IProgress<float> zipFileProgress;
+        private IProgress<long> estimatedDurationProgress;
+
+        public UnzipTask(CancellationToken token, string archiveFilePath, string extractedPath, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null)
+            : base(token)
+        {
+            this.archiveFilePath = archiveFilePath;
+            this.extractedPath = extractedPath;
+            this.zipFileProgress = zipFileProgress;
+            this.estimatedDurationProgress = estimatedDurationProgress;
+        }
+
+        protected override void Run(bool success)
+        {
+            base.Run(success);
+
+            UnzipArchive();
+        }
+
+        private void UnzipArchive()
+        {
+            Logger.Trace("Zip File: {0}", archiveFilePath);
+            Logger.Trace("Target Path: {0}", extractedPath);
+
+            ZipHelper.ExtractZipFile(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
+
+            Logger.Trace("Completed");
+        }
+    }
+}

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -38,12 +38,11 @@ namespace GitHub.Unity
 
         private void UnzipArchive()
         {
-            Logger.Trace("Zip File: {0}", archiveFilePath);
-            Logger.Trace("Target Path: {0}", extractedPath);
+            Logger.Trace("Unzip File: {0} to Path: {1}", archiveFilePath, extractedPath);
 
             zipHelper.Extract(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
 
-            Logger.Trace("Completed");
+            Logger.Trace("Completed Unzip");
         }
     }
 }

--- a/src/GitHub.Api/Installer/ZipHelper.cs
+++ b/src/GitHub.Api/Installer/ZipHelper.cs
@@ -8,6 +8,21 @@ namespace GitHub.Unity
 {
     class ZipHelper : IZipHelper
     {
+        private static IZipHelper instance;
+
+        public static IZipHelper Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new ZipHelper();
+                }
+
+                return instance;
+            }
+        }
+
         public static bool Copy(Stream source, Stream destination, int chunkSize, long totalSize,
             Func<long, long, bool> progress, int progressUpdateRate)
         {

--- a/src/tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/IntegrationTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="ThreadSynchronizationContext.cs" />
+    <Compile Include="UnzipTaskTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\GitHub.Api\GitHub.Api.csproj">

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.Unity;
+using Microsoft.Win32.SafeHandles;
+using NSubstitute;
+using NUnit.Framework;
+using Rackspace.Threading;
+
+namespace IntegrationTests
+{
+    [TestFixture]
+    class UnzipTaskTests : BaseTaskManagerTest
+    {
+        [Test]
+        public void UnzipTest()
+        {
+            InitializeTaskManager();
+
+            var cacheContainer = Substitute.For<ICacheContainer>();
+            Environment = new IntegrationTestEnvironment(cacheContainer, TestBasePath, SolutionDirectory);
+
+            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", TestBasePath.Combine("gip_zip_extracted"), Environment);
+
+            Logger.Trace("ArchiveFilePath: {0}", archiveFilePath);
+            Logger.Trace("TestBasePath: {0}", TestBasePath);
+
+            var extractedPath = TestBasePath.Combine("git_zip_extracted");
+            extractedPath.CreateDirectory();
+
+            var zipProgress = 0;
+            Logger.Trace("Pct Complete {0}%", zipProgress);
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, 
+                new Progress<float>(zipFileProgress => {
+                    var zipFileProgressInteger = (int) (zipFileProgress * 100);
+                    if (zipProgress != zipFileProgressInteger)
+                    {
+                        zipProgress = zipFileProgressInteger;
+                        Logger.Trace("Pct Complete {0}%", zipProgress);
+                    }
+                }));
+
+            unzipTask.Start().Wait();
+        }
+    }
+}

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -19,13 +19,13 @@ namespace IntegrationTests
             var cacheContainer = Substitute.For<ICacheContainer>();
             Environment = new IntegrationTestEnvironment(cacheContainer, TestBasePath, SolutionDirectory);
 
-            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", TestBasePath.Combine("gip_zip_extracted"), Environment);
+            var destinationPath = TestBasePath.Combine("git_zip").CreateDirectory();
+            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", destinationPath, Environment);
 
             Logger.Trace("ArchiveFilePath: {0}", archiveFilePath);
             Logger.Trace("TestBasePath: {0}", TestBasePath);
 
-            var extractedPath = TestBasePath.Combine("git_zip_extracted");
-            extractedPath.CreateDirectory();
+            var extractedPath = TestBasePath.Combine("git_zip_extracted").CreateDirectory();
 
             var zipProgress = 0;
             Logger.Trace("Pct Complete {0}%", zipProgress);


### PR DESCRIPTION
**Note:** This pull request targets `enhancements/async-git-setup-rollup`

- Creating a lazily loaded singleton of `ZipHelper`
- Creating an `UnzipTask` and a basic integration test that shows it works
- Removing delegate from `GitInstaller` and using the singleton `ZipHelper` instead.
  