### PR TITLE
Download portable git zip files to a known location

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -72,8 +72,7 @@ namespace GitHub.Unity
                         }
                     });
 
-                var applicationDataPath = Environment.GetSpecialFolder(System.Environment.SpecialFolder.LocalApplicationData).ToNPath();
-                var installDetails = new GitInstallDetails(applicationDataPath, true);
+                var installDetails = new GitInstallDetails(Environment.UserCachePath, true);
                 var gitInstaller = new GitInstaller(Environment, CancellationToken, installDetails);
 
                 // if successful, continue with environment initialization, otherwise try to find an existing git installation

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -24,10 +24,13 @@ namespace GitHub.Unity
 
         private readonly bool onWindows;
 
-        public GitInstallDetails(NPath targetInstallPath, bool onWindows)
+        public GitInstallDetails(NPath applicationDataPath, bool onWindows)
         {
             this.onWindows = onWindows;
-            var gitInstallPath = targetInstallPath.Combine(ApplicationInfo.ApplicationName, PackageNameWithVersion);
+
+            PluginDataPath = applicationDataPath.Combine(ApplicationInfo.ApplicationName);
+
+            var gitInstallPath = PluginDataPath.Combine(PackageNameWithVersion);
             GitInstallationPath = gitInstallPath;
 
             if (onWindows)
@@ -55,6 +58,7 @@ namespace GitHub.Unity
                 : gitInstallRoot.Combine("libexec", "git-core", GitLfsExecutable);
         }
 
+        public NPath PluginDataPath { get; }
         public NPath GitInstallationPath { get; }
         public string GitExecutable { get; }
         public NPath GitExecutablePath { get; }
@@ -177,21 +181,20 @@ namespace GitHub.Unity
 
         private ITask CreateDownloadTask()
         {
-            var tempZipPath = NPath.CreateTempDirectory("git_zip_paths");
-            gitArchiveFilePath = tempZipPath.Combine("git.zip");
-            gitLfsArchivePath = tempZipPath.Combine("git-lfs.zip");
+            gitArchiveFilePath = installDetails.PluginDataPath.Combine("git.zip");
+            gitLfsArchivePath = installDetails.PluginDataPath.Combine("git-lfs.zip");
 
             var downloadGitMd5Task = new DownloadTextTask(TaskManager.Instance.Token, environment.FileSystem,
-                installDetails.GitZipMd5Url, tempZipPath);
+                installDetails.GitZipMd5Url, installDetails.PluginDataPath);
 
             var downloadGitTask = new DownloadTask(TaskManager.Instance.Token, environment.FileSystem,
-                installDetails.GitZipUrl, tempZipPath);
+                installDetails.GitZipUrl, installDetails.PluginDataPath);
 
             var downloadGitLfsMd5Task = new DownloadTextTask(TaskManager.Instance.Token, environment.FileSystem,
-                installDetails.GitLfsZipMd5Url, tempZipPath);
+                installDetails.GitLfsZipMd5Url, installDetails.PluginDataPath);
 
             var downloadGitLfsTask = new DownloadTask(TaskManager.Instance.Token, environment.FileSystem,
-                installDetails.GitLfsZipUrl, tempZipPath);
+                installDetails.GitLfsZipUrl, installDetails.PluginDataPath);
 
             return
                 downloadGitMd5Task.Then((b, s) => { downloadGitTask.ValidationHash = s; })

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -25,11 +25,11 @@ namespace GitHub.Unity
 
         private readonly bool onWindows;
 
-        public GitInstallDetails(NPath applicationDataPath, bool onWindows)
+        public GitInstallDetails(NPath pluginDataPath, bool onWindows)
         {
             this.onWindows = onWindows;
 
-            PluginDataPath = applicationDataPath.Combine(ApplicationInfo.ApplicationName);
+            PluginDataPath = pluginDataPath;
 
             var gitInstallPath = PluginDataPath.Combine(PackageNameWithVersion);
             GitInstallationPath = gitInstallPath;

--- a/src/GitHub.Api/Tasks/DownloadTask.cs
+++ b/src/GitHub.Api/Tasks/DownloadTask.cs
@@ -99,30 +99,53 @@ namespace GitHub.Unity
                 {
                     Logger.Trace($"Download of {Url} to {Destination} Attempt {attempts + 1} of {RetryCount + 1}");
 
-                    using (var destinationStream = fileSystem.OpenWrite(Destination, FileMode.Append))
+                    var fileExistsAndValid = false;
+                    if (Destination.FileExists())
                     {
-                        result = Utils.Download(Logger, Url, destinationStream,
-                            (value, total) =>
-                            {
-                                UpdateProgress(value, total);
-                                return !Token.IsCancellationRequested;
-                            });
-                    }
-
-                    if (result && ValidationHash != null)
-                    {
-                        var md5 = fileSystem.CalculateFileMD5(TargetDirectory);
-                        result = md5.Equals(ValidationHash, StringComparison.CurrentCultureIgnoreCase);
-
-                        if (!result)
+                        if (ValidationHash == null)
                         {
-                            Logger.Warning($"Downloaded MD5 {md5} does not match {ValidationHash}. Deleting {TargetDirectory}.");
-                            fileSystem.FileDelete(TargetDirectory);
+                            Destination.Delete();
                         }
                         else
                         {
-                            Logger.Trace($"Download confirmed {md5}");
-                            break;
+                            var md5 = fileSystem.CalculateFileMD5(Destination);
+                            result = md5.Equals(ValidationHash, StringComparison.CurrentCultureIgnoreCase);
+
+                            if (result)
+                            {
+                                Logger.Trace($"Download previously exists & confirmed {md5}");
+                                fileExistsAndValid = true;
+                            }
+                        }
+                    }
+
+                    if (!fileExistsAndValid)
+                    {
+                        using (var destinationStream = fileSystem.OpenWrite(Destination, FileMode.Append))
+                        {
+                            result = Utils.Download(Logger, Url, destinationStream,
+                                (value, total) =>
+                                {
+                                    UpdateProgress(value, total);
+                                    return !Token.IsCancellationRequested;
+                                });
+                        }
+
+                        if (result && ValidationHash != null)
+                        {
+                            var md5 = fileSystem.CalculateFileMD5(Destination);
+                            result = md5.Equals(ValidationHash, StringComparison.CurrentCultureIgnoreCase);
+
+                            if (!result)
+                            {
+                                Logger.Warning($"Downloaded MD5 {md5} does not match {ValidationHash}. Deleting {Destination}.");
+                                fileSystem.FileDelete(TargetDirectory);
+                            }
+                            else
+                            {
+                                Logger.Trace($"Download confirmed {md5}");
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Moving downloaded zip files to the AppData folder 
- Preventing download of a file when it exists

Currently, the DownloadTask will download and append to a file, even if it already exists and
passes MD5.

In order to fix this:
- Check if the file exists
 - If there is no validation hash delete the file
 - If there is a validation hash, check if it matches, if so bypass the
 downloading an additional check