### PR TITLE
Retain logs when developing

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
@@ -40,10 +40,17 @@ namespace GitHub.Unity
                 var oldLogPath = logPath.Parent.Combine(logPath.FileNameWithoutExtension + "-old" + logPath.ExtensionWithDot);
                 try
                 {
-                    oldLogPath.DeleteIfExists();
-                    if (logPath.FileExists())
+                    var shouldRotate = true;
+#if DEVELOPER_BUILD
+                    shouldRotate = new FileInfo(logPath).Length > 10 * 1024 * 1024;
+#endif
+                    if (shouldRotate)
                     {
-                        logPath.Move(oldLogPath);
+                        oldLogPath.DeleteIfExists();
+                        if (logPath.FileExists())
+                        {
+                            logPath.Move(oldLogPath);
+                        }
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Only roll over the log file when it is over 10 MBS when developing