### PR TITLE
Task/Cache Jenga 2: Fixing initialization and git installation and other fixes

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -247,7 +247,7 @@ namespace GitHub.Unity
         public ISettings SystemSettings { get; protected set; }
         public ISettings UserSettings { get; protected set; }
         public IUsageTracker UsageTracker { get; protected set; }
-        public bool IsBusy { get { return isBusy || RepositoryManager.IsBusy; } }
+        public bool IsBusy { get { return isBusy || (RepositoryManager?.IsBusy ?? false); } }
         protected TaskScheduler UIScheduler { get; private set; }
         protected SynchronizationContext SynchronizationContext { get; private set; }
         protected IRepositoryManager RepositoryManager { get { return repositoryManager; } }

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -150,6 +150,7 @@ namespace GitHub.Unity
                 repositoryManager.Initialize();
                 Environment.Repository.Initialize(repositoryManager);
                 repositoryManager.Start();
+                Environment.Repository.Start();
                 Logger.Trace($"Got a repository? {Environment.Repository}");
             }
         }

--- a/src/GitHub.Api/Application/IApplicationManager.cs
+++ b/src/GitHub.Api/Application/IApplicationManager.cs
@@ -17,9 +17,10 @@ namespace GitHub.Unity
         ITaskManager TaskManager { get; }
         IGitClient GitClient { get; }
         IUsageTracker UsageTracker { get; }
-
+        bool IsBusy { get; }
         void Run(bool firstRun);
         void RestartRepository();
         ITask InitializeRepository();
+        event Action<IProgress> OnProgress;
     }
 }

--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -84,7 +84,7 @@ namespace GitHub.Unity
     public interface IBranchCache : IManagedCache
     {
         ConfigRemote? CurrentConfigRemote { get; set; }
-        ConfigBranch? CurentConfigBranch { get; set; }
+        ConfigBranch? CurrentConfigBranch { get; set; }
         
         GitBranch[] LocalBranches { get; set; }
         GitBranch[] RemoteBranches { get; set; }
@@ -105,7 +105,7 @@ namespace GitHub.Unity
     public interface IRepositoryInfoCache : IManagedCache
     {
         GitRemote? CurrentGitRemote { get; set; }
-        GitBranch? CurentGitBranch { get; set; }
+        GitBranch? CurrentGitBranch { get; set; }
     }
 
     public interface IGitLogCache : IManagedCache

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -169,12 +169,6 @@ namespace GitHub.Unity
                 var eventDirectory = new NPath(fileEvent.Directory);
                 var fileA = eventDirectory.Combine(fileEvent.FileA);
 
-                NPath fileB = null;
-                if (fileEvent.FileB != null)
-                {
-                    fileB = eventDirectory.Combine(fileEvent.FileB);
-                }
-
                 // handling events in .git/*
                 if (fileA.IsChildOf(paths.DotGitPath))
                 {

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -78,5 +78,6 @@ namespace GitHub.Unity
         event Action<CacheUpdateEvent> LocksChanged;
         event Action<CacheUpdateEvent> RemoteBranchListChanged;
         event Action<CacheUpdateEvent> LocalAndRemoteBranchListChanged;
+        void Start();
     }
 }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -523,8 +523,8 @@ namespace GitHub.Unity
 
         private ConfigBranch? CurrentConfigBranch
         {
-            get { return this.cacheContainer.BranchCache.CurentConfigBranch; }
-            set { cacheContainer.BranchCache.CurentConfigBranch = value; }
+            get { return this.cacheContainer.BranchCache.CurrentConfigBranch; }
+            set { cacheContainer.BranchCache.CurrentConfigBranch = value; }
         }
 
         private ConfigRemote? CurrentConfigRemote
@@ -553,8 +553,8 @@ namespace GitHub.Unity
 
         public GitBranch? CurrentBranch
         {
-            get { return cacheContainer.RepositoryInfoCache.CurentGitBranch; }
-            private set { cacheContainer.RepositoryInfoCache.CurentGitBranch = value; }
+            get { return cacheContainer.RepositoryInfoCache.CurrentGitBranch; }
+            private set { cacheContainer.RepositoryInfoCache.CurrentGitBranch = value; }
         }
 
         public string CurrentBranchName => CurrentConfigBranch?.Name;

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -298,6 +298,7 @@ namespace GitHub.Unity
                     break;
 
                 case CacheType.RepositoryInfoCache:
