### PR TITLE
[do not merge] Task/Cache Jenga 1: Fixing the task system to be more predictive

### DIFF
--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -217,12 +217,12 @@ namespace GitHub.Unity
                     }
                 })
                 .Then(GetConfig(UserEmailConfigKey, GitConfigSource.User)
-                .Then((success, value) => {
-                    if (success)
-                    {
-                        email = value;
-                    }
-                })).Then(success => {
+                    .Then((success, value) => {
+                        if (success)
+                        {
+                            email = value;
+                        }
+                    })).Then(success => {
                 Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
                 return new GitUser(username, email);
             });

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Helpers\Validation.cs" />
     <Compile Include="Installer\GitInstaller.cs" />
     <Compile Include="Installer\UnzipTask.cs" />
+    <Compile Include="Managers\Downloader.cs" />
     <Compile Include="OutputProcessors\GitAheadBehindStatusOutputProcessor.cs" />
     <Compile Include="OutputProcessors\LfsVersionOutputProcessor.cs" />
     <Compile Include="OutputProcessors\VersionOutputProcessor.cs" />

--- a/src/GitHub.Api/IO/NiceIO.cs
+++ b/src/GitHub.Api/IO/NiceIO.cs
@@ -1074,6 +1074,11 @@ GitHub.Unity
 
             return new NPath(Mono.Unix.UnixPath.GetCompleteRealPath(path.ToString()));
         }
