### PR TITLE
GitInstaller should prefer local resources before downloading

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -72,9 +72,22 @@ namespace GitHub.Unity
                         }
                     });
 
+                var archiveParentPath = NPath.CreateTempDirectory("git_zip_paths");
+                var gitArchiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", archiveParentPath, Environment);
+                if (!gitArchiveFilePath.FileExists())
+                {
+                    gitArchiveFilePath = null;
+                }
+
+                var gitLfsArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", archiveParentPath, Environment);
+                if (!gitLfsArchivePath.FileExists())
+                {
+                    gitLfsArchivePath = null;
+                }
+
                 var applicationDataPath = Environment.GetSpecialFolder(System.Environment.SpecialFolder.LocalApplicationData).ToNPath();
                 var installDetails = new GitInstallDetails(applicationDataPath, true);
-                var gitInstaller = new GitInstaller(Environment, CancellationToken, installDetails);
+                var gitInstaller = new GitInstaller(Environment, CancellationToken, installDetails, gitArchiveFilePath, gitLfsArchivePath);
 
                 // if successful, continue with environment initialization, otherwise try to find an existing git installation
                 gitInstaller.SetupGitIfNeeded(initEnvironmentTask, findExecTask);

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -135,24 +135,6 @@ namespace GitHub.Unity
             {
                 archiveParentPath = NPath.CreateTempDirectory("git_zip_paths");
 
-                if (gitArchiveFilePath == null)
-                {
-                    gitArchiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", archiveParentPath, environment);
-                    if (!gitArchiveFilePath.FileExists())
-                    {
-                        gitArchiveFilePath = null;
-                    }
-                }
-
-                if (gitLfsArchivePath == null)
-                {
-                    gitLfsArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", archiveParentPath, environment);
-                    if (!gitLfsArchivePath.FileExists())
-                    {
-                        gitLfsArchivePath = null;
-                    }
-                }
-
                 var downloadGit = false;
                 var downloadGitLfs = false;
 


### PR DESCRIPTION
- Added functionality to `GitInstaller` to check locally for git and git lfs zip files
- If one or both are found the `GitInstaller` will download the respective files
- Afterwards it resumes as expected.