+                    repositoryManager?.UpdateRepositoryInfo();
                     break;
 
                 case CacheType.GitStatusEntriesCache:

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -332,10 +332,9 @@ namespace GitHub.Unity
                     if (itemsToRevert.Any())
                     {
                         gitDiscardTask = GitClient.Discard(itemsToRevert);
-                        task
-                            .Then(gitDiscardTask)
-                            // we're appending a new continuation, we need to reset the finally handler
-                            // so it runs after the discard task
+                        task.Then(gitDiscardTask)
+                            // we're appending a new continuation after HookupHandlers has run,
+                            // we need to set the finally handler manually so it runs at the end of everything
                             .Finally(s =>
                             {
                                 watcher.Start();

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -379,7 +379,7 @@ namespace GitHub.Unity
         public void UpdateLocks()
         {
             GitClient.ListLocks(false)
-                .Finally((success, locks) =>
+                .Then((success, locks) =>
                 {
                     if (success)
                     {

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -42,11 +42,11 @@ namespace GitHub.Unity
         void UpdateGitAheadBehindStatus();
         void UpdateLocks();
         int WaitForEvents();
+        void UpdateRepositoryInfo();
 
         IGitConfig Config { get; }
         IGitClient GitClient { get; }
         bool IsBusy { get; }
-        void UpdateRepositoryInfo();
     }
 
     interface IRepositoryPathConfiguration
@@ -400,7 +400,7 @@ namespace GitHub.Unity
             var isExclusive = task.IsChainExclusive();
             task.GetTopOfChain().OnStart += t =>
             {
-                if (t.Affinity == TaskAffinity.Exclusive)
+                if (isExclusive)
                 {
                     Logger.Trace("Starting Operation - Setting Busy Flag");
                     IsBusy = true;

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -46,6 +46,7 @@ namespace GitHub.Unity
         IGitConfig Config { get; }
         IGitClient GitClient { get; }
         bool IsBusy { get; }
+        void UpdateRepositoryInfo();
     }
 
     interface IRepositoryPathConfiguration
@@ -443,7 +444,7 @@ namespace GitHub.Unity
         private void UpdateHead()
         {
             Logger.Trace("UpdateHead");
-            UpdateCurrentBranchAndRemote();
+            UpdateRepositoryInfo();
             UpdateGitLog();
         }
 
@@ -452,7 +453,7 @@ namespace GitHub.Unity
             return repositoryPaths.DotGitHead.ReadAllLines().FirstOrDefault();
         }
 
-        private void UpdateCurrentBranchAndRemote()
+        public void UpdateRepositoryInfo()
         {
             ConfigBranch? branch;
             ConfigRemote? remote;

--- a/src/GitHub.Api/Helpers/Progress.cs
+++ b/src/GitHub.Api/Helpers/Progress.cs
@@ -1,3 +1,4 @@
+using GitHub.Logging;
 using System;
 
 namespace GitHub.Unity
@@ -11,25 +12,41 @@ namespace GitHub.Unity
         float Percentage { get; }
         long Value { get; }
         long Total { get; }
+        string Message { get; }
+        event Action<IProgress> OnProgress;
     }
 
     public class Progress : IProgress
     {
+        private static ILogging Logger = LogHelper.GetLogger<Progress>(); 
         public ITask Task { get; internal set; }
         public float Percentage { get { return Total > 0 ? (float)(double)Value / Total : 0f; } }
         public long Value { get; internal set; }
         public long Total { get; internal set; }
+        public string Message { get; internal set; }
 
         private long previousValue;
         private float averageSpeed = -1f;
         private float lastSpeed = 0f;
         private float smoothing = 0.005f;
+        public event Action<IProgress> OnProgress;
 
-        public void UpdateProgress(long value, long total)
+        public void UpdateProgress(IProgress progress)
         {
-            previousValue = Value;
+            Task = progress.Task;
+            UpdateProgress(progress.Value, progress.Total, progress.Message);
+        }
+
+        public void UpdateProgress(long value, long total, string message = null)
+        {
             Total = total;
             Value = value;
+            Message = message ?? Message;
+            if (Total == 0 || ((float)(double)Value / Total) - ((float)(double)previousValue / Total) > 1f / 100f)
+            { // signal progress in 1% increments or if we don't know what the total is
+                previousValue = Value;
+                OnProgress?.Invoke(this);
+            }
         }
     }
 }

--- a/src/GitHub.Api/IO/Utils.cs
+++ b/src/GitHub.Api/IO/Utils.cs
@@ -14,7 +14,6 @@ namespace GitHub.Unity
             Func<long, long, bool> progress = null,
             int progressUpdateRate = 100)
         {
-            var logger = LogHelper.GetLogger("Copy");
             byte[] buffer = new byte[chunkSize];
             int bytesRead = 0;
             long totalRead = 0;
@@ -62,7 +61,6 @@ namespace GitHub.Unity
                             timeToFinish = Math.Max(1L,
                                 (long)((totalSize - totalRead) / (averageSpeed / progressUpdateRate)));
 
-                            logger.Trace($"totalRead: {totalRead} of {totalSize}");
                             success = progress(totalRead, timeToFinish);
                             if (!success)
                                 break;

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -5,75 +5,6 @@ using GitHub.Logging;
 
 namespace GitHub.Unity
 {
-    class GitInstallDetails
-    {
-        public const string DefaultGitZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git.zip.MD5.txt";
-        public const string DefaultGitZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git.zip";
-        public const string DefaultGitLfsZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip.MD5.txt";
-        public const string DefaultGitLfsZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip";
-
-        public const string GitExtractedMD5 = "e6cfc0c294a2312042f27f893dfc9c0a";
-        public const string GitLfsExtractedMD5 = "36e3ae968b69fbf42dff72311040d24a";
-
-        public const string WindowsGitExecutableMD5 = "50570ed932559f294d1a1361801740b9";
-        public const string MacGitExecutableMD5 = "";
-
-        public const string WindowsGitLfsExecutableMD5 = "177bb14d0c08f665a24f0d5516c3b080";
-        public const string MacGitLfsExecutableMD5 = "f81a1a065a26a4123193e8fd96c561ad";
-
-        private const string PackageVersion = "f02737a78695063deace08e96d5042710d3e32db";
-        private const string PackageName = "PortableGit";
-
-        private readonly bool onWindows;
-
-        public GitInstallDetails(NPath baseDataPath, bool onWindows)
-        {
-            this.onWindows = onWindows;
-
-            ZipPath = baseDataPath.Combine("downloads");
-            ZipPath.EnsureDirectoryExists();
-
-            var gitInstallPath = baseDataPath.Combine(PackageNameWithVersion);
-            GitInstallationPath = gitInstallPath;
-
-            if (onWindows)
-            {
-                GitExecutable += "git.exe";
-                GitLfsExecutable += "git-lfs.exe";
-
-                GitExecutablePath = gitInstallPath.Combine("cmd", GitExecutable);
-            }
-            else
-            {
-                GitExecutable = "git";
-                GitLfsExecutable = "git-lfs";
-
-                GitExecutablePath = gitInstallPath.Combine("bin", GitExecutable);
-            }
-
-            GitLfsExecutablePath = GetGitLfsExecutablePath(gitInstallPath);
-        }
-
-        public NPath GetGitLfsExecutablePath(NPath gitInstallRoot)
-        {
-            return onWindows
-                ? gitInstallRoot.Combine("mingw32", "libexec", "git-core", GitLfsExecutable)
-                : gitInstallRoot.Combine("libexec", "git-core", GitLfsExecutable);
-        }
-
-        public NPath ZipPath { get; }
-        public NPath GitInstallationPath { get; }
-        public string GitExecutable { get; }
-        public NPath GitExecutablePath { get; }
-        public string GitLfsExecutable { get; }
-        public NPath GitLfsExecutablePath { get; }
-        public UriString GitZipMd5Url { get; set; } = DefaultGitZipMd5Url;
-        public UriString GitZipUrl { get; set; } = DefaultGitZipUrl;
-        public UriString GitLfsZipMd5Url { get; set; } = DefaultGitLfsZipMd5Url;
-        public UriString GitLfsZipUrl { get; set; } = DefaultGitLfsZipUrl;
-        public string PackageNameWithVersion => PackageName + "_" + PackageVersion;
-    }
-
     class GitInstaller
     {
         private static readonly ILogging Logger = LogHelper.GetLogger<GitInstaller>();
@@ -238,5 +169,74 @@ namespace GitHub.Unity
             Logger.Trace("Git Present");
             return true;
         }
+
+    public class GitInstallDetails
+    {
+        public const string DefaultGitZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git.zip.MD5.txt";
+        public const string DefaultGitZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git.zip";
+        public const string DefaultGitLfsZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip.MD5.txt";
+        public const string DefaultGitLfsZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip";
+
+        public const string GitExtractedMD5 = "e6cfc0c294a2312042f27f893dfc9c0a";
+        public const string GitLfsExtractedMD5 = "36e3ae968b69fbf42dff72311040d24a";
+
+        public const string WindowsGitExecutableMD5 = "50570ed932559f294d1a1361801740b9";
+        public const string MacGitExecutableMD5 = "";
+
+        public const string WindowsGitLfsExecutableMD5 = "177bb14d0c08f665a24f0d5516c3b080";
+        public const string MacGitLfsExecutableMD5 = "f81a1a065a26a4123193e8fd96c561ad";
+
+        private const string PackageVersion = "f02737a78695063deace08e96d5042710d3e32db";
+        private const string PackageName = "PortableGit";
+
+        private readonly bool onWindows;
+
+        public GitInstallDetails(NPath baseDataPath, bool onWindows)
+        {
+            this.onWindows = onWindows;
+
+            ZipPath = baseDataPath.Combine("downloads");
+            ZipPath.EnsureDirectoryExists();
+
+            var gitInstallPath = baseDataPath.Combine(PackageNameWithVersion);
+            GitInstallationPath = gitInstallPath;
+
+            if (onWindows)
+            {
+                GitExecutable += "git.exe";
+                GitLfsExecutable += "git-lfs.exe";
+
+                GitExecutablePath = gitInstallPath.Combine("cmd", GitExecutable);
+            }
+            else
+            {
+                GitExecutable = "git";
+                GitLfsExecutable = "git-lfs";
+
+                GitExecutablePath = gitInstallPath.Combine("bin", GitExecutable);
+            }
+
+            GitLfsExecutablePath = GetGitLfsExecutablePath(gitInstallPath);
+        }
+
+        public NPath GetGitLfsExecutablePath(NPath gitInstallRoot)
+        {
+            return onWindows
+                ? gitInstallRoot.Combine("mingw32", "libexec", "git-core", GitLfsExecutable)
+                : gitInstallRoot.Combine("libexec", "git-core", GitLfsExecutable);
+        }
+
+        public NPath ZipPath { get; }
+        public NPath GitInstallationPath { get; }
+        public string GitExecutable { get; }
+        public NPath GitExecutablePath { get; }
+        public string GitLfsExecutable { get; }
+        public NPath GitLfsExecutablePath { get; }
+        public UriString GitZipMd5Url { get; set; } = DefaultGitZipMd5Url;
+        public UriString GitZipUrl { get; set; } = DefaultGitZipUrl;
+        public UriString GitLfsZipMd5Url { get; set; } = DefaultGitLfsZipMd5Url;
+        public UriString GitLfsZipUrl { get; set; } = DefaultGitLfsZipUrl;
+        public string PackageNameWithVersion => PackageName + "_" + PackageVersion;
     }
+}
 }

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -86,23 +86,12 @@ namespace GitHub.Unity
         private NPath gitLfsArchivePath;
 
         public GitInstaller(IEnvironment environment, CancellationToken cancellationToken,
-            GitInstallDetails installDetails)
-            : this(environment, ZipHelper.Instance, cancellationToken, installDetails, null, null)
-        {}
-
-        public GitInstaller(IEnvironment environment, CancellationToken cancellationToken,
-            GitInstallDetails installDetails, NPath gitArchiveFilePath, NPath gitLfsArchivePath)
-            : this(environment, ZipHelper.Instance, cancellationToken, installDetails,
-                gitArchiveFilePath, gitLfsArchivePath)
-        {}
-
-        public GitInstaller(IEnvironment environment, IZipHelper sharpZipLibHelper, CancellationToken cancellationToken,
-            GitInstallDetails installDetails, NPath gitArchiveFilePath, NPath gitLfsArchivePath)
+            GitInstallDetails installDetails = null, NPath gitArchiveFilePath = null, NPath gitLfsArchivePath = null)
         {
             this.environment = environment;
-            this.sharpZipLibHelper = sharpZipLibHelper;
+            this.sharpZipLibHelper = ZipHelper.Instance;
             this.cancellationToken = cancellationToken;
-            this.installDetails = installDetails;
+            this.installDetails = installDetails ?? new GitInstallDetails(environment.UserCachePath, environment.IsWindows);
             this.gitArchiveFilePath = gitArchiveFilePath;
             this.gitLfsArchivePath = gitLfsArchivePath;
         }

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -13,230 +13,260 @@ namespace GitHub.Unity
         private readonly IEnvironment environment;
         private readonly GitInstallDetails installDetails;
         private readonly IZipHelper sharpZipLibHelper;
-        private NPath gitArchiveFilePath;
-        private NPath gitLfsArchivePath;
+
+        ITask<NPath> installationTask;
 
         public GitInstaller(IEnvironment environment, CancellationToken cancellationToken,
-            GitInstallDetails installDetails = null, NPath gitArchiveFilePath = null, NPath gitLfsArchivePath = null)
+            GitInstallDetails installDetails = null)
         {
             this.environment = environment;
             this.sharpZipLibHelper = ZipHelper.Instance;
             this.cancellationToken = cancellationToken;
             this.installDetails = installDetails ?? new GitInstallDetails(environment.UserCachePath, environment.IsWindows);
-            this.gitArchiveFilePath = gitArchiveFilePath;
-            this.gitLfsArchivePath = gitLfsArchivePath;
         }
 
-        public void SetupGitIfNeeded(ActionTask<NPath> onSuccess, ITask onFailure)
+        public ITask<NPath> SetupGitIfNeeded()
         {
             Logger.Trace("SetupGitIfNeeded");
 
-            if (!environment.IsWindows)
-            {
-                onFailure.Start();
-                return;
-            }
+            installationTask = new FuncTask<GitInstallationState, NPath>(cancellationToken, (_, r) => installDetails.GitExecutablePath)
+                { Name = "Git Installation - Complete" };
+            installationTask.OnStart += thisTask => thisTask.UpdateProgress(0, 100);
+            installationTask.OnEnd += (thisTask, result, success, exception) => thisTask.UpdateProgress(100, 100);
 
-            var isGitExtractedTask = new FuncTask<NPath>(cancellationToken, () =>
-            {
-                if (!IsGitExtracted())
+            if (!environment.IsWindows)
+                return installationTask;
+
+            var startTask = new FuncTask<GitInstallationState>(cancellationToken, () =>
                 {
-                    GrabZipFromResources();
-                    return null;
-                }
-                Logger.Trace("SetupGitIfNeeded: Skipped");
-                return installDetails.GitExecutablePath;
-            });
-            isGitExtractedTask.OnEnd += (t, res, _, __) =>
+                    var state = VerifyGitInstallation();
+                    if (!state.GitIsValid && !state.GitLfsIsValid)
+                        state = GrabZipFromResources(state);
+                    else
+                        Logger.Trace("SetupGitIfNeeded: Skipped");
+                    return state;
+                })
+                { Name = "Git Installation - Extract" };
+
+
+            startTask.OnEnd += (thisTask, state, success, exception) =>
             {
-                if (res == null)
+                if (!state.GitIsValid && !state.GitLfsIsValid)
                 {
-                    var extractTask = ExtractPortableGit();
-                    extractTask.Then(onSuccess, TaskRunOptions.OnSuccess, taskIsTopOfChain: true);
-                    extractTask.Then(onFailure, TaskRunOptions.OnFailure, taskIsTopOfChain: true);
-                    t.Then(extractTask);
+                    if (!state.GitZipExists || !state.GitLfsZipExists)
+                        thisTask = thisTask.Then(CreateDownloadTask(state));
+                    thisTask = thisTask.Then(ExtractPortableGit(state));
                 }
-                else
-                    t.Then(onSuccess);
+                thisTask.Then(installationTask);
             };
 
-            isGitExtractedTask.Start();
+            // we want to start the startTask and not the installationTask because the latter only gets
+            // appended to the task chain when startTask ends, so calling Start() on it wouldn't work
+            startTask.Start();
+            return installationTask;
         }
 
-        private void GrabZipFromResources()
+        private GitInstallationState VerifyGitInstallation()
         {
-            if (gitArchiveFilePath == null || !gitArchiveFilePath.FileExists())
-                gitArchiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", installDetails.ZipPath, environment);
-            if (!gitArchiveFilePath.FileExists())
-                gitArchiveFilePath = null;
+            var state = new GitInstallationState();
+            state.GitExists = installDetails.GitExecutablePath?.FileExists() ?? false;
+            state.GitLfsExists = installDetails.GitLfsExecutablePath?.FileExists() ?? false;
+            state.GitZipExists = installDetails.GitZipPath.FileExists();
+            state.GitLfsZipExists = installDetails.GitLfsZipPath.FileExists();
 
-            if (gitLfsArchivePath == null || !gitLfsArchivePath.FileExists())
-                gitLfsArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", installDetails.ZipPath, environment);
-            if (!gitLfsArchivePath.FileExists())
-                gitLfsArchivePath = null;
+            if (state.GitExists)
+            {
+                var actualmd5 = installDetails.GitExecutablePath.CalculateMD5();
+                var expectedmd5 = environment.IsWindows ? GitInstallDetails.WindowsGitExecutableMD5 : GitInstallDetails.MacGitExecutableMD5;
+                state.GitIsValid = expectedmd5.Equals(actualmd5, StringComparison.InvariantCultureIgnoreCase);
+                if (!state.GitIsValid)
+                    Logger.Trace($"Path {installDetails.GitExecutablePath} has MD5 {actualmd5} expected {expectedmd5}");
+            }
+            else
+                Logger.Trace($"{installDetails.GitExecutablePath} does not exist");
+
+            if (state.GitLfsExists)
+            {
+                var actualmd5 = installDetails.GitLfsExecutablePath.CalculateMD5();
+                var expectedmd5 = environment.IsWindows ? GitInstallDetails.WindowsGitLfsExecutableMD5 : GitInstallDetails.MacGitLfsExecutableMD5;
+                state.GitLfsIsValid = expectedmd5.Equals(actualmd5, StringComparison.InvariantCultureIgnoreCase);
+                if (!state.GitLfsIsValid)
+                    Logger.Trace($"Path {installDetails.GitLfsExecutablePath} has MD5 {actualmd5} expected {expectedmd5}");
+            }
+            else
+                Logger.Trace($"{installDetails.GitLfsExecutablePath} does not exist");
+            installationTask.UpdateProgress(10, 100);
+            return state;
         }
 
-        private ITask CreateDownloadTask()
+        private GitInstallationState GrabZipFromResources(GitInstallationState state)
         {
-            gitArchiveFilePath = installDetails.ZipPath.Combine("git.zip");
-            gitLfsArchivePath = installDetails.ZipPath.Combine("git-lfs.zip");
+            if (!state.GitZipExists)
+                AssemblyResources.ToFile(ResourceType.Platform, "git.zip", installDetails.ZipPath, environment);
+            state.GitZipExists = installDetails.GitZipPath.FileExists();
 
+            if (!state.GitLfsZipExists)
+                AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", installDetails.ZipPath, environment);
+            state.GitLfsZipExists = installDetails.GitLfsZipPath.FileExists();
+            installationTask.UpdateProgress(20, 100);
+            return state;
+        }
+
+        private ITask<GitInstallationState> CreateDownloadTask(GitInstallationState state)
+        {
             var downloader = new Downloader();
             downloader.QueueDownload(installDetails.GitZipUrl, installDetails.GitZipMd5Url, installDetails.ZipPath);
             downloader.QueueDownload(installDetails.GitLfsZipUrl, installDetails.GitLfsZipMd5Url, installDetails.ZipPath);
-            return downloader;
+            return downloader.Then((_, data) =>
+            {
+                state.GitZipExists = installDetails.GitZipPath.FileExists();
+                state.GitLfsZipExists = installDetails.GitLfsZipPath.FileExists();
+                installationTask.UpdateProgress(40, 100);
+                return state;
+            });
         }
 
-        private FuncTask<NPath> CreateUnzipTasks(NPath gitExtractPath, NPath gitLfsExtractPath, NPath tempZipExtractPath)
+        private FuncTask<GitInstallationState> ExtractPortableGit(GitInstallationState state)
         {
-            var unzipGitTask = new UnzipTask(cancellationToken, gitArchiveFilePath, gitExtractPath, sharpZipLibHelper,
-                environment.FileSystem, GitInstallDetails.GitExtractedMD5);
-            var unzipGitLfsTask = new UnzipTask(cancellationToken, gitLfsArchivePath, gitLfsExtractPath, sharpZipLibHelper,
-                environment.FileSystem, GitInstallDetails.GitLfsExtractedMD5);
-            
-            var moveGitTask = new FuncTask<NPath>(cancellationToken, () => MoveGitAndLfs(gitExtractPath, gitLfsExtractPath, tempZipExtractPath));
-            return unzipGitTask
-                   .Then(unzipGitLfsTask)
-                   .Then(moveGitTask);
-        }
-
-        private FuncTask<NPath> ExtractPortableGit()
-        {
+            ITask<NPath> task = null;
             var tempZipExtractPath = NPath.CreateTempDirectory("git_zip_extract_zip_paths");
             var gitExtractPath = tempZipExtractPath.Combine("git").CreateDirectory();
+
+            if (!state.GitIsValid)
+            {
+                ITask<NPath> unzipTask = new UnzipTask(cancellationToken, installDetails.GitZipPath, gitExtractPath, sharpZipLibHelper,
+                    environment.FileSystem, GitInstallDetails.GitExtractedMD5);
+                unzipTask.Progress(p => installationTask.UpdateProgress(40 + (long)(20 * p.Percentage), 100, unzipTask.Name));
+
+                unzipTask = unzipTask.Then((s, path) =>
+                {
+                    var source = path;
+                    var target = installDetails.GitInstallationPath;
+                    target.DeleteIfExists();
+                    target.EnsureParentDirectoryExists();
+                    Logger.Trace($"Moving '{source}' to '{target}'");
+                    source.Move(target);
+                    state.GitExists = installDetails.GitExecutablePath.FileExists();
+                    state.GitIsValid = s;
+                    return path;
+                });
+                task = unzipTask;
+            }
+
             var gitLfsExtractPath = tempZipExtractPath.Combine("git-lfs").CreateDirectory();
 
-            var unzipTasks = CreateUnzipTasks(gitExtractPath, gitLfsExtractPath, tempZipExtractPath);
-
-            if (gitArchiveFilePath == null || gitLfsArchivePath == null)
+            if (!state.GitLfsIsValid)
             {
-                var downloadFilesTask = CreateDownloadTask();
-                unzipTasks = downloadFilesTask.Then(unzipTasks);
+                ITask<NPath> unzipTask = new UnzipTask(cancellationToken, installDetails.GitLfsZipPath, gitLfsExtractPath, sharpZipLibHelper,
+                    environment.FileSystem, GitInstallDetails.GitLfsExtractedMD5);
+                unzipTask.Progress(p => installationTask.UpdateProgress(60 + (long)(20 * p.Percentage), 100, unzipTask.Name));
+
+                unzipTask = unzipTask.Then((s, path) =>
+                {
+                    var source = path.Combine(installDetails.GitLfsExecutable);
+                    var target = installDetails.GetGitLfsExecutablePath(installDetails.GitInstallationPath);
+                    target.DeleteIfExists();
+                    target.EnsureParentDirectoryExists();
+                    Logger.Trace($"Moving '{source}' to '{target}'");
+                    source.Move(target);
+                    state.GitExists = target.FileExists();
+                    state.GitIsValid = s;
+                    return path;
+                });
+                task = task?.Then(unzipTask) ?? unzipTask;
             }
 
-            return unzipTasks;
+            return task.Finally(new FuncTask<GitInstallationState>(cancellationToken, (success) =>
+            {
+                tempZipExtractPath.DeleteIfExists();
+                return state;
+            }));
         }
 
-        private NPath MoveGitAndLfs(NPath gitExtractPath, NPath gitLfsExtractPath, NPath tempZipExtractPath)
+        class GitInstallationState
         {
-            var targetGitLfsExecPath = installDetails.GetGitLfsExecutablePath(gitExtractPath);
-            var extractGitLfsExePath = gitLfsExtractPath.Combine(installDetails.GitLfsExecutable);
-
-            Logger.Trace($"Moving Git LFS Exe:'{extractGitLfsExePath}' to target in tempDirectory:'{targetGitLfsExecPath}'");
-
-            extractGitLfsExePath.Move(targetGitLfsExecPath);
-
-            Logger.Trace($"Moving tempDirectory:'{gitExtractPath}' to extractTarget:'{installDetails.GitInstallationPath}'");
-
-            installDetails.GitInstallationPath.EnsureParentDirectoryExists();
-            gitExtractPath.Move(installDetails.GitInstallationPath);
-
-            Logger.Trace($"Deleting targetGitLfsExecPath:'{targetGitLfsExecPath}'");
-
-            targetGitLfsExecPath.DeleteIfExists();
-
-            Logger.Trace($"Deleting tempZipPath:'{tempZipExtractPath}'");
-            tempZipExtractPath.DeleteIfExists();
-            return installDetails.GitExecutablePath;
+            public bool GitExists { get; set; }
+            public bool GitLfsExists { get; set; }
+            public bool GitIsValid { get; set; }
+            public bool GitLfsIsValid { get; set; }
+            public bool GitZipExists { get; set; }
+            public bool GitLfsZipExists { get; set; }
         }
 
-        private bool IsGitExtracted()
+        public class GitInstallDetails
         {
-            if (!installDetails.GitInstallationPath.DirectoryExists())
+            public const string DefaultGitZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git.zip.MD5.txt";
+            public const string DefaultGitZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git.zip";
+            public const string DefaultGitLfsZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip.MD5.txt";
+            public const string DefaultGitLfsZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip";
+
+            public const string GitExtractedMD5 = "e6cfc0c294a2312042f27f893dfc9c0a";
+            public const string GitLfsExtractedMD5 = "36e3ae968b69fbf42dff72311040d24a";
+
+            public const string WindowsGitExecutableMD5 = "50570ed932559f294d1a1361801740b9";
+            public const string MacGitExecutableMD5 = "";
+
+            public const string WindowsGitLfsExecutableMD5 = "177bb14d0c08f665a24f0d5516c3b080";
+            public const string MacGitLfsExecutableMD5 = "f81a1a065a26a4123193e8fd96c561ad";
+
+            private const string PackageVersion = "f02737a78695063deace08e96d5042710d3e32db";
+            private const string PackageName = "PortableGit";
+
+            private const string gitZip = "git.zip";
+            private const string gitLfsZip = "git-lfs.zip";
+
+            private readonly bool onWindows;
+
+            public GitInstallDetails(NPath baseDataPath, bool onWindows)
             {
-                Logger.Warning($"{installDetails.GitInstallationPath} does not exist");
-                return false;
+                this.onWindows = onWindows;
+
+                ZipPath = baseDataPath.Combine("downloads");
+                ZipPath.EnsureDirectoryExists();
+                GitZipPath = ZipPath.Combine(gitZip);
+                GitLfsZipPath = ZipPath.Combine(gitLfsZip);
+
+                var gitInstallPath = baseDataPath.Combine(PackageNameWithVersion);
+                GitInstallationPath = gitInstallPath;
+
+                if (onWindows)
+                {
+                    GitExecutable += "git.exe";
+                    GitLfsExecutable += "git-lfs.exe";
+
+                    GitExecutablePath = gitInstallPath.Combine("cmd", GitExecutable);
+                }
+                else
+                {
+                    GitExecutable = "git";
+                    GitLfsExecutable = "git-lfs";
+
+                    GitExecutablePath = gitInstallPath.Combine("bin", GitExecutable);
+                }
+
+                GitLfsExecutablePath = GetGitLfsExecutablePath(gitInstallPath);
             }
 
-            var gitExecutableMd5 = installDetails.GitExecutablePath.CalculateMD5();
-            var expectedGitExecutableMd5 = environment.IsWindows ? GitInstallDetails.WindowsGitExecutableMD5 : GitInstallDetails.MacGitExecutableMD5;
-
-            if (!expectedGitExecutableMd5.Equals(gitExecutableMd5, StringComparison.InvariantCultureIgnoreCase))
+            public NPath GetGitLfsExecutablePath(NPath gitInstallRoot)
             {
-                Logger.Warning($"Path {installDetails.GitExecutablePath} has MD5 {gitExecutableMd5} expected {expectedGitExecutableMd5}");
-                return false;
+                return onWindows
+                    ? gitInstallRoot.Combine("mingw32", "libexec", "git-core", GitLfsExecutable)
+                    : gitInstallRoot.Combine("libexec", "git-core", GitLfsExecutable);
             }
 
-            var gitLfsExecutableMd5 = installDetails.GitLfsExecutablePath.CalculateMD5();
-            var expectedGitLfsExecutableMd5 = environment.IsWindows ? GitInstallDetails.WindowsGitLfsExecutableMD5 : GitInstallDetails.MacGitLfsExecutableMD5;
-
-            if (!expectedGitLfsExecutableMd5.Equals(gitLfsExecutableMd5, StringComparison.InvariantCultureIgnoreCase))
-            {
-                Logger.Warning($"Path {installDetails.GitLfsExecutablePath} has MD5 {gitLfsExecutableMd5} expected {expectedGitLfsExecutableMd5}");
-                return false;
-            }
-
-            Logger.Trace("Git Present");
-            return true;
+            public NPath ZipPath { get; }
+            public NPath GitZipPath { get; }
+            public NPath GitLfsZipPath { get; }
+            public NPath GitInstallationPath { get; }
+            public string GitExecutable { get; }
+            public NPath GitExecutablePath { get; }
+            public string GitLfsExecutable { get; }
+            public NPath GitLfsExecutablePath { get; }
+            public UriString GitZipMd5Url { get; set; } = DefaultGitZipMd5Url;
+            public UriString GitZipUrl { get; set; } = DefaultGitZipUrl;
+            public UriString GitLfsZipMd5Url { get; set; } = DefaultGitLfsZipMd5Url;
+            public UriString GitLfsZipUrl { get; set; } = DefaultGitLfsZipUrl;
+            public string PackageNameWithVersion => PackageName + "_" + PackageVersion;
         }
-
-    public class GitInstallDetails
-    {
-        public const string DefaultGitZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git.zip.MD5.txt";
-        public const string DefaultGitZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git.zip";
-        public const string DefaultGitLfsZipMd5Url = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip.MD5.txt";
-        public const string DefaultGitLfsZipUrl = "https://ghfvs-installer.github.com/unity/portable_git/git-lfs.zip";
-
-        public const string GitExtractedMD5 = "e6cfc0c294a2312042f27f893dfc9c0a";
-        public const string GitLfsExtractedMD5 = "36e3ae968b69fbf42dff72311040d24a";
-
-        public const string WindowsGitExecutableMD5 = "50570ed932559f294d1a1361801740b9";
-        public const string MacGitExecutableMD5 = "";
-
-        public const string WindowsGitLfsExecutableMD5 = "177bb14d0c08f665a24f0d5516c3b080";
-        public const string MacGitLfsExecutableMD5 = "f81a1a065a26a4123193e8fd96c561ad";
-
-        private const string PackageVersion = "f02737a78695063deace08e96d5042710d3e32db";
-        private const string PackageName = "PortableGit";
-
-        private readonly bool onWindows;
-
-        public GitInstallDetails(NPath baseDataPath, bool onWindows)
-        {
-            this.onWindows = onWindows;
-
-            ZipPath = baseDataPath.Combine("downloads");
-            ZipPath.EnsureDirectoryExists();
-
-            var gitInstallPath = baseDataPath.Combine(PackageNameWithVersion);
-            GitInstallationPath = gitInstallPath;
-
-            if (onWindows)
-            {
-                GitExecutable += "git.exe";
-                GitLfsExecutable += "git-lfs.exe";
-
-                GitExecutablePath = gitInstallPath.Combine("cmd", GitExecutable);
-            }
-            else
-            {
-                GitExecutable = "git";
-                GitLfsExecutable = "git-lfs";
-
-                GitExecutablePath = gitInstallPath.Combine("bin", GitExecutable);
-            }
-
-            GitLfsExecutablePath = GetGitLfsExecutablePath(gitInstallPath);
-        }
-
-        public NPath GetGitLfsExecutablePath(NPath gitInstallRoot)
-        {
-            return onWindows
-                ? gitInstallRoot.Combine("mingw32", "libexec", "git-core", GitLfsExecutable)
-                : gitInstallRoot.Combine("libexec", "git-core", GitLfsExecutable);
-        }
-
-        public NPath ZipPath { get; }
-        public NPath GitInstallationPath { get; }
-        public string GitExecutable { get; }
-        public NPath GitExecutablePath { get; }
-        public string GitLfsExecutable { get; }
-        public NPath GitLfsExecutablePath { get; }
-        public UriString GitZipMd5Url { get; set; } = DefaultGitZipMd5Url;
-        public UriString GitZipUrl { get; set; } = DefaultGitZipUrl;
-        public UriString GitLfsZipMd5Url { get; set; } = DefaultGitLfsZipMd5Url;
-        public UriString GitLfsZipUrl { get; set; } = DefaultGitLfsZipUrl;
-        public string PackageNameWithVersion => PackageName + "_" + PackageVersion;
     }
-}
 }

