### PR TITLE
Fix path to node on mac/unix

### DIFF
--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -164,7 +164,11 @@ namespace GitHub.Unity
             get
             {
                 if (!nodeJsExecutablePath.IsInitialized)
-                    nodeJsExecutablePath = UnityApplicationContents.Combine("Tools", "nodejs", "node" + ExecutableExtension);
+                {
+                    nodeJsExecutablePath = IsWindows ?
+                        UnityApplicationContents.Combine("Tools", "nodejs", "node" + ExecutableExtension) :
+                        UnityApplicationContents.Combine("Tools", "nodejs", "bin", "node" + ExecutableExtension);
+                }
                 return nodeJsExecutablePath;
             }
         }


### PR DESCRIPTION
In non-Windows, Unity has the node executable inside a bin directory, just 'cause.