+
+        public static string CalculateMD5(this NPath path)
+        {
+            return NPath.FileSystem.CalculateFileMD5(path);
+        }
     }
 
     public enum SlashMode

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -78,7 +78,7 @@ namespace GitHub.Unity
                     if (expectedMD5 != null)
                     {
                         var calculatedMD5 = fileSystem.CalculateFolderMD5(extractedPath);
-                        success = !calculatedMD5.Equals(expectedMD5, StringComparison.InvariantCultureIgnoreCase);
+                        success = calculatedMD5.Equals(expectedMD5, StringComparison.InvariantCultureIgnoreCase);
                         if (!success)
                         {
                             extractedPath.DeleteIfExists();
@@ -100,7 +100,7 @@ namespace GitHub.Unity
             if (!success)
             {
                 Token.ThrowIfCancellationRequested();
-                throw new UnzipException("Error downloading file", exception);
+                throw new UnzipException("Error unzipping file", exception);
             }
         }
         protected int RetryCount { get; }

--- a/src/GitHub.Api/Installer/ZipHelper.cs
+++ b/src/GitHub.Api/Installer/ZipHelper.cs
@@ -153,12 +153,12 @@ namespace GitHub.Unity
                     using (var streamWriter = targetFile.OpenWrite())
                     {
                         const int chunkSize = 4096; // 4K is optimum
-                        Copy(zipStream, streamWriter, chunkSize, targetFile.Length, (totalRead, timeToFinish) =>
+                        Copy(zipStream, streamWriter, chunkSize, zipEntry.Size, (totalRead, timeToFinish) =>
                         {
                             estimatedDuration = timeToFinish;
 
-                            estimatedDurationProgress.Report(estimatedDuration);
-                            zipFileProgress?.Report((float)(totalBytes + totalRead) / targetFile.Length);
+                            estimatedDurationProgress?.Report(estimatedDuration);
+                            zipFileProgress?.Report((float)(totalBytes + totalRead) / zipEntry.Size);
                             return true;
                         }, 100);
                         cancellationToken.ThrowIfCancellationRequested();

--- a/src/GitHub.Api/Managers/Downloader.cs
+++ b/src/GitHub.Api/Managers/Downloader.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.Logging;
+using System.Linq;
+
+namespace GitHub.Unity
+{
+    class DownloadData
+    {
+        public UriString Url { get; }
+        public NPath File { get; }
+        public DownloadData(UriString url, NPath file)
+        {
+            this.Url = url;
+            this.File = file;
+        }
+    }
+
+    class Downloader : FuncListTask<DownloadData>
+    {
+        public event Action<DownloadData> DownloadStart;
+        public event Action<DownloadData> DownloadComplete;
+        public event Action<DownloadData, Exception> DownloadFailed;
+
+        private readonly List<PairDownloader> downloaders = new List<PairDownloader>();
+
+        public Downloader() : base(TaskManager.Instance.Token, RunDownloaders)
+        {}
+
+        public void QueueDownload(UriString url, UriString md5Url, NPath targetDirectory)
+        {
+            var pairDownloader = new PairDownloader();
+            pairDownloader.QueueDownload(url, md5Url, targetDirectory);
+            downloaders.Add(pairDownloader);
+        }
+
+        private static List<DownloadData> RunDownloaders(bool success, FuncListTask<DownloadData> source)
+        {
+            Downloader self = (Downloader)source;
+            List<DownloadData> result = null;
+            var listOfTasks = new List<Task<DownloadData>>();
+            foreach (var downloader in self.downloaders)
+            {
+                downloader.DownloadStart += self.DownloadStart;
+                downloader.DownloadComplete += self.DownloadComplete;
+                downloader.DownloadFailed += self.DownloadFailed;
+                listOfTasks.Add(downloader.Run());
+            }
+            var res = TaskEx.WhenAll(listOfTasks).Result;
+            if (res != null)
+                result = new List<DownloadData>(res);
+            return result;
+        }
+
+        class PairDownloader
+        {
+            public event Action<DownloadData> DownloadStart;
+            public event Action<DownloadData> DownloadComplete;
+            public event Action<DownloadData, Exception> DownloadFailed;
+
+            private readonly List<ITask<NPath>> queuedTasks = new List<ITask<NPath>>();
+            private readonly TaskCompletionSource<DownloadData> aggregateDownloads = new TaskCompletionSource<DownloadData>();
+            private readonly IFileSystem fs;
+            private readonly CancellationToken cancellationToken;
+
+            private volatile int finishedTaskCount;
+            private volatile bool isSuccessful = true;
+            private volatile Exception exception;
+
+            public PairDownloader()
+            {
+                fs = NPath.FileSystem;
+                cancellationToken = TaskManager.Instance.Token;
+                DownloadComplete += d => aggregateDownloads.TrySetResult(d);
+                DownloadFailed += (_, e) => aggregateDownloads.TrySetException(e);
+            }
+
+            public Task<DownloadData> Run()
+            {
+                foreach (var task in queuedTasks)
+                    task.Start();
+                return aggregateDownloads.Task;
+            }
+
+            public Task<DownloadData> QueueDownload(UriString url, UriString md5Url, NPath targetDirectory)
+            {
+                var destinationFile = targetDirectory.Combine(url.Filename);
+                var destinationMd5 = targetDirectory.Combine(md5Url.Filename);
+                var result = new DownloadData(url, destinationFile);
+
+                Action<ITask<NPath>, NPath, bool, Exception> verifyDownload = (t, res, success, ex) =>
+                {
+                    var count = Interlocked.Increment(ref finishedTaskCount);
+                    isSuccessful &= success;
+                    if (!success)
+                        exception = ex;
+                    if (count == queuedTasks.Count)
+                    {
+                        if (!isSuccessful)
+                        {
+                            DownloadFailed(result, exception);
+                        }
+                        else
+                        {
+                            if (!Utils.VerifyFileIntegrity(destinationFile, destinationMd5))
+                            {
+                                destinationMd5.Delete();
+                                destinationFile.Delete();
+                                DownloadFailed(result, new DownloadException($"Verification of {url} failed"));
+                            }
+                            else
+                                DownloadComplete(result);
+                        }
+                    }
+                };
+
+                var md5Exists = destinationMd5.FileExists();
+                var fileExists = destinationFile.FileExists();
+
+                if (!md5Exists)
+                {
+                    destinationMd5.DeleteIfExists();
+                    var md5Download = new DownloadTask(cancellationToken, fs, md5Url, targetDirectory)
+                        .Catch(e => DownloadFailed(result, e));
+                    md5Download.OnEnd += verifyDownload;
+                    queuedTasks.Add(md5Download);
+                }
+
+                if (!fileExists)
+                {
+                    var fileDownload = new DownloadTask(cancellationToken, fs, url, targetDirectory)
+                        .Catch(e => DownloadFailed(result, e));
+                    fileDownload.OnStart += _ => DownloadStart?.Invoke(result);
+                    fileDownload.OnEnd += verifyDownload;
+                    queuedTasks.Add(fileDownload);
+                }
+
+                if (fileExists && md5Exists)
+                {
+                    var verification = new FuncTask<NPath>(cancellationToken, () => destinationFile);
+                    verification.OnEnd += verifyDownload;
+                    queuedTasks.Add(verification);
+                }
+                return aggregateDownloads.Task;
+            }
+        }
+
+        public static bool Download(ILogging logger, UriString url,
+            Stream destinationStream,
+            Func<long, long, bool> onProgress)
+        {
+            long bytes = destinationStream.Length;
+
+            var expectingResume = bytes > 0;
+
+            var webRequest = (HttpWebRequest)WebRequest.Create(url);
+
+            if (expectingResume)
+            {
+                // classlib for 3.5 doesn't take long overloads...
+                webRequest.AddRange((int)bytes);
+            }
+
+            webRequest.Method = "GET";
+            webRequest.Timeout = ApplicationConfiguration.WebTimeout;
+
+            if (expectingResume)
+                logger.Trace($"Resuming download of {url}");
+            else
+                logger.Trace($"Downloading {url}");
+
+            using (var webResponse = (HttpWebResponse)webRequest.GetResponseWithoutException())
+            {
+                var httpStatusCode = webResponse.StatusCode;
+                logger.Trace($"Downloading {url} StatusCode:{(int)webResponse.StatusCode}");
+
+                if (expectingResume && httpStatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+                {
+                    onProgress(bytes, bytes);
+                    return true;
+                }
+
+                if (!(httpStatusCode == HttpStatusCode.OK || httpStatusCode == HttpStatusCode.PartialContent))
+                {
+                    return false;
+                }
+
+                if (expectingResume && httpStatusCode == HttpStatusCode.OK)
+                {
+                    expectingResume = false;
+                    destinationStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                var responseLength = webResponse.ContentLength;
+                if (expectingResume)
+                {
+                    if (!onProgress(bytes, bytes + responseLength))
+                        return false;
+                }
+
+                using (var responseStream = webResponse.GetResponseStream())
+                {
+                    return Utils.Copy(responseStream, destinationStream, responseLength,
+                        progress: (totalRead, timeToFinish) =>
+                        {
+                            return onProgress(totalRead, responseLength);
+                        });
+                }
+            }
+        }
+    }
+}

--- a/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
+++ b/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
+    public interface ITaskScheduler
+    {
+        Queue<Task> Tasks { get; }
+        void ExecuteTask(Task task);
+    }
+
     class TaskSchedulerExcludingThread : TaskScheduler
     {
         private static ParameterizedThreadStart longRunningThreadWork = new ParameterizedThreadStart(LongRunningThreadWork);
@@ -91,7 +98,7 @@ namespace GitHub.Unity
         /// <summary>Synchronizes all activity in this type and its generated schedulers.</summary>
         private readonly object internalLock;
         /// <summary>The scheduler used to queue and execute "reader" tasks that may run concurrently with other readers.</summary>
-        private readonly ConcurrentExclusiveTaskScheduler concurrentTaskScheduler;
+        private readonly ITaskScheduler concurrentTaskScheduler;
         /// <summary>Whether the exclusive processing of a task should include all of its children as well.</summary>
         private readonly bool exclusiveProcessingIncludesChildren;
         /// <summary>The scheduler used to queue and execute "writer" tasks that must run exclusively while no other tasks for this interleave are running.</summary>
@@ -121,7 +128,8 @@ namespace GitHub.Unity
             // Create the state for this interleave
             internalLock = new object();
             this.exclusiveProcessingIncludesChildren = exclusiveProcessingIncludesChildren;
-            concurrentTaskScheduler = new ConcurrentExclusiveTaskScheduler(this, new Queue<Task>(), interleaveTaskScheduler.MaximumConcurrencyLevel);
+            //concurrentTaskScheduler = new ConcurrentExclusiveTaskScheduler(this, new Queue<Task>(), interleaveTaskScheduler.MaximumConcurrencyLevel);
+            concurrentTaskScheduler = new ThreadPerTaskScheduler();
             exclusiveTaskScheduler = new ConcurrentExclusiveTaskScheduler(this, new Queue<Task>(), 1);
         }
 
@@ -150,6 +158,8 @@ namespace GitHub.Unity
         /// <remarks>This has been separated out into its own method to improve the Parallel Tasks window experience.</remarks>
         private void ConcurrentExclusiveInterleaveProcessor()
         {
+            Logging.LogHelper.GetLogger<ConcurrentExclusiveInterleave>().Trace("ConcurrentExclusiveInterleaveProcessor");
+
             if (token.IsCancellationRequested) return;
             interleaveTaskScheduler.ThreadToExclude = Thread.CurrentThread.ManagedThreadId;
 
@@ -262,7 +272,7 @@ namespace GitHub.Unity
         /// Gets a TaskScheduler that can be used to schedule tasks to this interleave
         /// that may run concurrently with other tasks on this interleave.
         /// </summary>
-        public TaskScheduler ConcurrentTaskScheduler
+        public ITaskScheduler ConcurrentTaskScheduler
         {
             get { return concurrentTaskScheduler; }
         }
@@ -330,7 +340,7 @@ namespace GitHub.Unity
         /// <summary>
         /// A scheduler shim used to queue tasks to the interleave and execute those tasks on request of the interleave.
         /// </summary>
-        private class ConcurrentExclusiveTaskScheduler : TaskScheduler
+        private class ConcurrentExclusiveTaskScheduler : TaskScheduler, ITaskScheduler
         {
             /// <summary>The parent interleave.</summary>
             private readonly ConcurrentExclusiveInterleave interleave;
@@ -389,7 +399,7 @@ namespace GitHub.Unity
 
             /// <summary>Executes a task on this scheduler.</summary>
             /// <param name="task">The task to be executed.</param>
-            internal void ExecuteTask(Task task)
+            public void ExecuteTask(Task task)
             {
                 var isProcessingTaskOnCurrentThread = this.processingTaskOnCurrentThread.Value;
                 if (!isProcessingTaskOnCurrentThread) this.processingTaskOnCurrentThread.Value = true;
@@ -413,7 +423,37 @@ namespace GitHub.Unity
             }
 
             /// <summary>Gets the queue of tasks for this scheduler.</summary>
-            internal Queue<Task> Tasks { get; }
+            public Queue<Task> Tasks { get; }
+        }
+    }
+
+    /// <summary>Provides a task scheduler that dedicates a thread per task.</summary>
+    public class ThreadPerTaskScheduler : TaskScheduler, ITaskScheduler
+    {
+        /// <summary>Gets the tasks currently scheduled to this scheduler.</summary>
+        /// <remarks>This will always return an empty enumerable, as tasks are launched as soon as they're queued.</remarks>
+        protected override IEnumerable<Task> GetScheduledTasks() { return Enumerable.Empty<Task>(); }
+        public Queue<Task> Tasks { get; } = new Queue<Task>();
+
+        /// <summary>Starts a new thread to process the provided task.</summary>
+        /// <param name="task">The task to be executed.</param>
+        protected override void QueueTask(Task task)
+        {
+            new Thread(() => TryExecuteTask(task)) { IsBackground = true }.Start();
+        }
+
+        /// <summary>Runs the provided task on the current thread.</summary>
+        /// <param name="task">The task to be executed.</param>
+        /// <param name="taskWasPreviouslyQueued">Ignored.</param>
+        /// <returns>Whether the task could be executed on the current thread.</returns>
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            return TryExecuteTask(task);
+        }
+
+        public void ExecuteTask(Task task)
+        {
+            TryExecuteTask(task);
         }
     }
 }

--- a/src/GitHub.Api/Tasks/TaskExtensions.cs
+++ b/src/GitHub.Api/Tasks/TaskExtensions.cs
@@ -236,7 +236,7 @@ namespace GitHub.Unity
         public static Task<T> StartAsAsync<T>(this ITask<T> task)
         {
             var tcs = new TaskCompletionSource<T>();
-            task.Finally(r =>
+            task.Finally((success, r) =>
             {
                 tcs.TrySetResult(r);
             });
@@ -251,9 +251,9 @@ namespace GitHub.Unity
         public static Task<bool> StartAsAsync(this ITask task)
         {
             var tcs = new TaskCompletionSource<bool>();
-            task.Finally(() =>
+            task.Finally(success =>
             {
-                tcs.TrySetResult(true);
+                tcs.TrySetResult(success);
             });
             task.Catch(e =>
             {

--- a/src/GitHub.Api/Tasks/TaskExtensions.cs
+++ b/src/GitHub.Api/Tasks/TaskExtensions.cs
@@ -121,31 +121,19 @@ namespace GitHub.Unity
             };
         }
 
-        public static ITask Then(this ITask task, Action continuation, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
-        {
-            Guard.ArgumentNotNull(continuation, "continuation");
-            return task.Then(new ActionTask(task.Token, _ => continuation()) { Name = "Then" }, runOptions);
-        }
-
-        public static ITask Then(this ITask task, Action continuation, TaskAffinity affinity, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
+        public static ITask Then(this ITask task, Action continuation, TaskAffinity affinity = TaskAffinity.Concurrent, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
         {
             Guard.ArgumentNotNull(continuation, "continuation");
             return task.Then(new ActionTask(task.Token, _ => continuation()) { Affinity = affinity, Name = "Then" }, runOptions);
         }
 
-        public static ITask Then(this ITask task, Action<bool> continuation, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
-        {
-            Guard.ArgumentNotNull(continuation, "continuation");
-            return task.Then(new ActionTask(task.Token, continuation) { Name = "Then" }, runOptions);
-        }
-
-        public static ITask Then(this ITask task, Action<bool> continuation, TaskAffinity affinity, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
+        public static ITask Then(this ITask task, Action<bool> continuation, TaskAffinity affinity = TaskAffinity.Concurrent, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
         {
             Guard.ArgumentNotNull(continuation, "continuation");
             return task.Then(new ActionTask(task.Token, continuation) { Affinity = affinity, Name = "Then" }, runOptions);
         }
 
-        public static ITask Then<T>(this ITask task, ActionTask<T> nextTask, T valueForNextTask, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
+        public static ITask Then<T>(this ITask task, ActionTask<T> nextTask, T valueForNextTask, TaskAffinity affinity = TaskAffinity.Concurrent, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
         {
             Guard.ArgumentNotNull(nextTask, nameof(nextTask));
             nextTask.PreviousResult = valueForNextTask;

--- a/src/GitHub.Api/Tasks/TaskManager.cs
+++ b/src/GitHub.Api/Tasks/TaskManager.cs
@@ -12,7 +12,7 @@ namespace GitHub.Unity
         private CancellationTokenSource cts;
         private readonly ConcurrentExclusiveInterleave manager;
         public TaskScheduler UIScheduler { get; set; }
-        public TaskScheduler ConcurrentScheduler { get { return manager.ConcurrentTaskScheduler; } }
+        public TaskScheduler ConcurrentScheduler { get { return (TaskScheduler)manager.ConcurrentTaskScheduler; } }
         public TaskScheduler ExclusiveScheduler { get { return manager.ExclusiveTaskScheduler; } }
         public CancellationToken Token { get { return cts.Token; } }
 
@@ -149,7 +149,7 @@ namespace GitHub.Unity
                     TaskContinuationOptions.OnlyOnFaulted, ConcurrentScheduler
                 );
             }
-            return (T)task.Start(manager.ConcurrentTaskScheduler);
+            return (T)task.Start((TaskScheduler)manager.ConcurrentTaskScheduler);
         }
 
         private void Stop()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -13,47 +13,44 @@ namespace GitHub.Unity
     [Serializable]
     public class ChangesTreeNode : TreeNode
     {
-        public string projectPath;
-        public GitFileStatus gitFileStatus;
-        public bool isLocked;
-
-        public GitStatusEntry GitStatusEntry { get; set; }
-
-        public string ProjectPath
-        {
-            get { return GitStatusEntry.projectPath; }
-        }
-
-        public GitFileStatus GitFileStatus
-        {
-            get { return GitStatusEntry.status; }
-        }
+        [SerializeField] private bool isLocked;
+        [SerializeField] private GitStatusEntry gitStatusEntry;
 
         public bool IsLocked
         {
             get { return isLocked; }
             set { isLocked = value; }
         }
+        public GitStatusEntry GitStatusEntry
+        {
+            get { return gitStatusEntry; }
+            set { gitStatusEntry = value; }
+        }
+
+        public string ProjectPath { get { return GitStatusEntry.projectPath; } }
+        public GitFileStatus GitFileStatus { get { return GitStatusEntry.status; } }
     }
 
     [Serializable]
     public class ChangesTree : Tree<ChangesTreeNode, GitStatusEntryTreeData>
     {
+        [NonSerialized] public Texture2D FolderIcon;
+
         [SerializeField] public ChangesTreeNodeDictionary assets = new ChangesTreeNodeDictionary();
         [SerializeField] public ChangesTreeNodeDictionary folders = new ChangesTreeNodeDictionary();
         [SerializeField] public ChangesTreeNodeDictionary checkedFileNodes = new ChangesTreeNodeDictionary();
-
-        [NonSerialized] public Texture2D FolderIcon;
         [SerializeField] public string title = string.Empty;
         [SerializeField] public string pathSeparator = "/";
         [SerializeField] public bool displayRootNode = true;
         [SerializeField] public bool isSelectable = true;
         [SerializeField] public bool isCheckable = false;
         [SerializeField] public bool isUsingGlobalSelection = false;
-        [SerializeField] private List<ChangesTreeNode> nodes = new List<ChangesTreeNode>();
-        [SerializeField] private ChangesTreeNode selectedNode = null;
+
         [NonSerialized] private bool viewHasFocus;
         [NonSerialized] private Object lastActivatedObject;
+
+        [SerializeField] private List<ChangesTreeNode> nodes = new List<ChangesTreeNode>();
+        [SerializeField] private ChangesTreeNode selectedNode = null;
 
         public override string Title
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -677,7 +677,7 @@ namespace GitHub.Unity
                             // whether pull triggered a merge or a rebase, and abort the operation accordingly
                             // (either git rebase --abort or git merge --abort)
                         }
-                    }, TaskRunOptions.OnAlways)
+                    }, runOptions: TaskRunOptions.OnAlways)
                     .FinallyInUI((success, e) => {
                         if (success)
                         {

--- a/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
+++ b/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
@@ -202,7 +202,7 @@ namespace IntegrationTests.Download
             md5Sum.Should().BeEquivalentTo(md5);
         }
 
-        [Test]
+        [Category("DoNotRunOnAppVeyor")]
         public async Task DownloadsRunSideBySide()
         {
             Stopwatch watch;

--- a/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
+++ b/src/tests/IntegrationTests/Download/DownloadTaskTests.cs
@@ -77,7 +77,7 @@ namespace IntegrationTests.Download
 
             StartTrackTime(watch, logger, gitLfsMd5);
             new DownloadTextTask(TaskManager.Token, fileSystem, gitLfsMd5, TestBasePath)
-                .Finally(r => {
+                .Finally((success, r) => {
                     md5 = r;
                     evtDone.Set();
                 })
@@ -92,7 +92,7 @@ namespace IntegrationTests.Download
             string downloadPath = null;
             StartTrackTime(watch, logger, gitLfs);
             new DownloadTask(TaskManager.Token, fileSystem, gitLfs, TestBasePath)
-                .Finally(r => {
+                .Finally((success, r) => {
                     downloadPath = r;
                     evtDone.Set();
                 })
@@ -117,7 +117,7 @@ namespace IntegrationTests.Download
 
             StartTrackTime(watch, logger, "resuming download");
             new DownloadTask(TaskManager.Token, fileSystem, gitLfs, TestBasePath)
-                .Finally(r => {
+                .Finally((success, r) => {
                     downloadPath = r;
                     evtDone.Set();
                 })
@@ -153,8 +153,8 @@ namespace IntegrationTests.Download
 
             StartTrackTime(watch);
             downloadTask
-                .Finally((b, exception) => {
-                    taskFailed = !b;
+                .Finally((success, exception) => {
+                    taskFailed = !success;
                     exceptionThrown = exception;
                     autoResetEvent.Set();
                 })
@@ -187,7 +187,7 @@ namespace IntegrationTests.Download
 
             StartTrackTime(watch);
             downloadTask
-                .Finally(r => {
+                .Finally((success, r) => {
                     result = r;
                     autoResetEvent.Set();
                 })
@@ -215,8 +215,8 @@ namespace IntegrationTests.Download
 
             StartTrackTime(watch);
             downloadTask
-            .Finally((b, exception) => {
-                exceptionThrown = exception != null;
+            .Finally(success => {
+                exceptionThrown = !success;
                 autoResetEvent.Set();
             })
             .Start();

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -14,64 +14,44 @@ namespace IntegrationTests
     class UnzipTaskTests : BaseTaskManagerTest
     {
         [Test]
-        public void TaskSucceeds()
+        public async Task UnzipWorks()
         {
             InitializeTaskManager();
 
             var cacheContainer = Substitute.For<ICacheContainer>();
             Environment = new IntegrationTestEnvironment(cacheContainer, TestBasePath, SolutionDirectory);
 
-            var destinationPath = TestBasePath.Combine("git_zip").CreateDirectory();
-            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", destinationPath, Environment);
+            var destinationPath = TestBasePath.Combine("gitlfs_zip").CreateDirectory();
+            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", destinationPath, Environment);
 
-            var extractedPath = TestBasePath.Combine("git_zip_extracted").CreateDirectory();
+            var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
-            var zipProgress = 0;
-            Logger.Trace("Pct Complete {0}%", zipProgress);
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, GitInstallDetails.GitExtractedMD5, 
-                new Progress<float>(zipFileProgress => {
-                    var zipFileProgressInteger = (int) (zipFileProgress * 100);
-                    if (zipProgress != zipFileProgressInteger)
-                    {
-                        zipProgress = zipFileProgressInteger;
-                        Logger.Trace("Pct Complete {0}%", zipProgress);
-                    }
-                }));
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath,
+                Environment.FileSystem, GitInstallDetails.GitLfsExtractedMD5);
 
-            unzipTask.Start().Wait();
+            await unzipTask.StartAwait();
 
             extractedPath.DirectoryExists().Should().BeTrue();
         }
 
         [Test]
-        public void TaskFailsWhenMD5Incorect()
+        public void FailsWhenMD5Incorrect()
         {
             InitializeTaskManager();
 
             var cacheContainer = Substitute.For<ICacheContainer>();
             Environment = new IntegrationTestEnvironment(cacheContainer, TestBasePath, SolutionDirectory);
 
-            var destinationPath = TestBasePath.Combine("git_zip").CreateDirectory();
-            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git.zip", destinationPath, Environment);
+            var destinationPath = TestBasePath.Combine("gitlfs_zip").CreateDirectory();
+            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", destinationPath, Environment);
 
-            var extractedPath = TestBasePath.Combine("git_zip_extracted").CreateDirectory();
+            var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
+            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, "AABBCCDD");
 
-            var failed = false;
-            Exception exception = null;
-
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, Environment.FileSystem, "AABBCCDD")
-                .Finally((b, ex) => {
-                    failed = true;
-                    exception = ex;
-                });
-
-            unzipTask.Start().Wait();
+            Assert.Throws<UnzipException>(async () => await unzipTask.StartAwait());
 
             extractedPath.DirectoryExists().Should().BeFalse();
-            failed.Should().BeTrue();
-            exception.Should().NotBeNull();
-            exception.Should().BeOfType<UnzipException>();
         }
     }
 }

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -71,7 +71,7 @@ namespace IntegrationTests
             extractedPath.DirectoryExists().Should().BeFalse();
             failed.Should().BeTrue();
             exception.Should().NotBeNull();
-            exception.Should().BeOfType<UnzipTaskException>();
+            exception.Should().BeOfType<UnzipException>();
         }
     }
 }

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -136,7 +136,7 @@ namespace IntegrationTests
                 values.Add("OnStart");
             };
 
-            combinedTask.OnEnd += task => {
+            combinedTask.OnEnd += (task, success, ex) => {
                 values.Add("OnEnd");
             };
 
@@ -599,7 +599,7 @@ namespace IntegrationTests
             var runOrder = new List<string>();
             ITask task = new ActionTask(Token, _ => { throw new Exception(); });
             task.OnStart += _ => runOrder.Add("start");
-            task.OnEnd += _ => runOrder.Add("end");
+            task.OnEnd += (_, __, ___) => runOrder.Add("end");
             task = task.Finally((_, __) => {});
 
             await task.StartAndSwallowException();

--- a/src/tests/TestWebServer/HttpServer.cs
+++ b/src/tests/TestWebServer/HttpServer.cs
@@ -75,7 +75,8 @@ namespace TestWebServer
                         abort = false;
                         Logger.Info($"Waiting for a request...");
                         var context = listener.GetContext();
-                        Process(context);
+                        var thread = new Thread(p => Process((HttpListenerContext)p));
+                        thread.Start(context);
                     }
                     catch (Exception ex)
                     {
@@ -98,7 +99,10 @@ namespace TestWebServer
 
         private void Process(HttpListenerContext context)
         {
+            Logger.Info($"Handling request");
+
             var filename = context.Request.Url.AbsolutePath;
+            Logger.Info($"{filename}");
             filename = filename.TrimStart('/');
             filename = Path.Combine(rootDirectory, filename);
 


### PR DESCRIPTION
Followed by #608 

Includes:

- #585 - Downloading zips to a known location
- Essential changes in #590 
- Fix start/end handlers and tweak Finally callback
  - It's useful to have the success of the state in the Finally handler that is called in-thread (the ITask-based Finally handlers already get this information), so add that to the callback.
  - In order for the API not to be confusing, make the task affinity parameter mandatory on the Finally overloads that run on a separate thread.
- Fix the HookupHandlers method to use OnStart/Finally so that the callbacks get called on the same thread and not spin up new threads just to set flags. They're already running on non-main threads and doing very simple things so this should be fine.
-  Fix Unzip task, it wasn't raising OnStart/OnEnd
- Fix a bunch of bugs in the task system related to tasks that run on failure
- Make it so we don't run tasks inside tasks, and instead just run one chain (so it can fail and we can catch it)
- Make the downloads in pairs (file and md5) in a downloader class that can run them all parallel.
- I kept getting deadlocks and it's something to do with how the concurrent scheduler is set up, so replaced it with a scheduler that just fires a thread per task and does nothing smart about it.