--- a/src/GitHub.Api/Installer/IZipHelper.cs
+++ b/src/GitHub.Api/Installer/IZipHelper.cs
@@ -5,7 +5,7 @@ namespace GitHub.Unity
 {
     interface IZipHelper
     {
-        void Extract(string archive, string outFolder, CancellationToken cancellationToken,
+        bool Extract(string archive, string outFolder, CancellationToken cancellationToken,
             Func<long, long, bool> onProgress = null);
     }
 }

--- a/src/GitHub.Api/Installer/IZipHelper.cs
+++ b/src/GitHub.Api/Installer/IZipHelper.cs
@@ -6,6 +6,6 @@ namespace GitHub.Unity
     interface IZipHelper
     {
         void Extract(string archive, string outFolder, CancellationToken cancellationToken,
-            IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null);
+            Func<long, long, bool> onProgress = null);
     }
 }

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
-    class UnzipTask: TaskBase
+    class UnzipTask : TaskBase<NPath>
     {
         private readonly string archiveFilePath;
         private readonly NPath extractedPath;
@@ -12,13 +12,13 @@ namespace GitHub.Unity
         private readonly IFileSystem fileSystem;
         private readonly string expectedMD5;
 
-        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IFileSystem fileSystem, string expectedMD5 = null) :
+        public UnzipTask(CancellationToken token, NPath archiveFilePath, NPath extractedPath, IFileSystem fileSystem, string expectedMD5 = null) :
             this(token, archiveFilePath, extractedPath, ZipHelper.Instance, fileSystem, expectedMD5)
         {
             
         }
 
