### PR TITLE
Attaching to GitUserCache events at a time when they might actually be fired

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -649,9 +649,6 @@ namespace GitHub.Unity
         public User(ICacheContainer cacheContainer)
         {
             this.cacheContainer = cacheContainer;
-
-            cacheContainer.GitUserCache.CacheInvalidated += GitUserCacheOnCacheInvalidated;
-            cacheContainer.GitUserCache.CacheUpdated += GitUserCacheOnCacheUpdated;
         }
 
         public void CheckUserChangedEvent(CacheUpdateEvent cacheUpdateEvent)
@@ -677,6 +674,9 @@ namespace GitHub.Unity
             Logger.Trace("Initialize");
 
             gitClient = client;
+
+            cacheContainer.GitUserCache.CacheInvalidated += GitUserCacheOnCacheInvalidated;
+            cacheContainer.GitUserCache.CacheUpdated += GitUserCacheOnCacheUpdated;
             cacheContainer.GitUserCache.ValidateData();
         }
 


### PR DESCRIPTION
Initial access of `EntryPoint.Envrionment` marks the start of the program and causes the construction of the `ApplicationManager`.

In this bug, during the construction of `ApplicationManager` an access to `cacheContainer.GitUserCache` causes construction of a `ManagedCacheBase<T>` object.

This object requires information about the current environment. Which causes a re-entrant call into `EntryPoint.Environment` before the initial call has completed.

The bug can be identified by grabbing a stack trace of when `ApplicationManager` is being constructed, and looking for the cycle in the stack trace.

```Creating ApplicationManager ManagedThreadId:1
UnityEngine.Debug:LogFormat(String, Object[])
GitHub.Unity.EntryPoint:get_ApplicationManager() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs:84)
GitHub.Unity.BaseWindow:Awake() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs:49)
UnityEditorInternal.InternalEditorUtility:LoadSerializedFileAndForget(String)
UnityEditor.WindowLayout:LoadWindowLayout(String, Boolean)
```

```
Creating ApplicationManager ManagedThreadId:1
UnityEngine.Debug:LogFormat(String, Object[])
GitHub.Unity.EntryPoint:get_ApplicationManager() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs:84)
GitHub.Unity.EntryPoint:get_Environment() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs:91)
GitHub.Unity.LocationAttribute:.ctor(String, Location) (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs:25)
System.MonoType:GetCustomAttributes(Boolean)
GitHub.Unity.ScriptObjectSingleton`1:GetFilePath() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs:115)
GitHub.Unity.ScriptObjectSingleton`1:CreateAndLoad() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs:81)
GitHub.Unity.ScriptObjectSingleton`1:get_Instance() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs:59)
GitHub.Unity.CacheContainer:get_GitUserCache() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/CacheContainer.cs:173)
GitHub.Unity.User:.ctor(ICacheContainer) (at C:/Users/Spade/Projects/GitHub/Unity/src/GitHub.Api/Git/Repository.cs:653)
GitHub.Unity.DefaultEnvironment:Initialize(String, NPath, NPath, NPath) (at C:/Users/Spade/Projects/GitHub/Unity/src/GitHub.Api/Platform/DefaultEnvironment.cs:51)
GitHub.Unity.EnvironmentCache:get_Environment() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs:105)
GitHub.Unity.ApplicationManager:get_Environment() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs:98)
GitHub.Unity.ApplicationManagerBase:Initialize() (at C:/Users/Spade/Projects/GitHub/Unity/src/GitHub.Api/Application/ApplicationManagerBase.cs:29)
GitHub.Unity.ApplicationManager:.ctor(IMainThreadSynchronizationContext) (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs:21)
GitHub.Unity.EntryPoint:get_ApplicationManager() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs:85)
GitHub.Unity.BaseWindow:Awake() (at C:/Users/Spade/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs:49)
UnityEditorInternal.InternalEditorUtility:LoadSerializedFileAndForget(String)
UnityEditor.WindowLayout:LoadWindowLayout(String, Boolean)```