### PR TITLE
Build octorun before anything else in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,9 @@ install:
 
     nuget restore GitHub.Unity.sln
 
+before_build:
+  - cmd: msbuild GitHub.Unity.sln /target:OctoRun /Configuration:Release
+
 assembly_info:
   patch: false
   file: common\SolutionInfo.cs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
     nuget restore GitHub.Unity.sln
 
 before_build:
-  - cmd: msbuild GitHub.Unity.sln /target:OctoRun /Configuration:Release
+  - cmd: msbuild GitHub.Unity.sln /target:OctoRun /property:Configuration=Release
 
 assembly_info:
   patch: false


### PR DESCRIPTION
OctoRun needs to be built before the rest of the projects and currently it's not set as a build dependency, so build it manually.