-        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IZipHelper zipHelper, IFileSystem fileSystem, string expectedMD5 = null)
+        public UnzipTask(CancellationToken token, NPath archiveFilePath, NPath extractedPath, IZipHelper zipHelper, IFileSystem fileSystem, string expectedMD5 = null)
             : base(token)
         {
             this.archiveFilePath = archiveFilePath;
@@ -26,22 +26,23 @@ namespace GitHub.Unity
             this.zipHelper = zipHelper;
             this.fileSystem = fileSystem;
             this.expectedMD5 = expectedMD5;
+            Name = $"Unzip {archiveFilePath.FileName}";
         }
 
-        protected void BaseRun(bool success)
+        protected NPath BaseRun(bool success)
         {
-            base.Run(success);
+            return base.RunWithReturn(success);
         }
 
-        protected override void Run(bool success)
+        protected override NPath RunWithReturn(bool success)
         {
-            BaseRun(success);
+            var ret = BaseRun(success);
 
             RaiseOnStart();
 
             try
             {
-                RunUnzip(success);
+                ret = RunUnzip(success);
             }
             catch (Exception ex)
             {
@@ -51,11 +52,12 @@ namespace GitHub.Unity
             }
             finally
             {
-                RaiseOnEnd();
+                RaiseOnEnd(ret);
             }
+            return ret;
         }
 
