### PR TITLE
Adding a field in Environment to locate Unity's content's path

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -88,9 +88,7 @@ namespace GitHub.Unity
 
             var targetPath = NPath.CurrentDirectory;
 
-            var unityYamlMergeExec = Environment.IsWindows
-                ? Environment.UnityApplicationContents.Parent.Combine("Tools", "UnityYAMLMerge.exe")
-                : Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge");
+            var unityYamlMergeExec = Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge" + Environment.ExecutableExtension);
 
             var yamlMergeCommand = Environment.IsWindows
                 ? $@"'{unityYamlMergeExec}' merge -p ""$BASE"" ""$REMOTE"" ""$LOCAL"" ""$MERGED"""

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -89,8 +89,8 @@ namespace GitHub.Unity
             var targetPath = NPath.CurrentDirectory;
 
             var unityYamlMergeExec = Environment.IsWindows
-                ? Environment.UnityApplication.Parent.Combine("Data", "Tools", "UnityYAMLMerge.exe")
-                : Environment.UnityApplication.Combine("Contents", "Tools", "UnityYAMLMerge");
+                ? Environment.UnityApplicationContents.Parent.Combine("Tools", "UnityYAMLMerge.exe")
+                : Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge");
 
             var yamlMergeCommand = Environment.IsWindows
                 ? $@"'{unityYamlMergeExec}' merge -p ""$BASE"" ""$REMOTE"" ""$LOCAL"" ""$MERGED"""

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -143,7 +143,7 @@ namespace GitHub.Unity
                 if (!nodeJsExecutablePath.IsInitialized)
                 {
                     nodeJsExecutablePath = IsWindows
-                        ? UnityApplicationContents.Parent.Combine("Tools", "nodejs", "node.exe")
+                        ? UnityApplicationContents.Combine("Tools", "nodejs", "node.exe")
                         : UnityApplicationContents.Combine("Tools", "nodejs", "node");
                 }
 

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -42,10 +42,11 @@ namespace GitHub.Unity
             this.CacheContainer = cacheContainer;
         }
 
-        public void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityPath, NPath assetsPath)
+        public void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityApplicationPath, NPath unityApplicationContentsPath, NPath assetsPath)
         {
             ExtensionInstallPath = extensionInstallPath;
-            UnityApplication = unityPath;
+            UnityApplication = unityApplicationPath;
+            UnityApplicationContents = unityApplicationContentsPath;
             UnityAssetsPath = assetsPath;
             UnityProjectPath = assetsPath.Parent;
             UnityVersion = unityVersion;
@@ -109,6 +110,7 @@ namespace GitHub.Unity
         public IFileSystem FileSystem { get { return NPath.FileSystem; } set { NPath.FileSystem = value; } }
         public string UnityVersion { get; set; }
         public NPath UnityApplication { get; set; }
+        public NPath UnityApplicationContents { get; set; }
         public NPath UnityAssetsPath { get; set; }
         public NPath UnityProjectPath { get; set; }
         public NPath ExtensionInstallPath { get; set; }
@@ -141,8 +143,8 @@ namespace GitHub.Unity
                 if (!nodeJsExecutablePath.IsInitialized)
                 {
                     nodeJsExecutablePath = IsWindows
-                        ? UnityApplication.Parent.Combine("Data", "Tools", "nodejs", "node.exe")
-                        : UnityApplication.Combine("Contents", "Tools", "nodejs", "node");
+                        ? UnityApplicationContents.Parent.Combine("Tools", "nodejs", "node.exe")
+                        : UnityApplicationContents.Combine("Tools", "nodejs", "node");
                 }
 
                 return nodeJsExecutablePath;

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -142,9 +142,8 @@ namespace GitHub.Unity
             {
                 if (!nodeJsExecutablePath.IsInitialized)
                 {
-                    nodeJsExecutablePath = IsWindows
-                        ? UnityApplicationContents.Combine("Tools", "nodejs", "node.exe")
-                        : UnityApplicationContents.Combine("Tools", "nodejs", "node");
+                    nodeJsExecutablePath =
+                        UnityApplicationContents.Combine("Tools", "nodejs", "node" + ExecutableExtension);
                 }
 
                 return nodeJsExecutablePath;
@@ -209,7 +208,7 @@ namespace GitHub.Unity
             }
             set { onMac = value; }
         }
