### PR TITLE
Add .editorconfig with whitespace definition

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Makes VS 2017 magically not screw up whitespace, which is nice.