-        protected virtual void RunUnzip(bool success)
+        protected virtual NPath RunUnzip(bool success)
         {
             Logger.Trace("Unzip File: {0} to Path: {1}", archiveFilePath, extractedPath);
 
@@ -69,7 +71,7 @@ namespace GitHub.Unity
                 exception = null;
                 try
                 {
-                    zipHelper.Extract(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
+                    success = zipHelper.Extract(archiveFilePath, extractedPath, Token,
                         (value, total) =>
                         {
                             UpdateProgress(value, total);
@@ -103,6 +105,7 @@ namespace GitHub.Unity
                 Token.ThrowIfCancellationRequested();
                 throw new UnzipException("Error unzipping file", exception);
             }
+            return extractedPath;
         }
         protected int RetryCount { get; }
     }

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -11,16 +11,14 @@ namespace GitHub.Unity
         private readonly IZipHelper zipHelper;
         private readonly IFileSystem fileSystem;
         private readonly string expectedMD5;
-        private readonly IProgress<float> zipFileProgress;
-        private readonly IProgress<long> estimatedDurationProgress;
 
-        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IFileSystem fileSystem, string expectedMD5 = null, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null) :
-            this(token, archiveFilePath, extractedPath, ZipHelper.Instance, fileSystem, expectedMD5, zipFileProgress, estimatedDurationProgress)
+        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IFileSystem fileSystem, string expectedMD5 = null) :
+            this(token, archiveFilePath, extractedPath, ZipHelper.Instance, fileSystem, expectedMD5)
         {
             
         }
 
-        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IZipHelper zipHelper, IFileSystem fileSystem, string expectedMD5 = null, IProgress<float> zipFileProgress = null, IProgress<long> estimatedDurationProgress = null)
+        public UnzipTask(CancellationToken token, string archiveFilePath, NPath extractedPath, IZipHelper zipHelper, IFileSystem fileSystem, string expectedMD5 = null)
             : base(token)
         {
             this.archiveFilePath = archiveFilePath;
@@ -28,8 +26,6 @@ namespace GitHub.Unity
             this.zipHelper = zipHelper;
             this.fileSystem = fileSystem;
             this.expectedMD5 = expectedMD5;
-            this.zipFileProgress = zipFileProgress;
-            this.estimatedDurationProgress = estimatedDurationProgress;
         }
 
         protected void BaseRun(bool success)
@@ -74,6 +70,11 @@ namespace GitHub.Unity
                 try
                 {
                     zipHelper.Extract(archiveFilePath, extractedPath, Token, zipFileProgress, estimatedDurationProgress);
+                        (value, total) =>
+                        {
+                            UpdateProgress(value, total);
+                            return !Token.IsCancellationRequested;
+                        });
 
                     if (expectedMD5 != null)
                     {

--- a/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
+++ b/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
@@ -158,8 +158,6 @@ namespace GitHub.Unity
         /// <remarks>This has been separated out into its own method to improve the Parallel Tasks window experience.</remarks>
         private void ConcurrentExclusiveInterleaveProcessor()
         {
-            Logging.LogHelper.GetLogger<ConcurrentExclusiveInterleave>().Trace("ConcurrentExclusiveInterleaveProcessor");
-
             if (token.IsCancellationRequested) return;
             interleaveTaskScheduler.ThreadToExclude = Thread.CurrentThread.ManagedThreadId;
 

--- a/src/GitHub.Api/Tasks/DownloadTask.cs
+++ b/src/GitHub.Api/Tasks/DownloadTask.cs
@@ -41,7 +41,7 @@ namespace GitHub.Unity
             Url = url;
             Filename = filename ?? url.Filename;
             TargetDirectory = targetDirectory ?? NPath.CreateTempDirectory("ghu");
-            Name = nameof(DownloadTask);
+            this.Name = $"Download {Url}";
         }
 
         protected string BaseRunWithReturn(bool success)

--- a/src/GitHub.Api/Tasks/ProcessTask.cs
+++ b/src/GitHub.Api/Tasks/ProcessTask.cs
@@ -306,7 +306,7 @@ namespace GitHub.Unity
                     catch (Exception ex)
                     {
                         if (!RaiseFaultHandlers(ex))
-                            throw ex;
+                            throw;
                     }
                     finally
                     {
@@ -420,19 +420,28 @@ namespace GitHub.Unity
                 RaiseOnStart,
                 () =>
                 {
-                    if (outputProcessor != null)
-                        result = outputProcessor.Result;
-                    if (result == null)
-                        result = new List<T>();
-
-                    RaiseOnEnd(result);
-
-                    if (Errors != null)
+                    try
                     {
-                        OnErrorData?.Invoke(Errors);
-                        thrownException = thrownException ?? new ProcessException(this);
-                        if (!RaiseFaultHandlers(thrownException))
+                        if (outputProcessor != null)
+                            result = outputProcessor.Result;
+                        if (result == null)
+                            result = new List<T>();
+
+                        if (Errors != null)
+                        {
+                            OnErrorData?.Invoke(Errors);
+                            thrownException = thrownException ?? new ProcessException(this);
                             throw thrownException;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!RaiseFaultHandlers(ex))
+                            throw;
+                    }
+                    finally
+                    {
+                        RaiseOnEnd(result);
                     }
                 },
                 (ex, error) =>

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -639,6 +639,7 @@ namespace GitHub.Unity
         protected override void CallFinallyHandler()
         {
             finallyHandler?.Invoke(!taskFailed, result);
+            base.CallFinallyHandler();
         }
 
         public new Task<TResult> Task

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -24,7 +24,7 @@ namespace GitHub.Unity
         /// <summary>
         /// Run a callback at the end of the task execution, on a separate thread, regardless of execution state
         /// </summary>
-        ITask Finally(Action<bool, Exception> actionToContinueWith, TaskAffinity affinity = TaskAffinity.Concurrent);
+        ITask Finally(Action<bool, Exception> actionToContinueWith, TaskAffinity affinity);
         /// <summary>
         /// Run another task at the end of the task execution, on a separate thread, regardless of execution state
         /// </summary>

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -387,16 +387,16 @@ namespace GitHub.Unity
             OnEnd?.Invoke(this, !taskFailed, exception);
             if (!taskFailed || exceptionWasHandled)
             {
-                if (continuationOnSuccess == null && continuationOnAlways == null)
+                if (continuationOnSuccess == null)
                     CallFinallyHandler();
-                else if (continuationOnSuccess != null)
+                else
                     SetContinuation(continuationOnSuccess, runOnSuccessOptions);
             }
             else
             {
-                if (continuationOnFailure == null && continuationOnAlways == null)
+                if (continuationOnFailure == null)
                     CallFinallyHandler();
-                else if (continuationOnFailure != null)
+                else
                     SetContinuation(continuationOnFailure, runOnSuccessOptions);
             }
             //Logger.Trace($"Finished {ToString()}");
@@ -404,7 +404,7 @@ namespace GitHub.Unity
 
         protected void CallFinallyHandler()
         {
-            finallyHandler?.Invoke(Task.Status == TaskStatus.RanToCompletion);
+            finallyHandler?.Invoke(!taskFailed);
         }
 
         protected virtual bool RaiseFaultHandlers(Exception ex)
@@ -617,9 +617,9 @@ namespace GitHub.Unity
         {
             this.result = data;
             OnEnd?.Invoke(this, result, !taskFailed, exception);
-            if (continuationOnSuccess == null && continuationOnFailure == null && continuationOnAlways == null)
+            if (continuationOnSuccess == null && continuationOnFailure == null)
             {
-                finallyHandler?.Invoke(Task.Status == TaskStatus.RanToCompletion, result);
+                finallyHandler?.Invoke(!taskFailed, result);
                 CallFinallyHandler();
             }
             else if (continuationOnSuccess != null)

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -33,8 +33,6 @@ namespace GitHub.Unity
         ITask Start(TaskScheduler scheduler);
         ITask Progress(Action<IProgress> progressHandler);
 
-        void Wait();
-        bool Wait(int milliseconds);
         bool Successful { get; }
         string Errors { get; }
         Task Task { get; }
@@ -373,16 +371,6 @@ namespace GitHub.Unity
             return depends.GetTopMostTask(ret, onlyCreatedState);
         }
 
-        public virtual void Wait()
-        {
-            Task.Wait(Token);
-        }
-
-        public virtual bool Wait(int milliseconds)
-        {
-            return Task.Wait(milliseconds, Token);
-        }
-
         protected virtual void Run(bool success)
         {
         }
@@ -443,8 +431,8 @@ namespace GitHub.Unity
 
             if (DependsOn.Task.Status == TaskStatus.Faulted)
             {
-                var exception = DependsOn.Task.Exception;
-                return exception?.InnerException ?? exception;
+                var ex = DependsOn.Task.Exception;
+                return ex?.InnerException ?? ex;
             }
             return DependsOn.GetThrownException();
         }
@@ -704,33 +692,6 @@ namespace GitHub.Unity
         protected void RaiseOnData(TData data)
         {
             OnData?.Invoke(data);
-        }
-    }
-
-    static class TaskBaseExtensions
-    {
-        public static T Schedule<T>(this T task, ITaskManager taskManager)
-            where T : ITask
-        {
-            return taskManager.Schedule(task);
-        }
-
-        public static T ScheduleUI<T>(this T task, ITaskManager taskManager)
-            where T : ITask
-        {
-            return taskManager.ScheduleUI(task);
-        }
-
-        public static T ScheduleExclusive<T>(this T task, ITaskManager taskManager)
-            where T : ITask
-        {
-            return taskManager.ScheduleExclusive(task);
-        }
-
-        public static T ScheduleConcurrent<T>(this T task, ITaskManager taskManager)
-            where T : ITask
-        {
-            return taskManager.ScheduleConcurrent(task);
         }
     }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -477,7 +477,7 @@ namespace GitHub.Unity
             }
         }
 
-        public GitBranch? CurentGitBranch
+        public GitBranch? CurrentGitBranch
         {
             get
             {
@@ -548,7 +548,7 @@ namespace GitHub.Unity
             }
         }
 
-        public ConfigBranch? CurentConfigBranch
+        public ConfigBranch? CurrentConfigBranch
         {
             get
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -501,10 +501,7 @@ namespace GitHub.Unity
             }
         }
 