-        public string ExecutableExtension { get { return IsWindows ? ".exe" : null; } }
+        public string ExecutableExtension { get { return IsWindows ? ".exe" : string.Empty; } }
         protected static ILogging Logger { get; } = LogHelper.GetLogger<DefaultEnvironment>();
     }
 }

--- a/src/GitHub.Api/Platform/IEnvironment.cs
+++ b/src/GitHub.Api/Platform/IEnvironment.cs
@@ -4,7 +4,7 @@ namespace GitHub.Unity
 {
     public interface IEnvironment
     {
-        void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityPath, NPath assetsPath);
+        void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityApplicationPath, NPath unityApplicationContentsPath, NPath assetsPath);
         void InitializeRepository(NPath? expectedRepositoryPath = null);
         string ExpandEnvironmentVariables(string name);
         string GetEnvironmentVariable(string v);
@@ -20,6 +20,7 @@ namespace GitHub.Unity
         bool IsMac { get; }
         string UnityVersion { get; }
         NPath UnityApplication { get; }
+        NPath UnityApplicationContents { get; }
         NPath UnityAssetsPath { get; }
         NPath UnityProjectPath { get; }
         NPath ExtensionInstallPath { get; }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -81,6 +81,7 @@ namespace GitHub.Unity
         [SerializeField] private string extensionInstallPath;
         [SerializeField] private string repositoryPath;
         [SerializeField] private string unityApplication;
+        [SerializeField] private string unityApplicationContents;
         [SerializeField] private string unityAssetsPath;
         [SerializeField] private string unityVersion;
 
@@ -88,6 +89,7 @@ namespace GitHub.Unity
         {
             repositoryPath = Environment.RepositoryPath;
             unityApplication = Environment.UnityApplication;
+            unityApplicationContents = Environment.UnityApplicationContents;
             unityAssetsPath = Environment.UnityAssetsPath;
             extensionInstallPath = Environment.ExtensionInstallPath;
             Save(true);
@@ -114,11 +116,12 @@ namespace GitHub.Unity
                     {
                         unityAssetsPath = Application.dataPath;
                         unityApplication = EditorApplication.applicationPath;
+                        unityApplicationContents = EditorApplication.applicationContentsPath;
                         extensionInstallPath = DetermineInstallationPath();
                         unityVersion = Application.unityVersion;
                     }
                     environment.Initialize(unityVersion, extensionInstallPath.ToNPath(), unityApplication.ToNPath(),
-                        unityAssetsPath.ToNPath());
+                        unityApplicationContents.ToNPath(), unityAssetsPath.ToNPath());
                     NPath? path = null;
                     if (!String.IsNullOrEmpty(repositoryPath))
                         path = repositoryPath.ToNPath();

--- a/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
@@ -33,7 +33,7 @@ namespace IntegrationTests
 
             var installPath = solutionDirectory.Parent.Parent.Combine("src", "GitHub.Api");
 
-            Initialize(UnityVersion, installPath, solutionDirectory, repoPath.Combine("Assets"));
+            Initialize(UnityVersion, installPath, solutionDirectory, NPath.Default, repoPath.Combine("Assets"));
 
             if (initializeRepository)
                 InitializeRepository();
@@ -47,9 +47,9 @@ namespace IntegrationTests
             }
         }
 
-        public void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityPath, NPath assetsPath)
+        public void Initialize(string unityVersion, NPath extensionInstallPath, NPath unityPath, NPath unityContentsPath, NPath assetsPath)
         {
-            defaultEnvironment.Initialize(unityVersion, extensionInstallPath, unityPath, assetsPath);
+            defaultEnvironment.Initialize(unityVersion, extensionInstallPath, unityPath, unityContentsPath, assetsPath);
         }
 
         public void InitializeRepository(NPath? expectedPath = null)
@@ -113,6 +113,8 @@ namespace IntegrationTests
         public bool IsMac => defaultEnvironment.IsMac;
 
         public NPath UnityApplication => defaultEnvironment.UnityApplication;
+
+        public NPath UnityApplicationContents => defaultEnvironment.UnityApplicationContents;
 
         public NPath UnityAssetsPath => defaultEnvironment.UnityAssetsPath;
 


### PR DESCRIPTION
Fixes #622 

Adding `UnityContentsPath` as a field to `Environment` and using it where appropriate