### PR TITLE
GitHub.Logging naming fixes

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
@@ -20,7 +20,7 @@ namespace GitHub.Unity
                 new GitHubClient(ApplicationConfiguration.ProductHeader, credentialStore, hostAddress.ApiUri));
         }
 
-        private static readonly ILogging logger = Logging.GetLogger<ApiClient>();
+        private static readonly ILogging logger = LogHelper.GetLogger<ApiClient>();
         public HostAddress HostAddress { get; }
         public UriString OriginalUrl { get; }
 

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -3,13 +3,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
     abstract class ApplicationManagerBase : IApplicationManager
     {
-        protected static ILogging Logger { get; } = Logging.GetLogger<IApplicationManager>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<IApplicationManager>();
 
         private RepositoryManager repositoryManager;
 
@@ -36,7 +36,7 @@ namespace GitHub.Unity
             LocalSettings.Initialize();
             SystemSettings.Initialize();
 
-            Logging.TracingEnabled = UserSettings.Get(Constants.TraceLoggingKey, false);
+            LogHelper.TracingEnabled = UserSettings.Get(Constants.TraceLoggingKey, false);
             ProcessManager = new ProcessManager(Environment, Platform.GitEnvironment, CancellationToken);
             Platform.Initialize(ProcessManager, TaskManager);
             GitClient = new GitClient(Environment, ProcessManager, TaskManager.Token);

--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
@@ -23,7 +23,7 @@ namespace GitHub.Unity
     {
         const string ConnectionFile = "connections.json";
 
-        private readonly ILogging logger = Logging.GetLogger<Keychain>();
+        private readonly ILogging logger = LogHelper.GetLogger<Keychain>();
 
         private readonly ICredentialManager credentialManager;
         private readonly NPath cachePath;

--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -2,7 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Octokit;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
@@ -20,7 +20,7 @@ namespace GitHub.Unity
     /// </summary>
     class LoginManager : ILoginManager
     {
-        private readonly ILogging logger = Logging.GetLogger<LoginManager>();
+        private readonly ILogging logger = LogHelper.GetLogger<LoginManager>();
 
         private readonly string[] scopes = { "user", "repo", "gist", "write:public_key" };
         private readonly IKeychain keychain;

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using sfw.net;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
@@ -294,7 +294,7 @@ namespace GitHub.Unity
             Dispose(true);
         }
 
-        protected static ILogging Logger { get; } = Logging.GetLogger<RepositoryWatcher>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<RepositoryWatcher>();
 
         private enum EventType
         {

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -402,7 +402,7 @@ namespace GitHub.Unity
                 .Configure(processManager);
         }
 
-        protected static ILogging Logger { get; } = Logging.GetLogger<GitClient>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<GitClient>();
     }
 
     public struct GitUser

--- a/src/GitHub.Api/Git/GitCredentialManager.cs
+++ b/src/GitHub.Api/Git/GitCredentialManager.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -7,7 +7,7 @@ namespace GitHub.Unity
 {
     class GitCredentialManager : ICredentialManager
     {
-        private static ILogging Logger { get; } = Logging.GetLogger<GitCredentialManager>();
+        private static ILogging Logger { get; } = LogHelper.GetLogger<GitCredentialManager>();
 
         private ICredential credential;
         private string credHelper = null;

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -626,7 +626,7 @@ namespace GitHub.Unity
             "{0} Owner: {1} Name: {2} CloneUrl: {3} LocalPath: {4} Branch: {5} Remote: {6}", GetHashCode(), Owner, Name,
             CloneUrl, LocalPath, CurrentBranch, CurrentRemote);
 
-        protected static ILogging Logger { get; } = Logging.GetLogger<Repository>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<Repository>();
     }
 
     public interface IUser
@@ -751,7 +751,7 @@ namespace GitHub.Unity
                      }).Start();
         }
         
-        protected static ILogging Logger { get; } = Logging.GetLogger<User>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<User>();
     }
 
     [Serializable]

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
@@ -595,6 +595,6 @@ namespace GitHub.Unity
             }
         }
 
-        protected static ILogging Logger { get; } = Logging.GetLogger<RepositoryManager>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<RepositoryManager>();
     }
 }