-        public override TimeSpan DataTimeout
-        {
-            get { return TimeSpan.MaxValue; }
-        }
+        public override TimeSpan DataTimeout { get { return TimeSpan.FromDays(1); } }
     }
 
     [Location("cache/branches.yaml", LocationAttribute.Location.LibraryFolder)]
@@ -740,7 +737,7 @@ namespace GitHub.Unity
         public ILocalConfigBranchDictionary LocalConfigBranches { get { return localConfigBranches; } }
         public IRemoteConfigBranchDictionary RemoteConfigBranches { get { return remoteConfigBranches; } }
         public IConfigRemoteDictionary ConfigRemotes { get { return configRemotes; } }
-        public override TimeSpan DataTimeout { get { return TimeSpan.MaxValue; } }
+        public override TimeSpan DataTimeout { get { return TimeSpan.FromDays(1); } }
     }
 
     [Location("cache/gitlog.yaml", LocationAttribute.Location.LibraryFolder)]

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -151,13 +151,10 @@ namespace GitHub.Unity
         public void ValidateData()
         {
             var initialized = ValidateInitialized();
-            if (initialized)
+            if (!initialized || DateTimeOffset.Now - LastUpdatedAt > DataTimeout)
             {
-                if (DateTimeOffset.Now - LastUpdatedAt > DataTimeout)
-                {
-                    Logger.Trace("Timeout Invalidation");
-                    InvalidateData();
-                }
+                Logger.Trace("Timeout Invalidation");
+                InvalidateData();
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
@@ -31,6 +31,7 @@ namespace GitHub.Unity
             Logger.Trace("Restarted {0}", Environment.Repository);
             EnvironmentCache.Instance.Flush();
 
+            isBusy = false;
             ProjectWindowInterface.Initialize(Environment.Repository);
             var window = Window.GetWindow();
             if (window != null)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/CacheContainer.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/CacheContainer.cs
@@ -59,6 +59,7 @@ namespace GitHub.Unity
 
         public void ValidateAll()
         {
+            RepositoryInfoCache.ValidateData();
             BranchCache.ValidateData();
             GitLogCache.ValidateData();
             GitTrackingStatusCache.ValidateData();
@@ -73,6 +74,7 @@ namespace GitHub.Unity
 
         public void InvalidateAll()
         {
+            RepositoryInfoCache.InvalidateData();
             BranchCache.InvalidateData();
             GitLogCache.InvalidateData();
             GitTrackingStatusCache.InvalidateData();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
@@ -62,7 +62,9 @@ namespace GitHub.Unity
                 Debug.LogFormat("Initialized GitHub for Unity version {0}{1}Log file: {2}", ApplicationInfo.Version, Environment.NewLine, logPath);
             }
 
-            LogHelper.LogAdapter = new FileLogAdapter(logPath);
+            LogHelper.LogAdapter = new MultipleLogAdapter(new FileLogAdapter(logPath)
+                , new UnityLogAdapter()
+                );
             LogHelper.Info("Initializing GitHub for Unity version " + ApplicationInfo.Version);
 
             ApplicationManager.Run(ApplicationCache.Instance.FirstRun);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
@@ -108,6 +108,7 @@
     <Compile Include="UI\LoadingView.cs" />
     <Compile Include="UI\PublishView.cs" />
     <Compile Include="UI\InitProjectView.cs" />
+    <Compile Include="UI\Spinner.cs" />
     <Compile Include="UI\TreeControl.cs" />
     <Compile Include="UI\UserSettingsView.cs" />
     <Compile Include="UI\GitPathView.cs" />
@@ -216,6 +217,20 @@
   <ItemGroup>
     <EmbeddedResource Include="IconsAndLogos\globe%402x.png" />
     <EmbeddedResource Include="IconsAndLogos\globe.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="IconsAndLogos\spinner-inside%402x.png" />
+    <EmbeddedResource Include="IconsAndLogos\spinner-inside.png" />
+    <EmbeddedResource Include="IconsAndLogos\spinner-outside%402x.png" />
+    <EmbeddedResource Include="IconsAndLogos\spinner-outside.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="IconsAndLogos\code%402x.png" />
+    <EmbeddedResource Include="IconsAndLogos\code.png" />
+    <EmbeddedResource Include="IconsAndLogos\merge%402x.png" />
+    <EmbeddedResource Include="IconsAndLogos\merge.png" />
+    <EmbeddedResource Include="IconsAndLogos\rocket%402x.png" />
+    <EmbeddedResource Include="IconsAndLogos\rocket.png" />
   </ItemGroup>
   <Import Project="..\..\..\..\..\common\nativelibraries.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/code.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/code.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3c602dae03ca5b625711036cd63a7b3010f032830fc89c5201b55d047600b0a
+size 874

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/code@2x.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/code@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3c602dae03ca5b625711036cd63a7b3010f032830fc89c5201b55d047600b0a
+size 874

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/merge.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/merge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f1d0d6fbbabe847e8309acee1686b0f2a0674f6ef56d8dba51e0ad003732e6
+size 915

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/merge@2x.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/merge@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f1d0d6fbbabe847e8309acee1686b0f2a0674f6ef56d8dba51e0ad003732e6
+size 915

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/rocket.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/rocket.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff45333e52a3a5139f12cdc56389928eb269111d3c5e364f99db3a5fb15a4bf
+size 919

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/rocket@2x.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/rocket@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff45333e52a3a5139f12cdc56389928eb269111d3c5e364f99db3a5fb15a4bf
+size 919

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-inside.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-inside.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405d1e1484ca3c44ecd3de8583c566a8f2896b204fd5d7e2cbf21c34637b3f57
+size 2917

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-inside@2x.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-inside@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405d1e1484ca3c44ecd3de8583c566a8f2896b204fd5d7e2cbf21c34637b3f57
+size 2917

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-outside.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-outside.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ae2584fdc78b6565110ca29f1e3fe90f3ae06a23b04cddac7e33f1d26828ad
+size 12001

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-outside@2x.png
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/IconsAndLogos/spinner-outside@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ae2584fdc78b6565110ca29f1e3fe90f3ae06a23b04cddac7e33f1d26828ad
+size 12001

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -98,7 +98,18 @@ namespace GitHub.Unity
                                  repoIcon,
                                  lockIcon,
                                  emptyStateInit,
-                                 dropdownListIcon;
+                                 dropdownListIcon,
+                                 globeIcon,
+                                 spinnerInside,
+                                 spinnerOutside,
+                                 code,
+                                 rocket,
+                                 merge,
+                                 spinnerInsideInverted,
+                                 spinnerOutsideInverted,
+                                 codeInverted,
+                                 rocketInverted,
+                                 mergeInverted;
 
         public static Texture2D GetFileStatusIcon(GitFileStatus status, bool isLocked)
         {
@@ -848,7 +859,6 @@ namespace GitHub.Unity
             }
         }
 
-        private static Texture2D globeIcon;
         public static Texture2D GlobeIcon
         {
             get
@@ -861,6 +871,130 @@ namespace GitHub.Unity
             }
         }
 
+        public static Texture2D SpinnerInside
+        {
+            get
+            {
+                if (spinnerInside == null)
+                {
+                    spinnerInside = Utility.GetIcon("spinner-inside.png", "spinner-inside@2x.png");
+                }
+                return spinnerInside;
+            }
+        }
+
+        public static Texture2D SpinnerOutside
+        {
+            get
+            {
+                if (spinnerOutside == null)
+                {
+                    spinnerOutside = Utility.GetIcon("spinner-outside.png", "spinner-outside@2x.png");
+                }
+                return spinnerOutside;
+            }
+        }
+
+        public static Texture2D Code
+        {
+            get
+            {
+                if (code == null)
+                {
+                    code = Utility.GetIcon("code.png", "spinner-outside@2x.png");
+                }
+                return code;
+            }
+        }
+
+        public static Texture2D Rocket
+        {
+            get
+            {
+                if (rocket == null)
+                {
+                    rocket = Utility.GetIcon("rocket.png", "rocket@2x.png");
+                }
+                return rocket;
+            }
+        }
+
+        public static Texture2D Merge
+        {
+            get
+            {
+                if (merge == null)
+                {
+                    merge = Utility.GetIcon("merge.png", "merge@2x.png");
+                }
+                return merge;
+            }
+        }
+
+        public static Texture2D SpinnerInsideInverted
+        {
+            get
+            {
+                if (spinnerInsideInverted == null)
+                {
+                    spinnerInsideInverted = Utility.GetIcon("spinner-inside.png", "spinner-inside@2x.png");
+                    spinnerInsideInverted.InvertColors();
+                }
+                return spinnerInsideInverted;
+            }
+        }
+
+        public static Texture2D SpinnerOutsideInverted
+        {
+            get
+            {
+                if (spinnerOutsideInverted == null)
+                {
+                    spinnerOutsideInverted = Utility.GetIcon("spinner-outside.png", "spinner-outside@2x.png");
+                    spinnerOutsideInverted.InvertColors();
+                }
+                return spinnerOutsideInverted;
+            }
+        }
+
+        public static Texture2D CodeInverted
+        {
+            get
+            {
+                if (codeInverted == null)
+                {
+                    codeInverted = Utility.GetIcon("code.png", "spinner-outside@2x.png");
+                    codeInverted.InvertColors();
+                }
+                return codeInverted;
+            }
+        }
+
+        public static Texture2D RocketInverted
+        {
+            get
+            {
+                if (rocketInverted == null)
+                {
+                    rocketInverted = Utility.GetIcon("rocket.png", "rocket@2x.png");
+                    rocketInverted.InvertColors();
+                }
+                return rocketInverted;
+            }
+        }
+
+        public static Texture2D MergeInverted
+        {
+            get
+            {
+                if (mergeInverted == null)
+                {
+                    mergeInverted = Utility.GetIcon("merge.png", "merge@2x.png");
+                    mergeInverted.InvertColors();
+                }
+                return mergeInverted;
+            }
+        }
         private static GUIStyle foldout;
         public static GUIStyle Foldout
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -114,5 +114,21 @@ namespace GitHub.Unity
                 return tex;
             }
         }
