### PR TITLE
Make sure events are unhooked when we're disposing so they don't leak

### DIFF
--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -14,7 +14,7 @@ namespace GitHub.Unity
         GitUser
     }
 
-    public interface ICacheContainer
+    public interface ICacheContainer : IDisposable
     {
         event Action<CacheType> CacheInvalidated;
         event Action<CacheType, DateTimeOffset> CacheUpdated;
@@ -34,8 +34,8 @@ namespace GitHub.Unity
 
     public interface IManagedCache
     {
-        event Action CacheInvalidated;
-        event Action<DateTimeOffset> CacheUpdated;
+        event Action<CacheType> CacheInvalidated;
+        event Action<CacheType, DateTimeOffset> CacheUpdated;
 
         bool ValidateData();
         void InvalidateData();

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -276,6 +276,14 @@ namespace GitHub.Unity
                 if (!disposed)
                 {
                     disposed = true;
+                    HeadChanged = null;
+                    IndexChanged = null;
+                    ConfigChanged = null;
+                    RepositoryCommitted = null;
+                    RepositoryChanged = null;
+                    LocalBranchesChanged = null;
+                    RemoteBranchesChanged = null;
+
                     Stop();
                     if (nativeInterface != null)
                     {

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -6,7 +6,7 @@ namespace GitHub.Unity
     /// <summary>
     /// Represents a repository, either local or retrieved via the GitHub API.
     /// </summary>
-    public interface IRepository : IEquatable<IRepository>
+    public interface IRepository : IEquatable<IRepository>, IDisposable
     {
         void Initialize(IRepositoryManager repositoryManager, ITaskManager taskManager);
         void Start();

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -282,6 +282,25 @@ namespace GitHub.Unity
             return new GitBranch(branchName, trackingName, isActive);
         }
 
+
+        private bool disposed;
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+
         private static GitBranch GetRemoteGitBranch(ConfigBranch x) => new GitBranch(x.Remote.Value.Name + "/" + x.Name, "[None]", false);
         private static GitRemote GetGitRemote(ConfigRemote configRemote) => new GitRemote(configRemote.Name, configRemote.Url);
 

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -18,6 +18,7 @@ namespace GitHub.Unity
         event Action<Dictionary<string, ConfigBranch>> LocalBranchesUpdated;
         event Action<Dictionary<string, ConfigRemote>, Dictionary<string, Dictionary<string, ConfigBranch>>> RemoteBranchesUpdated;
         event Action<GitAheadBehindStatus> GitAheadBehindStatusUpdated;
+
         event Action<CacheType> DataNeedsRefreshing;
 
         void Initialize();
@@ -115,6 +116,7 @@ namespace GitHub.Unity
         public event Action<List<GitLogEntry>> GitLogUpdated;
         public event Action<Dictionary<string, ConfigBranch>> LocalBranchesUpdated;
         public event Action<Dictionary<string, ConfigRemote>, Dictionary<string, Dictionary<string, ConfigBranch>>> RemoteBranchesUpdated;
+
         public event Action<CacheType> DataNeedsRefreshing;
 
         public RepositoryManager(IGitConfig gitConfig,
@@ -610,6 +612,14 @@ namespace GitHub.Unity
 
             if (disposing)
             {
+                CurrentBranchUpdated = null;
+                GitStatusUpdated = null;
+                GitAheadBehindStatusUpdated = null;
+                GitLogUpdated = null;
+                GitLocksUpdated = null;
+                LocalBranchesUpdated = null;
+                RemoteBranchesUpdated = null;
+                DataNeedsRefreshing = null;
                 Stop();
                 watcher.Dispose();
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -133,8 +133,8 @@ namespace GitHub.Unity
         [NonSerialized] private DateTimeOffset? lastUpdatedAtValue;
         [NonSerialized] private DateTimeOffset? initializedAtValue;
 
-        public event Action CacheInvalidated;
-        public event Action<DateTimeOffset> CacheUpdated;
+        public event Action<CacheType> CacheInvalidated;
+        public event Action<CacheType, DateTimeOffset> CacheUpdated;
 
         protected ManagedCacheBase(CacheType type)
         {
@@ -159,7 +159,7 @@ namespace GitHub.Unity
         {
             Logger.Trace("Invalidate");
             LastUpdatedAt = DateTimeOffset.MinValue;
-            CacheInvalidated.SafeInvoke();
+            CacheInvalidated.SafeInvoke(CacheType);
         }
 
         protected void SaveData(DateTimeOffset now, bool isChanged)
@@ -175,7 +175,7 @@ namespace GitHub.Unity
             if (isChanged)
             {
                 Logger.Trace("Updated: {0}", now);
-                CacheUpdated.SafeInvoke(now);
+                CacheUpdated.SafeInvoke(CacheType, now);
             }
         }
 

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -212,6 +212,8 @@ namespace IntegrationTests
         public virtual void OnTearDown()
         {
             TaskManager.Dispose();
+            Environment?.CacheContainer.Dispose();
+
             Logger.Debug("Deleting TestBasePath: {0}", TestBasePath.ToString());
             for (var i = 0; i < 5; i++)
             {

--- a/src/tests/IntegrationTests/CachingClasses.cs
+++ b/src/tests/IntegrationTests/CachingClasses.cs
@@ -109,8 +109,8 @@ namespace IntegrationTests
 
         private bool isInvalidating;
 
-        public event Action CacheInvalidated;
-        public event Action<DateTimeOffset> CacheUpdated;
+        public event Action<CacheType> CacheInvalidated;
+        public event Action<CacheType, DateTimeOffset> CacheUpdated;
 
         protected ManagedCacheBase(CacheType type)
         {
@@ -138,7 +138,7 @@ namespace IntegrationTests
             {
                 isInvalidating = true;
                 LastUpdatedAt = DateTimeOffset.MinValue;
-                CacheInvalidated.SafeInvoke();
+                CacheInvalidated.SafeInvoke(CacheType);
             }
         }
 
@@ -157,7 +157,7 @@ namespace IntegrationTests
             if (isChanged)
             {
                 Logger.Trace("Updated: {0}", now);
-                CacheUpdated.SafeInvoke(now);
+                CacheUpdated.SafeInvoke(CacheType, now);
             }
         }
 


### PR DESCRIPTION
Most of our objects are singletons that live through the lifetime of the process (the lifetime being the time between Unity reloading domains whenever it recompiles or the user enters play mode), we never really worry much about unhooking events to allow objects to be GC'd and to not raise events on objects that are dead.

In our tests, however, that's a problem, since we're not reloading the domain and killing all the things between one test and the other, which means events can definitely leak and may cause problems.

This makes sure we break event loops so that tests don't trample all over each other. It's not a thorough audit of everything that we need to dispose, but it's a start.