--- a/src/GitHub.Api/IO/Utils.cs
+++ b/src/GitHub.Api/IO/Utils.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -14,7 +14,7 @@ namespace GitHub.Unity
             Func<long, long, bool> progress = null,
             int progressUpdateRate = 100)
         {
-            var logger = Logging.GetLogger("Copy");
+            var logger = LogHelper.GetLogger("Copy");
             byte[] buffer = new byte[chunkSize];
             int bytesRead = 0;
             long totalRead = 0;

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Threading;
 
@@ -60,7 +60,7 @@ namespace GitHub.Unity
 
     class GitInstaller
     {
-        private static ILogging Logger = Logging.GetLogger<GitInstaller>();
+        private static ILogging Logger = LogHelper.GetLogger<GitInstaller>();
 
         private readonly IEnvironment environment;
         private readonly IZipHelper sharpZipLibHelper;

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -6,13 +6,13 @@ using System.Timers;
 using System.Globalization;
 using System.Threading;
 using Timer = System.Threading.Timer;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace GitHub.Unity
 {
     class UsageTracker : IUsageTracker
     {
-        private static ILogging Logger { get; } = Logging.GetLogger<UsageTracker>();
+        private static ILogging Logger { get; } = LogHelper.GetLogger<UsageTracker>();
         private static IMetricsService metricsService;
 
         private readonly NPath storePath;

--- a/src/GitHub.Api/OutputProcessors/ProcessManager.cs
+++ b/src/GitHub.Api/OutputProcessors/ProcessManager.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -10,7 +10,7 @@ namespace GitHub.Unity
 {
     class ProcessManager : IProcessManager
     {
-        private static readonly ILogging logger = Logging.GetLogger<ProcessManager>();
+        private static readonly ILogging logger = LogHelper.GetLogger<ProcessManager>();
 
         private readonly IEnvironment environment;
         private readonly IProcessEnvironment gitEnvironment;

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.IO;
 using System.Linq;
@@ -190,6 +190,6 @@ namespace GitHub.Unity
             set { onMac = value; }
         }
         public string ExecutableExtension { get { return IsWindows ? ".exe" : null; } }
-        protected static ILogging Logger { get; } = Logging.GetLogger<DefaultEnvironment>();
+        protected static ILogging Logger { get; } = LogHelper.GetLogger<DefaultEnvironment>();
     }
 }

--- a/src/GitHub.Api/Platform/ProcessEnvironment.cs
+++ b/src/GitHub.Api/Platform/ProcessEnvironment.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -13,7 +13,7 @@ namespace GitHub.Unity
 
         public ProcessEnvironment(IEnvironment environment)
         {
-            Logger = Logging.GetLogger(GetType());
+            Logger = LogHelper.GetLogger(GetType());
             Environment = environment;
         }
 

--- a/src/GitHub.Api/Platform/Settings.cs
+++ b/src/GitHub.Api/Platform/Settings.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -34,7 +34,7 @@ namespace GitHub.Unity
 
         public JsonBackedSettings()
         {
-            logger = Logging.GetLogger(GetType());
+            logger = LogHelper.GetLogger(GetType());
             fileExists = (path) => File.Exists(path);
             readAllText = (path, encoding) => File.ReadAllText(path, encoding);
             writeAllText = (path, content) => File.WriteAllText(path, content);

--- a/src/GitHub.Api/Tasks/BaseOutputProcessor.cs
+++ b/src/GitHub.Api/Tasks/BaseOutputProcessor.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -34,7 +34,7 @@ namespace GitHub.Unity
         public virtual T Result { get; protected set; }
 
         private ILogging logger;
-        protected ILogging Logger { get { return logger = logger ?? Logging.GetLogger(GetType()); } }
+        protected ILogging Logger { get { return logger = logger ?? LogHelper.GetLogger(GetType()); } }
     }
 
     public abstract class BaseOutputProcessor<TData, T> : BaseOutputProcessor<T>, IOutputProcessor<TData, T>

--- a/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
+++ b/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
@@ -399,7 +399,7 @@ namespace GitHub.Unity
                 //}
                 //catch(Exception ex)
                 //{
-                //    Logging.Error(ex);
+                //    LogHelper.Error(ex);
                 //    throw;
                 //}
 

--- a/src/GitHub.Api/Tasks/ProcessTask.cs
+++ b/src/GitHub.Api/Tasks/ProcessTask.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -65,7 +65,7 @@ namespace GitHub.Unity
         public StreamWriter Input { get; private set; }
 
         private ILogging logger;
-        protected ILogging Logger { get { return logger = logger ?? Logging.GetLogger(GetType()); } }
+        protected ILogging Logger { get { return logger = logger ?? LogHelper.GetLogger(GetType()); } }
 
         public ProcessWrapper(Process process, IOutputProcessor outputProcessor,
             Action onStart, Action onEnd, Action<Exception, string> onError,

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -398,7 +398,7 @@ namespace GitHub.Unity
         public string Name { get; set; }
         public virtual TaskAffinity Affinity { get; set; }
         private ILogging logger;
-        protected ILogging Logger { get { return logger = logger ?? Logging.GetLogger(GetType()); } }
+        protected ILogging Logger { get { return logger = logger ?? LogHelper.GetLogger(GetType()); } }
         public TaskBase DependsOn { get; private set; }
         public CancellationToken Token { get; }
         internal TaskBase Continuation => continuation;

--- a/src/GitHub.Api/Tasks/TaskExtensions.cs
+++ b/src/GitHub.Api/Tasks/TaskExtensions.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,7 +34,7 @@ namespace GitHub.Unity
             }
             catch (Exception ex)
             {
-                Logging.GetLogger().Error(ex);
+                LogHelper.GetLogger().Error(ex);
                 if (handler == null)
                     throw;
                 handler(ex);
@@ -49,7 +49,7 @@ namespace GitHub.Unity
             }
             catch (Exception ex)
             {
-                Logging.GetLogger().Error(ex);
+                LogHelper.GetLogger().Error(ex);
                 if (handler == null)
                     throw;
                 return handler(ex);
@@ -64,7 +64,7 @@ namespace GitHub.Unity
             }
             catch (Exception ex)
             {
-                Logging.GetLogger().Error(ex);
+                LogHelper.GetLogger().Error(ex);
                 if (handler == null)
                     throw;
                 handler(ex);
@@ -79,7 +79,7 @@ namespace GitHub.Unity
             }
             catch (Exception ex)
             {
-                Logging.GetLogger().Error(ex);
+                LogHelper.GetLogger().Error(ex);
                 if (handler == null)
                     throw;
                 return handler(ex);

--- a/src/GitHub.Api/Tasks/TaskManager.cs
+++ b/src/GitHub.Api/Tasks/TaskManager.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,7 +7,7 @@ namespace GitHub.Unity
 {
     class TaskManager : ITaskManager
     {
-        private static readonly ILogging logger = Logging.GetLogger<TaskManager>();
+        private static readonly ILogging logger = LogHelper.GetLogger<TaskManager>();
 
         private CancellationTokenSource cts;
         private readonly ConcurrentExclusiveInterleave manager;

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +31,7 @@ namespace GitHub.Unity
 
         protected TreeBase()
         {
-            Logger = Logging.GetLogger(GetType());
+            Logger = LogHelper.GetLogger(GetType());
         }
 
         public abstract IEnumerable<string> GetCheckedFiles();

--- a/src/GitHub.Logging/ConsoleLogAdapter.cs
+++ b/src/GitHub.Logging/ConsoleLogAdapter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     class ConsoleLogAdapter : LogAdapterBase
     {

--- a/src/GitHub.Logging/Extensions/ExceptionExtensions.cs
+++ b/src/GitHub.Logging/Extensions/ExceptionExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     static class ExceptionExtensions
     {
@@ -17,7 +17,7 @@ namespace GitHub.Unity.Logs
             var caller = Environment.StackTrace;
             var stack = caller.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
             message += Environment.NewLine + "=======";
-            message += Environment.NewLine + String.Join(Environment.NewLine, stack.Skip(1).SkipWhile(x => x.Contains("GitHub.Unity.Logs")).ToArray());
+            message += Environment.NewLine + String.Join(Environment.NewLine, stack.Skip(1).SkipWhile(x => x.Contains("GitHub.Logging")).ToArray());
             return message;
         }
     }

--- a/src/GitHub.Logging/FileLogAdapter.cs
+++ b/src/GitHub.Logging/FileLogAdapter.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     class FileLogAdapter : LogAdapterBase
     {

--- a/src/GitHub.Logging/GitHub.Logging.csproj
+++ b/src/GitHub.Logging/GitHub.Logging.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{BB6A8EDA-15D8-471B-A6ED-EE551E0B3BA0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>GitHub.Unity</RootNamespace>
+    <RootNamespace>GitHub.Logging</RootNamespace>
     <AssemblyName>GitHub.Logging</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -62,8 +62,9 @@
     <Compile Include="ILogging.cs" />
     <Compile Include="LogAdapterBase.cs" />
     <Compile Include="LogFacade.cs" />
-    <Compile Include="Logging.cs" />
+    <Compile Include="LogHelper.cs" />
     <Compile Include="MultipleLogAdapter.cs" />
+    <Compile Include="NullLogAdapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="$(SolutionDir)common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>

--- a/src/GitHub.Logging/ILogging.cs
+++ b/src/GitHub.Logging/ILogging.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     public interface ILogging
     {

--- a/src/GitHub.Logging/LogAdapterBase.cs
+++ b/src/GitHub.Logging/LogAdapterBase.cs
@@ -1,4 +1,4 @@
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     public abstract class LogAdapterBase
     {

--- a/src/GitHub.Logging/LogFacade.cs
+++ b/src/GitHub.Logging/LogFacade.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     class LogFacade : ILogging
     {
@@ -13,20 +13,20 @@ namespace GitHub.Unity.Logs
 
         public void Info(string message)
         {
-            Logging.LogAdapter.Info(context, message);
+            LogHelper.LogAdapter.Info(context, message);
         }
 
         public void Debug(string message)
         {
 #if DEBUG
-            Logging.LogAdapter.Debug(context, message);
+            LogHelper.LogAdapter.Debug(context, message);
 #endif
         }
 
         public void Trace(string message)
         {
-            if (!Logging.TracingEnabled) return;
-            Logging.LogAdapter.Trace(context, message);
+            if (!LogHelper.TracingEnabled) return;
+            LogHelper.LogAdapter.Trace(context, message);
         }
 
         public void Info(string format, params object[] objects)
@@ -79,35 +79,35 @@ namespace GitHub.Unity.Logs
 
         public void Trace(string format, params object[] objects)
         {
-            if (!Logging.TracingEnabled) return;
+            if (!LogHelper.TracingEnabled) return;
 
             Trace(String.Format(format, objects));
         }
 
         public void Trace(Exception ex, string message)
         {
-            if (!Logging.TracingEnabled) return;
+            if (!LogHelper.TracingEnabled) return;
 
             Trace(String.Concat(message, Environment.NewLine, ex.GetExceptionMessage()));
         }
 
         public void Trace(Exception ex)
         {
-            if (!Logging.TracingEnabled) return;
+            if (!LogHelper.TracingEnabled) return;
 
             Trace(ex, string.Empty);
         }
 
         public void Trace(Exception ex, string format, params object[] objects)
         {
-            if (!Logging.TracingEnabled) return;
+            if (!LogHelper.TracingEnabled) return;
 
             Trace(ex, String.Format(format, objects));
         }
 
         public void Warning(string message)
         {
-            Logging.LogAdapter.Warning(context, message);
+            LogHelper.LogAdapter.Warning(context, message);
         }
 
         public void Warning(string format, params object[] objects)
@@ -132,7 +132,7 @@ namespace GitHub.Unity.Logs
 
         public void Error(string message)
         {
-            Logging.LogAdapter.Error(context, message);
+            LogHelper.LogAdapter.Error(context, message);
         }
 
         public void Error(string format, params object[] objects)

--- a/src/GitHub.Logging/LogHelper.cs
+++ b/src/GitHub.Logging/LogHelper.cs
@@ -1,31 +1,8 @@
 using System;
 
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
-    class NullLogAdapter : LogAdapterBase
-    {
-        public override void Info(string context, string message)
-        {
-        }
-
-        public override void Debug(string context, string message)
-        {
-        }
-
-        public override void Trace(string context, string message)
-        {
-        }
-
-        public override void Warning(string context, string message)
-        {
-        }
-
-        public override void Error(string context, string message)
-        {
-        }
-    }
-
-    public static class Logging
+    public static class LogHelper
     {
         private static readonly LogAdapterBase nullLogAdapter = new NullLogAdapter();
 

--- a/src/GitHub.Logging/MultipleLogAdapter.cs
+++ b/src/GitHub.Logging/MultipleLogAdapter.cs
@@ -1,4 +1,4 @@
-namespace GitHub.Unity.Logs
+namespace GitHub.Logging
 {
     class MultipleLogAdapter : LogAdapterBase
     {

--- a/src/GitHub.Logging/NullLogAdapter.cs
+++ b/src/GitHub.Logging/NullLogAdapter.cs
@@ -1,0 +1,25 @@
+namespace GitHub.Logging
+{
+    class NullLogAdapter : LogAdapterBase
+    {
+        public override void Info(string context, string message)
+        {
+        }
+
+        public override void Debug(string context, string message)
+        {
+        }
+
+        public override void Trace(string context, string message)
+        {
+        }
+
+        public override void Warning(string context, string message)
+        {
+        }
+
+        public override void Error(string context, string message)
+        {
+        }
+    }
+}

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -128,7 +128,7 @@ namespace GitHub.Unity
         protected ManagedCacheBase(bool invalidOnFirstRun)
         {
             this.invalidOnFirstRun = invalidOnFirstRun;
-            Logger = Logging.GetLogger(GetType());
+            Logger = LogHelper.GetLogger(GetType());
         }
 
         public void ValidateData()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/CacheContainer.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/CacheContainer.cs
@@ -1,11 +1,11 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 
 namespace GitHub.Unity
 {
     public class CacheContainer : ICacheContainer
     {
-        private static ILogging Logger = Logging.GetLogger<CacheContainer>();
+        private static ILogging Logger = LogHelper.GetLogger<CacheContainer>();
 
         private IRepositoryInfoCache repositoryInfoCache;
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.IO;
 using System.Net;
@@ -22,7 +22,7 @@ namespace GitHub.Unity
                 return;
             }
 
-            Logging.LogAdapter = new FileLogAdapter(tempEnv.LogPath);
+            LogHelper.LogAdapter = new FileLogAdapter(tempEnv.LogPath);
 
             ServicePointManager.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
             EditorApplication.update += Initialize;
@@ -56,14 +56,14 @@ namespace GitHub.Unity
                 }
                 catch (Exception ex)
                 {
-                    Logging.Error(ex, "Error rotating log files");
+                    LogHelper.Error(ex, "Error rotating log files");
                 }
 
                 Debug.LogFormat("Initialized GitHub for Unity version {0}{1}Log file: {2}", ApplicationInfo.Version, Environment.NewLine, logPath);
             }
 
-            Logging.LogAdapter = new FileLogAdapter(logPath);
-            Logging.Info("Initializing GitHub for Unity version " + ApplicationInfo.Version);
+            LogHelper.LogAdapter = new FileLogAdapter(logPath);
+            LogHelper.Info("Initializing GitHub for Unity version " + ApplicationInfo.Version);
 
             ApplicationManager.Run(ApplicationCache.Instance.FirstRun);
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Logging/UnityLogAdapter.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Logging/UnityLogAdapter.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Threading;
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Installer.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Installer.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using UnityEditor;
 using UnityEngine;
@@ -7,7 +7,7 @@ namespace GitHub.Unity
 {
     class Installer : ScriptableObject
     {
-        private static readonly ILogging logger = Logging.GetLogger<Installer>();
+        private static readonly ILogging logger = LogHelper.GetLogger<Installer>();
 
         private const string PackageName = "GitHub extensions";
         private const string QueryTitle = "Embed " + PackageName + "?";

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.IO;
 using System.Linq;
@@ -94,7 +94,7 @@ namespace GitHub.Unity
 
             if (loadImage == null)
             {
-                Logging.Error("Could not find ImageConversion.LoadImage method");
+                LogHelper.Error("Could not find ImageConversion.LoadImage method");
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Linq;
 using UnityEditorInternal;
@@ -66,7 +66,7 @@ namespace GitHub.Unity
         {
             if (instance != null)
             {
-                Logging.Instance.Error("Singleton already exists!");
+                LogHelper.Instance.Error("Singleton already exists!");
             }
             else
             {
@@ -99,7 +99,7 @@ namespace GitHub.Unity
         {
             if (instance == null)
             {
-                Logging.Instance.Error("Cannot save singleton, no instance!");
+                LogHelper.Instance.Error("Cannot save singleton, no instance!");
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace GitHub.Unity
             var attr = typeof(T).GetCustomAttributes(true)
                                 .Select(t => t as LocationAttribute)
                                 .FirstOrDefault(t => t != null);
-            //Logging.Instance.Debug("FilePath {0}", attr != null ? attr.filepath : null);
+            //LogHelper.Instance.Debug("FilePath {0}", attr != null ? attr.filepath : null);
 
             return attr != null ? attr.filepath.ToNPath() : null;
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using UnityEditor;
 using UnityEngine;
@@ -135,7 +135,7 @@ namespace GitHub.Unity
             get
             {
                 if (logger == null)
-                    logger = Logging.GetLogger(GetType());
+                    logger = LogHelper.GetLogger(GetType());
                 return logger;
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,7 +19,7 @@ namespace GitHub.Unity
         private static IRepository repository;
         private static bool isBusy = false;
         private static ILogging logger;
-        private static ILogging Logger { get { return logger = logger ?? Logging.GetLogger<ProjectWindowInterface>(); } }
+        private static ILogging Logger { get { return logger = logger ?? LogHelper.GetLogger<ProjectWindowInterface>(); } }
         private static CacheUpdateEvent lastRepositoryStatusChangedEvent;
         private static CacheUpdateEvent lastLocksChangedEvent;
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -326,7 +326,7 @@ namespace GitHub.Unity
 
             EditorGUI.BeginDisabledGroup(IsBusy);
             {
-                var traceLogging = Logging.TracingEnabled;
+                var traceLogging = LogHelper.TracingEnabled;
 
                 EditorGUI.BeginChangeCheck();
                 {
@@ -334,7 +334,7 @@ namespace GitHub.Unity
                 }
                 if (EditorGUI.EndChangeCheck())
                 {
-                    Logging.TracingEnabled = traceLogging;
+                    LogHelper.TracingEnabled = traceLogging;
                     Manager.UserSettings.Set(Constants.TraceLoggingKey, traceLogging);
                 }
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using UnityEngine;
 
@@ -75,7 +75,7 @@ namespace GitHub.Unity
             get
             {
                 if (logger == null)
-                    logger = Logging.GetLogger(GetType());
+                    logger = LogHelper.GetLogger(GetType());
                 return logger;
             }
         }

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -5,7 +5,7 @@ using GitHub.Unity;
 using NCrunch.Framework;
 using System.Threading;
 using NSubstitute;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace IntegrationTests
 {
@@ -39,7 +39,7 @@ namespace IntegrationTests
         [TestFixtureSetUp]
         public virtual void TestFixtureSetUp()
         {
-            Logger = Logging.GetLogger(GetType());
+            Logger = LogHelper.GetLogger(GetType());
             Factory = new TestUtils.SubstituteFactory();
             GitHub.Unity.Guard.InUnitTestRunner = true;
         }

--- a/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
+++ b/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
@@ -6,7 +6,7 @@ using FluentAssertions;
 using GitHub.Unity;
 using NUnit.Framework;
 using System.Diagnostics;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System.Runtime.CompilerServices;
 
 namespace IntegrationTests.Download
@@ -41,7 +41,7 @@ namespace IntegrationTests.Download
         private void StartTest(out Stopwatch watch, out ILogging logger, [CallerMemberName] string testName = "test")
         {
             watch = new Stopwatch();
-            logger = Logging.GetLogger(testName);
+            logger = LogHelper.GetLogger(testName);
             logger.Trace("Starting test");
         }
 

--- a/src/tests/IntegrationTests/Events/RepositoryWatcherTests.cs
+++ b/src/tests/IntegrationTests/Events/RepositoryWatcherTests.cs
@@ -6,7 +6,7 @@ using NSubstitute;
 using NUnit.Framework;
 using TestUtils;
 using System.Threading.Tasks;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace IntegrationTests
 {
@@ -499,7 +499,7 @@ namespace IntegrationTests
     {
         public static void AttachListener(this IRepositoryWatcherListener listener, IRepositoryWatcher repositoryWatcher, RepositoryWatcherAutoResetEvent autoResetEvent = null, bool trace = false)
         {
-            var logger = trace ? Logging.GetLogger<IRepositoryWatcherListener>() : null;
+            var logger = trace ? LogHelper.GetLogger<IRepositoryWatcherListener>() : null;
 
             repositoryWatcher.HeadChanged += () =>
             {

--- a/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
@@ -1,12 +1,12 @@
 using System;
 using GitHub.Unity;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace IntegrationTests
 {
     class IntegrationTestEnvironment : IEnvironment
     {
-        private static readonly ILogging logger = Logging.GetLogger<IntegrationTestEnvironment>();
+        private static readonly ILogging logger = LogHelper.GetLogger<IntegrationTestEnvironment>();
         private readonly bool enableTrace;
 
         private readonly NPath integrationTestEnvironmentPath;

--- a/src/tests/IntegrationTests/SetUpFixture.cs
+++ b/src/tests/IntegrationTests/SetUpFixture.cs
@@ -1,7 +1,7 @@
 using System;
 using GitHub.Unity;
 using NUnit.Framework;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace IntegrationTests
 {
@@ -11,9 +11,9 @@ namespace IntegrationTests
         [SetUp]
         public void Setup()
         {
-            Logging.TracingEnabled = true;
+            LogHelper.TracingEnabled = true;
 
-            Logging.LogAdapter = new MultipleLogAdapter(
+            LogHelper.LogAdapter = new MultipleLogAdapter(
                 new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-integration-tests.log")
                 //, new ConsoleLogAdapter()
             );

--- a/src/tests/IntegrationTests/ThreadSynchronizationContext.cs
+++ b/src/tests/IntegrationTests/ThreadSynchronizationContext.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -89,7 +89,7 @@ namespace GitHub.Unity
             }
             if (queue.TryDequeue(out data))
             {
-                Logging.GetLogger<ThreadSynchronizationContext>().Trace($"Running {data.Id} on main thread");
+                LogHelper.GetLogger<ThreadSynchronizationContext>().Trace($"Running {data.Id} on main thread");
                 data.Run();
             }
         }

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -8,7 +8,7 @@ using GitHub.Unity;
 using System.Threading.Tasks.Schedulers;
 using System.IO;
 using NSubstitute;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace IntegrationTests
 {
@@ -16,7 +16,7 @@ namespace IntegrationTests
     {
         public BaseTest()
         {
-            Logger = Logging.GetLogger(GetType());
+            Logger = LogHelper.GetLogger(GetType());
         }
 
         protected ILogging Logger { get; }
@@ -31,8 +31,8 @@ namespace IntegrationTests
         public void OneTimeSetup()
         {
             GitHub.Unity.Guard.InUnitTestRunner = true;
-            Logging.LogAdapter = new MultipleLogAdapter(new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-tasksystem-tests.log"));
-            //Logging.TracingEnabled = true;
+            LogHelper.LogAdapter = new MultipleLogAdapter(new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-tasksystem-tests.log"));
+            //LogHelper.TracingEnabled = true;
             TaskManager = new TaskManager();
             var syncContext = new ThreadSynchronizationContext(Token);
             TaskManager.UIScheduler = new SynchronizationContextTaskScheduler(syncContext);

--- a/src/tests/TaskSystemIntegrationTests/ThreadSynchronizationContext.cs
+++ b/src/tests/TaskSystemIntegrationTests/ThreadSynchronizationContext.cs
@@ -1,4 +1,4 @@
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -90,7 +90,7 @@ namespace GitHub.Unity
             }
             if (queue.TryDequeue(out data))
             {
-                Logging.GetLogger<ThreadSynchronizationContext>().Trace($"Running {data.Id} on main thread");
+                LogHelper.GetLogger<ThreadSynchronizationContext>().Trace($"Running {data.Id} on main thread");
                 data.Run();
             }
         }

--- a/src/tests/TestUtils/Events/IRepositoryListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryListener.cs
@@ -18,7 +18,7 @@ namespace TestUtils.Events
         public static void AttachListener(this IRepositoryListener listener,
             IRepository repository, RepositoryEvents repositoryEvents = null, bool trace = true)
         {
-            //var logger = trace ? Logging.GetLogger<IRepositoryListener>() : null;
+            //var logger = trace ? LogHelper.GetLogger<IRepositoryListener>() : null;
         }
 
         public static void AssertDidNotReceiveAnyCalls(this IRepositoryListener repositoryListener)

--- a/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
+++ b/src/tests/TestUtils/Events/IRepositoryManagerListener.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using GitHub.Unity;
 using NSubstitute;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace TestUtils.Events
 {
@@ -57,7 +57,7 @@ namespace TestUtils.Events
         public static void AttachListener(this IRepositoryManagerListener listener,
             IRepositoryManager repositoryManager, RepositoryManagerEvents managerEvents = null, bool trace = true)
         {
-            var logger = trace ? Logging.GetLogger<IRepositoryManagerListener>() : null;
+            var logger = trace ? LogHelper.GetLogger<IRepositoryManagerListener>() : null;
 
             repositoryManager.IsBusyChanged += isBusy => {
                 logger?.Trace("OnIsBusyChanged: {0}", isBusy);

--- a/src/tests/TestUtils/Substitutes/SubstituteFactory.cs
+++ b/src/tests/TestUtils/Substitutes/SubstituteFactory.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using GitHub.Unity;
 using NSubstitute;
 using System.Threading;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace TestUtils
 {
@@ -38,7 +38,7 @@ namespace TestUtils
 
             var fileSystem = Substitute.For<IFileSystem>();
             var realFileSystem = new FileSystem();
-            var logger = Logging.GetLogger("TestFileSystem");
+            var logger = LogHelper.GetLogger("TestFileSystem");
 
             fileSystem.DirectorySeparatorChar.Returns(realFileSystem.DirectorySeparatorChar);
             fileSystem.GetCurrentDirectory().Returns(createFileSystemOptions.CurrentDirectory);
@@ -347,7 +347,7 @@ namespace TestUtils
         public IGitClient CreateRepositoryProcessRunner(
             CreateRepositoryProcessRunnerOptions options = null)
         {
-            var logger = Logging.GetLogger("TestRepositoryProcessRunner");
+            var logger = LogHelper.GetLogger("TestRepositoryProcessRunner");
 
             options = options ?? new CreateRepositoryProcessRunnerOptions();
 

--- a/src/tests/TestWebServer/HttpServer.cs
+++ b/src/tests/TestWebServer/HttpServer.cs
@@ -1,5 +1,4 @@
-﻿using GitHub.Unity;
-using GitHub.Unity.Logs;
+﻿using GitHub.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -24,7 +23,7 @@ namespace TestWebServer
         private readonly HttpListener listener;
         private readonly string rootDirectory;
         private bool abort;
-        private static ILogging Logger = Logging.GetLogger<HttpServer>();
+        private static ILogging Logger = LogHelper.GetLogger<HttpServer>();
         private ManualResetEvent delay = new ManualResetEvent(false);
 
         /// <summary>
@@ -181,7 +180,7 @@ namespace TestWebServer
             }
             catch (Exception ex)
             {
-                Logging.GetLogger<HttpServer>().Error(ex);
+                LogHelper.GetLogger<HttpServer>().Error(ex);
                 context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
             }
             finally

--- a/src/tests/UnitTests/SetUpFixture.cs
+++ b/src/tests/UnitTests/SetUpFixture.cs
@@ -1,7 +1,7 @@
 using System;
 using GitHub.Unity;
 using NUnit.Framework;
-using GitHub.Unity.Logs;
+using GitHub.Logging;
 
 namespace UnitTests
 {
@@ -11,9 +11,9 @@ namespace UnitTests
         [SetUp]
         public void SetUp()
         {
-            Logging.TracingEnabled = true;
+            LogHelper.TracingEnabled = true;
 
-            Logging.LogAdapter = new MultipleLogAdapter(
+            LogHelper.LogAdapter = new MultipleLogAdapter(
                 new FileLogAdapter($"..\\{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}-unit-tests.log")
                 //, new ConsoleLogAdapter()
             );


### PR DESCRIPTION
Set namespace of GitHub.Logging to match assembly name, and rename `Logging` static class to `LogHelper` to avoid conflicts