+
+        public static void InvertColors(this Texture2D texture)
+        {
+            for (var m = 0; m < texture.mipmapCount; m++)
+            {
+                var c = texture.GetPixels(m);
+                for (var i = 0; i < c.Length; i++)
+                {
+                    c[i].r = 1 - c[i].r;
+                    c[i].g = 1 - c[i].g;
+                    c[i].b = 1 - c[i].b;
+                }
+                texture.SetPixels(c, m);
+            }
+            texture.Apply();
+        }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -11,7 +11,7 @@ namespace GitHub.Unity
         [NonSerialized] private IUser cachedUser;
         [NonSerialized] private IRepository cachedRepository;
         [NonSerialized] private bool initializeWasCalled;
-        [NonSerialized] private bool inLayout;
+        [NonSerialized] protected bool inLayout;
 
         public virtual void Initialize(IApplicationManager applicationManager)
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -68,7 +68,7 @@ namespace GitHub.Unity
                         {
                             isBusy = true;
                             Manager.InitializeRepository()
-                                   .FinallyInUI(() => isBusy = false)
+                                   .FinallyInUI((s, e) => isBusy = false)
                                    .Start();
                         }
                     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -350,7 +350,7 @@ namespace GitHub.Unity
                 webTimeout = ApplicationConfiguration.WebTimeout;
                 EditorGUI.BeginChangeCheck();
                 {
-                    webTimeout = EditorGUILayout.IntField(webTimeout, WebTimeoutLabel);
+                    webTimeout = EditorGUILayout.IntField(WebTimeoutLabel, webTimeout);
                 }
                 if (EditorGUI.EndChangeCheck())
                 {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Spinner.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Spinner.cs
@@ -130,10 +130,10 @@ namespace GitHub.Unity
             GUI.matrix = matrix;
         }
 
-        private void PushRotation(float rotation, Vector2 center)
+        private void PushRotation(float rotation, Vector2 rotCenter)
         {
-            rotations.Push(new Rotation(rotation, center));
-            GUIUtility.RotateAroundPivot(rotation, center);
+            rotations.Push(new Rotation(rotation, rotCenter));
+            GUIUtility.RotateAroundPivot(rotation, rotCenter);
         }
 
         private void PopRotation()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Spinner.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Spinner.cs
@@ -1,0 +1,145 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace GitHub.Unity
+{
+    class Spinner
+    {
+        struct Rotation
+        {
+            public float rotation;
+            public Vector2 center;
+            public Rotation(float rotation, Vector2 center)
+            {
+                this.rotation = rotation;
+                this.center = center;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("rotation:{0} center:{1}:{2}", rotation, center.x, center.y);
+            }
+        }
+
+        private float speed = 120f;
+        private float currentRotation;
+        private float lastTime;
+        private bool started;
+        private float centerX;
+        private float centerY;
+        private Vector2 center;
+        private Vector2 codeIconTopLeft;
+        private Vector2 mergeIconTopLeft;
+        private Vector2 rocketIconTopLeft;
+        private Rect backgroundRect;
+        private Rect outsideRect;
+        private Rect insideRect;
+        private Vector2 rocketIconCenter;
+        private Vector2 codeIconCenter;
+        private Vector2 mergeIconCenter;
+
+        private Texture2D Inside { get { return Styles.SpinnerInside; } }
+        private Texture2D Outside { get { return Styles.SpinnerOutside; } }
+        private Texture2D Code { get { return Styles.Code; } }
+        private Texture2D Merge { get { return Styles.Merge; } }
+        private Texture2D Rocket { get { return Styles.Rocket; } }
+        private Stack<Rotation> rotations = new Stack<Rotation>();
+
+        public Spinner()
+        {
+        }
+
+        public void Start(float currentTime)
+        {
+            if (started)
+                return;
+            started = true;
+        }
+
+        public void Stop()
+        {
+            started = false;
+        }
+
+        public float Rotate(float currentTime)
+        {
+            var deltaTime = currentTime - lastTime;
+            currentRotation += deltaTime * speed * ((Mathf.Sin(currentTime * 1.2f)) + 2);
+            currentRotation = Mathf.Repeat(currentRotation, 360f);
+            lastTime = currentTime;
+            return currentRotation;
+        }
+
+        public Rect Layout(Rect rect)
+        {
+            var width = rect.width;
+            var height = rect.height;
+            var x = rect.x;
+            var y = rect.y;
+            centerX = width / 2 + x;
+            centerY = height / 2 + y;
+            center = new Vector2(centerX, centerY);
+            outsideRect = new Rect(centerX - Outside.width / 2, centerY - Outside.height / 2 - 11, Outside.width, Outside.height);
+            codeIconTopLeft = new Vector2(centerX - Code.width / 2 - 0.6f, centerY - Code.height / 2 - 45);
+            mergeIconTopLeft = new Vector2(centerX - Merge.width / 2 + 38, centerY - Merge.height / 2 + 24);
+            rocketIconTopLeft = new Vector2(centerX - Rocket.width / 2 - 39, centerY - Rocket.height / 2 + 24);
+            backgroundRect = new Rect(x, y, width, height);
+            insideRect = new Rect(centerX - Inside.width / 2, centerY - Inside.height / 2, Inside.width, Inside.height);
+            codeIconCenter = new Vector2(codeIconTopLeft.x + Code.width / 2 - .1f, codeIconTopLeft.y + Code.height / 2 + 0.1f);
+            rocketIconCenter = new Vector2(rocketIconTopLeft.x + Rocket.width / 2, rocketIconTopLeft.y + Rocket.height / 2);
+            mergeIconCenter = new Vector2(mergeIconTopLeft.x + Merge.width / 2, mergeIconTopLeft.y + Merge.height / 2);
+            return outsideRect;
+        }
+
+        public void Render()
+        {
+            var matrix = GUI.matrix;
+
+            // draw the background
+            GUI.DrawTexture(backgroundRect, Utility.GetTextureFromColor(new Color(0.2f, 0.2f, 0.2f, 0.9f)));
+
+            // draw the center
+            GUI.DrawTexture(insideRect, Inside);
+
+            // draw the outside ring, rotated
+            PushRotation(currentRotation, center);
+            GUI.DrawTexture(outsideRect, Outside);
+            PopRotation();
+
+            // draw the code icon inside the ring unrotated
+            PushRotation(-currentRotation, codeIconCenter);
+            PushRotation(currentRotation, center);
+            GUI.DrawTexture(new Rect(codeIconTopLeft.x, codeIconTopLeft.y, Code.width, Code.height), Code);
+            PopRotation();
+            PopRotation();
+
+            // draw the merge icon inside the ring unrotated
+            PushRotation(-currentRotation, mergeIconCenter);
+            PushRotation(currentRotation, center);
+            GUI.DrawTexture(new Rect(mergeIconTopLeft.x, mergeIconTopLeft.y, Merge.width, Merge.height), Merge);
+            PopRotation();
+            PopRotation();
+
+            // draw the rocket icon inside the ring unrotated
+            PushRotation(-currentRotation, rocketIconCenter);
+            PushRotation(currentRotation, center);
+            GUI.DrawTexture(new Rect(rocketIconTopLeft.x, rocketIconTopLeft.y, Rocket.width, Rocket.height), Rocket);
+            PopRotation();
+            PopRotation();
+
+            GUI.matrix = matrix;
+        }
+
+        private void PushRotation(float rotation, Vector2 center)
+        {
+            rotations.Push(new Rotation(rotation, center));
+            GUIUtility.RotateAroundPivot(rotation, center);
+        }
+
+        private void PopRotation()
+        {
+            var rot = rotations.Pop();
+            GUIUtility.RotateAroundPivot(-rot.rotation, rot.center);
+        }
+    }
+}

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -355,9 +355,9 @@ namespace GitHub.Unity
             }
         }
 
-        private void OnProgress(IProgress progress)
+        private void OnProgress(IProgress progr)
         {
-            this.progress = progress;
+            progress = progr;
         }
 
         private void DetachHandlers(IRepository repository)

--- a/src/tests/IntegrationTests/BaseGitEnvironmentTest.cs
+++ b/src/tests/IntegrationTests/BaseGitEnvironmentTest.cs
@@ -55,7 +55,7 @@ namespace IntegrationTests
             TestRepoMasterTwoRemotes = TestBasePath.Combine("IOTestsRepo", "IOTestsRepo_master_two_remotes");
 
             Logger.Trace("Extracting Zip File to {0}", TestBasePath);
-            ZipHelper.ExtractZipFile(TestZipFilePath, TestBasePath.ToString(), TaskManager.Token);
+            ZipHelper.ExtractZipFile(TestZipFilePath, TestBasePath.ToString(), TaskManager.Token, (value, total) => true);
             Logger.Trace("Extracted Zip File");
         }
 

--- a/src/tests/IntegrationTests/BasePlatformIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BasePlatformIntegrationTest.cs
@@ -30,7 +30,7 @@ namespace IntegrationTests
                 var autoResetEvent = new AutoResetEvent(false);
 
                 var applicationDataPath = Environment.GetSpecialFolder(System.Environment.SpecialFolder.LocalApplicationData).ToNPath();
-                var installDetails = new GitInstallDetails(applicationDataPath, true);
+                var installDetails = new GitInstaller.GitInstallDetails(applicationDataPath, true);
 
                 var zipArchivesPath = TestBasePath.Combine("ZipArchives").CreateDirectory();
                 var gitArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", zipArchivesPath, Environment);

--- a/src/tests/IntegrationTests/BasePlatformIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BasePlatformIntegrationTest.cs
@@ -33,22 +33,21 @@ namespace IntegrationTests
                 var installDetails = new GitInstaller.GitInstallDetails(applicationDataPath, true);
 
                 var zipArchivesPath = TestBasePath.Combine("ZipArchives").CreateDirectory();
-                var gitArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", zipArchivesPath, Environment);
-                var gitLfsArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", zipArchivesPath, Environment);
+                AssemblyResources.ToFile(ResourceType.Platform, "git.zip", zipArchivesPath, Environment);
+                AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", zipArchivesPath, Environment);
 
-                var gitInstaller = new GitInstaller(Environment, TaskManager.Token, installDetails, gitArchivePath, gitLfsArchivePath);
+                var gitInstaller = new GitInstaller(Environment, TaskManager.Token, installDetails);
 
                 NPath result = null;
                 Exception ex = null;
 
