### PR TITLE
Missing null check in TaskBase

### DIFF
--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -597,7 +597,7 @@ namespace GitHub.Unity
         {
             Task = new Task<TResult>(() =>
             {
-                var ret = RunWithData(DependsOn?.Successful ?? previousSuccess, DependsOn.Successful ? ((ITask<T>)DependsOn).Result : default(T));
+                var ret = RunWithData(DependsOn?.Successful ?? previousSuccess, (DependsOn?.Successful ?? false) ? ((ITask<T>)DependsOn).Result : default(T));
                 tcs.SetResult(ret);
                 AdjustNextTask(ret);
                 return ret;


### PR DESCRIPTION
**Note:** This pull request targets `enhancements/async-git-setup-rollup`

When this class is derived and used with no task set as it's dependency. It returns a false for success and should return a `default` value for `T`. In order to return the `default(T)` we need to perform a null check instead of getting the `NullReferenceException` we are getting now.
  