### PR TITLE
Using string.IsNullOrEmpty where appropriate

### DIFF
--- a/src/GitHub.Api/Helpers/AssemblyResources.cs
+++ b/src/GitHub.Api/Helpers/AssemblyResources.cs
@@ -25,7 +25,7 @@ namespace GitHub.Unity
                 : resourceType == ResourceType.Platform ? "PlatformResources"
                 : "Resources";
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(
-                                     String.Format("GitHub.Unity.{0}{1}.{2}", type, os != "" ? "." + os : os, resource));
+                                     String.Format("GitHub.Unity.{0}{1}.{2}", type, !string.IsNullOrEmpty(os) ? "." + os : os, resource));
             if (stream != null)
                 return destinationPath.Combine(resource).WriteAllBytes(stream.ToByteArray());
 

--- a/src/GitHub.Api/IO/NiceIO.cs
+++ b/src/GitHub.Api/IO/NiceIO.cs
@@ -222,7 +222,7 @@ GitHub.Unity
 
             var newElements = (string[])_elements.Clone();
             newElements[newElements.Length - 1] = FileSystem.ChangeExtension(_elements[_elements.Length - 1], WithDot(extension));
-            if (extension == string.Empty)
+            if (string.IsNullOrEmpty(extension))
                 newElements[newElements.Length - 1] = newElements[newElements.Length - 1].TrimEnd('.');
             return new NPath(newElements, _isRelative, _driveLetter);
         }

--- a/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
@@ -175,7 +175,7 @@ namespace GitHub.Unity
                     break;
 
                 case ProcessingPhase.Files:
-                    if (line == string.Empty)
+                    if (string.IsNullOrEmpty(line))
                     {
                         ReturnGitLogEntry();
                         return;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
@@ -37,7 +37,7 @@ namespace GitHub.Unity
             {
                 if (nFilePath == null)
                 {
-                    if (filePath == "")
+                    if (string.IsNullOrEmpty(filePath))
                         return null;
                     if (filePath == null)
                         filePath = GetFilePath();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
@@ -161,7 +161,7 @@ namespace GitHub.Unity
                         var organization = owners[selectedOwner] == username ? null : owners[selectedOwner];
 
                         var cleanRepoDescription = repoDescription.Trim();
-                        cleanRepoDescription = cleanRepoDescription == string.Empty ? null : cleanRepoDescription;
+                        cleanRepoDescription = string.IsNullOrEmpty(cleanRepoDescription) ? null : cleanRepoDescription;
 
                         Client.CreateRepository(new NewRepository(repoName)
                         {


### PR DESCRIPTION
**Note:** This pull request targets `fixes/code-analysis` #458
  
Working through different code analysis issues in small pull requests.
In this pull request I'm catching the different scenarios where a string is being compared to `""` and replacing it with a call to `string.IsNullOrWhitespace` as that usually cleaner code.