-                gitInstaller.SetupGitIfNeeded(new ActionTask<NPath>(TaskManager.Token, (b, path) => {
-                        result = path;
-                        autoResetEvent.Set();
-                    }),
-                    new ActionTask(TaskManager.Token, (b, exception) => {
-                        ex = exception;
-                        autoResetEvent.Set();
-                    }));
+                var setupTask = gitInstaller.SetupGitIfNeeded();
+                setupTask.OnEnd += (thisTask, path, success, exception) =>
+                {
+                    result = path;
+                    ex = exception;
+                    autoResetEvent.Set();
+                };
 
                 autoResetEvent.WaitOne();
 

--- a/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
+++ b/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
@@ -202,7 +202,7 @@ namespace IntegrationTests.Download
             md5Sum.Should().BeEquivalentTo(md5);
         }
 
-        [Test]
+        [Category("DoNotRunOnAppVeyor")]
         public async Task DownloadsRunSideBySide()
         {
             Stopwatch watch;

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -40,12 +40,12 @@ namespace IntegrationTests
         {
             var gitInstallationPath = TestBasePath.Combine("GitInstall").CreateDirectory();
 
-            var installDetails = new GitInstallDetails(gitInstallationPath, DefaultEnvironment.OnWindows)
+            var installDetails = new GitInstaller.GitInstallDetails(gitInstallationPath, DefaultEnvironment.OnWindows)
                 {
-                    GitZipMd5Url = $"http://localhost:{server.Port}/{new UriString(GitInstallDetails.DefaultGitZipMd5Url).Filename}",
-                    GitZipUrl = $"http://localhost:{server.Port}/{new UriString(GitInstallDetails.DefaultGitZipUrl).Filename}",
-                    GitLfsZipMd5Url = $"http://localhost:{server.Port}/{new UriString(GitInstallDetails.DefaultGitLfsZipMd5Url).Filename}",
-                    GitLfsZipUrl = $"http://localhost:{server.Port}/{new UriString(GitInstallDetails.DefaultGitLfsZipUrl).Filename}",
+                    GitZipMd5Url = $"http://localhost:{server.Port}/{new UriString(GitInstaller.GitInstallDetails.DefaultGitZipMd5Url).Filename}",
+                    GitZipUrl = $"http://localhost:{server.Port}/{new UriString(GitInstaller.GitInstallDetails.DefaultGitZipUrl).Filename}",
+                    GitLfsZipMd5Url = $"http://localhost:{server.Port}/{new UriString(GitInstaller.GitInstallDetails.DefaultGitLfsZipMd5Url).Filename}",
+                    GitLfsZipUrl = $"http://localhost:{server.Port}/{new UriString(GitInstaller.GitInstallDetails.DefaultGitLfsZipUrl).Filename}",
                 };
 
             TestBasePath.Combine("git").CreateDirectory();

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -50,34 +50,11 @@ namespace IntegrationTests
 
             TestBasePath.Combine("git").CreateDirectory();
 
-            //var gitArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", zipArchivesPath, Environment);
-            //var gitLfsArchivePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", zipArchivesPath, Environment);
-            
             var gitInstaller = new GitInstaller(Environment, CancellationToken.None, installDetails);
 
-            var autoResetEvent = new AutoResetEvent(false);
-
-            bool? result = null;
             NPath resultPath = null;
-            Exception ex = null;
-
-            gitInstaller.SetupGitIfNeeded(new ActionTask<NPath>(CancellationToken.None, (b, path) => {
-                    result = true;
-                    resultPath = path;
-                    autoResetEvent.Set();
-                }),
-                new ActionTask(CancellationToken.None, (b, exception) => {
-                    result = false;
-                    ex = exception;
-                    autoResetEvent.Set();
-                }));
-
-            autoResetEvent.WaitOne();
-
-            result.HasValue.Should().BeTrue();
-            result.Value.Should().BeTrue();
+            Assert.DoesNotThrow(async () => resultPath = await gitInstaller.SetupGitIfNeeded().Task);
             resultPath.Should().NotBeNull();
-            ex.Should().BeNull();
         }
     }
 }

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -35,7 +35,6 @@ namespace IntegrationTests
         }
 
         [Test]
-        [Category("DoNotRunOnAppVeyor")]
         public void GitInstallTest()
         {
             var gitInstallationPath = TestBasePath.Combine("GitInstall").CreateDirectory();

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -27,7 +27,7 @@ namespace IntegrationTests
             var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
             var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath,
-                Environment.FileSystem, GitInstallDetails.GitLfsExtractedMD5);
+                Environment.FileSystem, GitInstaller.GitInstallDetails.GitLfsExtractedMD5);
 
             await unzipTask.StartAwait();
 

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -26,8 +26,10 @@ namespace IntegrationTests
 
             var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath,
-                Environment.FileSystem, GitInstaller.GitInstallDetails.GitLfsExtractedMD5);
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstallDetails.GitExtractedMD5)
+                .Progress(p => 
+                {
+                });
 
             await unzipTask.StartAwait();
 

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -26,7 +26,7 @@ namespace IntegrationTests
 
             var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstaller.GitInstallDetails.GitExtractedMD5)
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstaller.GitInstallDetails.GitLfsExtractedMD5)
                 .Progress(p => 
                 {
                 });

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -26,7 +26,7 @@ namespace IntegrationTests
 
             var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstallDetails.GitExtractedMD5)
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstaller.GitInstallDetails.GitExtractedMD5)
                 .Progress(p => 
                 {
                 });

--- a/src/tests/TaskSystemIntegrationTests/TaskSystem.csproj
+++ b/src/tests/TaskSystemIntegrationTests/TaskSystem.csproj
@@ -38,6 +38,10 @@
       <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\NSubstitute.1.10.0.0\lib\net35\NSubstitute.dll</HintPath>
       <Private>True</Private>

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -600,7 +600,9 @@ namespace IntegrationTests
             ITask task = new ActionTask(Token, _ => { throw new Exception(); });
             task.OnStart += _ => runOrder.Add("start");
             task.OnEnd += (_, __, ___) => runOrder.Add("end");
-            task = task.Finally((_, __) => {});
+            // we want to run a Finally on a new task (and not in-thread) so that the StartAndSwallowException handler runs after this
+            // one, proving that the exception is propagated after everything is done
+            task = task.Finally((_, __) => {}, TaskAffinity.Concurrent);
 
             await task.StartAndSwallowException();
             CollectionAssert.AreEqual(new string[] { "start", "end" }, runOrder);

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -850,7 +850,7 @@ namespace IntegrationTests
             var callOrder = new List<string>();
 
             var taskEnd = new ActionTask(Token, () => callOrder.Add("chain completed")) { Name = "Chain Completed" };
-            var final = taskEnd.Finally((_, __) => { });
+            var final = taskEnd.Finally((_, __) => { }, TaskAffinity.Concurrent);
 
             var taskStart = new FuncTask<bool>(Token, _ =>
                 {

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -10,11 +10,15 @@ using System.IO;
 using NSubstitute;
 using GitHub.Logging;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
 
 namespace IntegrationTests
 {
     class BaseTest
     {
+        protected const int Timeout = 30000;
+
         public BaseTest()
         {
             Logger = LogHelper.GetLogger(GetType());
@@ -74,6 +78,27 @@ namespace IntegrationTests
         [TearDown]
         public void Teardown()
         {
+        }
+
+        protected void StartTest(out Stopwatch watch, out ILogging logger, [CallerMemberName] string testName = "test")
+        {
+            watch = new Stopwatch();
+            logger = LogHelper.GetLogger(testName);
+            logger.Trace("Starting test");
+        }
+
+        protected void StartTrackTime(Stopwatch watch, ILogging logger = null, string message = "")
+        {
+            if (!String.IsNullOrEmpty(message))
+                logger.Trace(message);
+            watch.Reset();
+            watch.Start();
+        }
+
+        protected void StopTrackTimeAndLog(Stopwatch watch, ILogging logger)
+        {
+            watch.Stop();
+            logger.Trace($"Time: {watch.ElapsedMilliseconds}");
         }
     }
 
@@ -618,10 +643,45 @@ namespace IntegrationTests
         }
 
         [Test]
+        public async Task AllFinallyHandlersAreCalledOnException()
+        {
+            Stopwatch watch;
+            ILogging logger;
+            StartTest(out watch, out logger);
+
+            var task = new FuncTask<string>(TaskManager.Token, () => { throw new InvalidOperationException(); });
+            bool exceptionThrown1, exceptionThrown2;
+            exceptionThrown1 = exceptionThrown2 = false;
+
+            task.Finally(success => exceptionThrown1 = !success);
+            task.Finally((success, _) => exceptionThrown2 = !success);
+
+            StartTrackTime(watch);
+            var waitTask = task.Start().Task;
+            var ret = await TaskEx.WhenAny(waitTask, TaskEx.Delay(Timeout));
+            StopTrackTimeAndLog(watch, logger);
+            Assert.AreEqual(ret, waitTask);
+
+            exceptionThrown1.Should().BeTrue();
+            exceptionThrown2.Should().BeTrue();
+        }
+
+        [Test]
         public async Task StartAsyncWorks()
         {
+            Stopwatch watch;
+            ILogging logger;
+            StartTest(out watch, out logger);
+
             var task = new FuncTask<int>(Token, _ => 1);
-            var ret = await task.StartAsAsync();
+
+            StartTrackTime(watch);
+            var waitTask = task.StartAsAsync();
+            var retTask = await TaskEx.WhenAny(waitTask, TaskEx.Delay(Timeout));
+            StopTrackTimeAndLog(watch, logger);
+            Assert.AreEqual(retTask, waitTask);
+            var ret = await waitTask;
+
             Assert.AreEqual(1, ret);
         }
 

--- a/src/tests/TaskSystemIntegrationTests/packages.config
+++ b/src/tests/TaskSystemIntegrationTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncBridge.Net35" version="0.2.3333.0" targetFramework="net35" />
+  <package id="FluentAssertions" version="2.2.0.0" targetFramework="net35" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net35" />
   <package id="NUnit" version="2.6.4" targetFramework="net35" />
   <package id="NUnit.Runners" version="2.6.4" targetFramework="net35" />


### PR DESCRIPTION
Built on top of shana/fix-tasks #609
Followed by #608 

- Merging in the loading spinner from #583 
- deduping and killing unused code
- fixing the git installation sequence
- replaying cache invalidation requests that happen before RepositoryManager is set (because data might be requested and invalidated before we've had a chance to finish the initialization)
- fixing the process task begin/end sequence (it could have thrown before OnEnd is called)
