### PR TITLE
Fix a bunch of mac things

### DIFF
--- a/common/SolutionInfo.cs
+++ b/common/SolutionInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "0.30.1";
+        internal const string Version = "0.30.2";
     }
 }

--- a/common/properties.props
+++ b/common/properties.props
@@ -3,6 +3,7 @@
   <!-- Build flags -->
   <PropertyGroup>
     <BuildType Condition="Exists('$(SolutionDir)script\src\MetricsService.cs')">Internal</BuildType>
+    <BuildDefs Condition="Exists('$(SolutionDir)script\src\MetricsService.cs')">ENABLE_METRICS</BuildDefs>
 
     <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\script\lib\UnityEditor.dll')">$(SolutionDir)\script\lib\</UnityDir>
     <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\lib\UnityEditor.dll')">$(SolutionDir)\lib\</UnityDir>

--- a/src/GitHub.Api/Application/ApplicationInfo.cs
+++ b/src/GitHub.Api/Application/ApplicationInfo.cs
@@ -4,7 +4,7 @@ namespace GitHub.Unity
     static partial class ApplicationInfo
     {
 #if DEBUG
-        public const string ApplicationName = "GitHubUnityDebug";
+        public const string ApplicationName = "GitHub for Unity Debug";
         public const string ApplicationProvider = "GitHub";
 #else
         public const string ApplicationName = "GitHubUnity";

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -84,16 +84,15 @@ namespace GitHub.Unity
                     if (path.IsInitialized)
                         return;
 
-                    Logger.Trace("No git path found in settings");
+                    Logger.Trace("Using portable git");
 
                     var gitInstaller = new GitInstaller(Environment, ProcessManager, TaskManager);
 
-                    // if successful, continue with environment initialization, otherwise try to find an existing git installation
                     var task = gitInstaller.SetupGitIfNeeded();
                     task.Progress(progressReporter.UpdateProgress);
                     task.OnEnd += (thisTask, result, success, exception) =>
                     {
-                        thisTask.Then(initEnvironmentTask, taskIsTopOfChain: true);
+                        thisTask.GetEndOfChain().Then(initEnvironmentTask, taskIsTopOfChain: true);
                     };
 
                     // append installer task to top chain

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -86,7 +86,7 @@ namespace GitHub.Unity
 
                     Logger.Trace("No git path found in settings");
 
-                    var gitInstaller = new GitInstaller(Environment, CancellationToken);
+                    var gitInstaller = new GitInstaller(Environment, ProcessManager, TaskManager);
 
                     // if successful, continue with environment initialization, otherwise try to find an existing git installation
                     var task = gitInstaller.SetupGitIfNeeded();

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -174,7 +174,8 @@ namespace GitHub.Unity
                 id = Guid.NewGuid().ToString();
                 UserSettings.Set(Constants.GuidKey, id);
             }
-/*
+
+#if ENABLE_METRICS
             var metricsService = new MetricsService(ProcessManager,
                 TaskManager,
                 Environment.FileSystem,
@@ -187,7 +188,7 @@ namespace GitHub.Unity
             {
                 UsageTracker.IncrementLaunchCount();
             }
-*/
+#endif
         }
 
         protected abstract void SetupMetrics();

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -174,7 +174,7 @@ namespace GitHub.Unity
                 id = Guid.NewGuid().ToString();
                 UserSettings.Set(Constants.GuidKey, id);
             }
-
+/*
             var metricsService = new MetricsService(ProcessManager,
                 TaskManager,
                 Environment.FileSystem,
@@ -187,6 +187,7 @@ namespace GitHub.Unity
             {
                 UsageTracker.IncrementLaunchCount();
             }
+*/
         }
 
         protected abstract void SetupMetrics();

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(BuildDefs)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
@@ -32,7 +32,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(BuildDefs)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <BuildConfid>Release</BuildConfid>
@@ -44,7 +44,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;DEVELOPER_BUILD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DEVELOPER_BUILD;$(BuildDefs)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>

--- a/src/GitHub.Api/Helpers/AssemblyResources.cs
+++ b/src/GitHub.Api/Helpers/AssemblyResources.cs
@@ -33,7 +33,7 @@ namespace GitHub.Unity
             if (stream != null)
                 return destinationPath.Combine(resource).WriteAllBytes(stream.ToByteArray());
 
-            return environment.ExtensionInstallPath.Combine(type, os, resource);
+            return environment.ExtensionInstallPath.Combine(type, os, resource).Copy(destinationPath.Combine(resource));
         }
     }
 }

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -29,7 +29,7 @@ namespace GitHub.Unity
         {
             //Logger.Trace("SetupGitIfNeeded");
 
-            installationTask = new FuncTask<GitInstallationState, NPath>(cancellationToken, (_, r) => installDetails.GitExecutablePath)
+            installationTask = new FuncTask<NPath>(cancellationToken, (_) => installDetails.GitExecutablePath)
                 { Name = "Git Installation - Complete" };
             installationTask.OnStart += thisTask => thisTask.UpdateProgress(0, 100);
             installationTask.OnEnd += (thisTask, result, success, exception) => thisTask.UpdateProgress(100, 100);

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -146,7 +146,7 @@ namespace GitHub.Unity
             if (!state.GitIsValid)
             {
                 ITask<NPath> unzipTask = new UnzipTask(cancellationToken, installDetails.GitZipPath, gitExtractPath, sharpZipLibHelper,
-                    environment.FileSystem, GitInstallDetails.GitExtractedMD5);
+                    environment.FileSystem);
                 unzipTask.Progress(p => installationTask.UpdateProgress(40 + (long)(20 * p.Percentage), 100, unzipTask.Name));
 
                 unzipTask = unzipTask.Then((s, path) =>
@@ -169,7 +169,7 @@ namespace GitHub.Unity
             if (!state.GitLfsIsValid)
             {
                 ITask<NPath> unzipTask = new UnzipTask(cancellationToken, installDetails.GitLfsZipPath, gitLfsExtractPath, sharpZipLibHelper,
-                    environment.FileSystem, GitInstallDetails.GitLfsExtractedMD5);
+                    environment.FileSystem);
                 unzipTask.Progress(p => installationTask.UpdateProgress(60 + (long)(20 * p.Percentage), 100, unzipTask.Name));
 
                 unzipTask = unzipTask.Then((s, path) =>

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -45,7 +45,7 @@ namespace GitHub.Unity
                     var tempZipExtractPath = NPath.CreateTempDirectory("octorun_extract_archive_path");
                     var unzipTask = new UnzipTask(taskManager.Token, installDetails.ZipFile,
                             tempZipExtractPath, sharpZipLibHelper,
-                            fileSystem, OctorunInstallDetails.ExtractedMD5)
+                            fileSystem)
                         .Then((success, p) => MoveOctorun(p));
                     t.Then(unzipTask);
                 }

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -12,14 +12,13 @@ namespace GitHub.Unity
         private readonly string expectedMD5;
 
         public UnzipTask(CancellationToken token, NPath archiveFilePath, NPath extractedPath,
-            IZipHelper zipHelper, IFileSystem fileSystem, string expectedMD5)
+            IZipHelper zipHelper, IFileSystem fileSystem)
             : base(token)
         {
             this.archiveFilePath = archiveFilePath;
             this.extractedPath = extractedPath;
             this.zipHelper = zipHelper;
             this.fileSystem = fileSystem;
-            this.expectedMD5 = expectedMD5;
             Name = $"Unzip {archiveFilePath.FileName}";
         }
 
@@ -71,22 +70,14 @@ namespace GitHub.Unity
                             UpdateProgress(value, total);
                             return !Token.IsCancellationRequested;
                         });
-/*
-                    if (expectedMD5 != null)
+
+                    if (!success)
                     {
-                        var calculatedMD5 = fileSystem.CalculateFolderMD5(extractedPath);
-                        success = calculatedMD5.Equals(expectedMD5, StringComparison.InvariantCultureIgnoreCase);
-*/
-                        if (!success)
-                        {
-                            extractedPath.DeleteIfExists();
+                        extractedPath.DeleteIfExists();
 
-                            //var message = $"Extracted MD5: {calculatedMD5} Does not match expected: {expectedMD5}";
-                            var message = $"Failed to extract {archiveFilePath} to {extractedPath}";
-
-                            exception = new UnzipException(message);
-                        }
-//                    }
+                        var message = $"Failed to extract {archiveFilePath} to {extractedPath}";
+                        exception = new UnzipException(message);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -71,21 +71,22 @@ namespace GitHub.Unity
                             UpdateProgress(value, total);
                             return !Token.IsCancellationRequested;
                         });
-
+/*
                     if (expectedMD5 != null)
                     {
                         var calculatedMD5 = fileSystem.CalculateFolderMD5(extractedPath);
                         success = calculatedMD5.Equals(expectedMD5, StringComparison.InvariantCultureIgnoreCase);
+*/
                         if (!success)
                         {
                             extractedPath.DeleteIfExists();
 
-                            var message = $"Extracted MD5: {calculatedMD5} Does not match expected: {expectedMD5}";
-                            Logger.Error(message);
+                            //var message = $"Extracted MD5: {calculatedMD5} Does not match expected: {expectedMD5}";
+                            var message = $"Failed to extract {archiveFilePath} to {extractedPath}";
 
                             exception = new UnzipException(message);
                         }
-                    }
+//                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -9,7 +9,6 @@ namespace GitHub.Unity
         private readonly NPath extractedPath;
         private readonly IZipHelper zipHelper;
         private readonly IFileSystem fileSystem;
-        private readonly string expectedMD5;
 
         public UnzipTask(CancellationToken token, NPath archiveFilePath, NPath extractedPath,
             IZipHelper zipHelper, IFileSystem fileSystem)

--- a/src/GitHub.Api/OutputProcessors/ProcessManager.cs
+++ b/src/GitHub.Api/OutputProcessors/ProcessManager.cs
@@ -84,7 +84,7 @@ namespace GitHub.Unity
                 var envVars = startInfo.EnvironmentVariables;
                 var scriptContents = new[] {
                     $"cd {envVars["GHU_WORKINGDIR"]}",
-                    $"PATH={envVars["GHU_FULLPATH"]}:$PATH /bin/bash"
+                    $"PATH=\"{envVars["GHU_FULLPATH"]}\":$PATH /bin/bash"
                 };
                 environment.FileSystem.WriteAllLines(envVarFile, scriptContents);
                 Mono.Unix.Native.Syscall.chmod(envVarFile, (Mono.Unix.Native.FilePermissions)493); // -rwxr-xr-x mode (0755)

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -51,6 +51,7 @@ namespace GitHub.Unity
         bool IsChainExclusive();
 
         void UpdateProgress(long value, long total, string message = null);
+        ITask GetEndOfChain();
     }
 
     public interface ITask<TResult> : ITask
@@ -192,7 +193,7 @@ namespace GitHub.Unity
             // if the current task has a fault handler, attach it to the chain we're appending
             if (finallyHandler != null)
             {
-                var endOfChainTask = nextTaskBase.GetBottomMostTask();
+                TaskBase endOfChainTask = (TaskBase)nextTaskBase.GetEndOfChain();
                 while (endOfChainTask != this && endOfChainTask != null)
                 {
                     endOfChainTask.finallyHandler += finallyHandler;
@@ -373,12 +374,12 @@ namespace GitHub.Unity
             return depends.GetTopMostTask(null, false);
         }
 
-        protected TaskBase GetBottomMostTask()
+        public ITask GetEndOfChain()
         {
             if (continuationOnSuccess != null)
-                return continuationOnSuccess.GetBottomMostTask();
+                return continuationOnSuccess.GetEndOfChain();
             else if (continuationOnAlways != null)
-                return continuationOnAlways.GetBottomMostTask();
+                return continuationOnAlways.GetEndOfChain();
             return this;
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -901,7 +901,7 @@ namespace GitHub.Unity
             {
                 if (code == null)
                 {
-                    code = Utility.GetIcon("code.png", "spinner-outside@2x.png");
+                    code = Utility.GetIcon("code.png", "code@2x.png");
                 }
                 return code;
             }
@@ -963,7 +963,7 @@ namespace GitHub.Unity
             {
                 if (codeInverted == null)
                 {
-                    codeInverted = Utility.GetIcon("code.png", "spinner-outside@2x.png");
+                    codeInverted = Utility.GetIcon("code.png", "code@2x.png");
                     codeInverted.InvertColors();
                 }
                 return codeInverted;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -75,7 +75,7 @@ namespace GitHub.Unity
         // This is Unity's magic method
         private void OnGUI()
         {
-            if (Event.current.type == EventType.layout)
+            if (Event.current.type == EventType.Layout)
             {
                 if (cachedRepository != Environment.Repository || initializeWasCalled)
                 {
@@ -89,7 +89,7 @@ namespace GitHub.Unity
 
             OnUI();
 
-            if (Event.current.type == EventType.repaint)
+            if (Event.current.type == EventType.Repaint)
             {
                 inLayout = false;
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -166,7 +166,7 @@ namespace GitHub.Unity
         {
             if (metricsHasChanged)
             {
-                //metricsEnabled = Manager.UsageTracker.Enabled;
+                metricsEnabled = Manager.UsageTracker != null ? Manager.UsageTracker.Enabled : false;
                 metricsHasChanged = false;
             }
 
@@ -311,7 +311,7 @@ namespace GitHub.Unity
         {
             GUILayout.Label(PrivacyTitle, EditorStyles.boldLabel);
 
-            EditorGUI.BeginDisabledGroup(IsBusy);
+            EditorGUI.BeginDisabledGroup(IsBusy && Manager.UsageTracker != null);
             {
                 
                 EditorGUI.BeginChangeCheck();
@@ -320,7 +320,8 @@ namespace GitHub.Unity
                 }
                 if (EditorGUI.EndChangeCheck())
                 {
-                    Manager.UsageTracker.Enabled = metricsEnabled;
+                    if (Manager.UsageTracker != null)
+                        Manager.UsageTracker.Enabled = metricsEnabled;
                 }
             }
             EditorGUI.EndDisabledGroup();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -166,7 +166,7 @@ namespace GitHub.Unity
         {
             if (metricsHasChanged)
             {
-                metricsEnabled = Manager.UsageTracker.Enabled;
+                //metricsEnabled = Manager.UsageTracker.Enabled;
                 metricsHasChanged = false;
             }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -465,7 +465,7 @@ namespace GitHub.Unity
 
             var contentStyle = IsActive ? activeNodeStyle : nodeStyle;
 
-            if (Event.current.type == EventType.repaint)
+            if (Event.current.type == EventType.Repaint)
             {
                 contentStyle.Draw(fillRect, GUIContent.none, false, false, false, isSelected);
             }
@@ -475,7 +475,7 @@ namespace GitHub.Unity
             {
                 styleOn = !IsCollapsed;
 
-                if (Event.current.type == EventType.repaint)
+                if (Event.current.type == EventType.Repaint)
                 {
                     toggleStyle.Draw(toggleRect, GUIContent.none, false, false, styleOn, isSelected);
                 }
@@ -514,7 +514,7 @@ namespace GitHub.Unity
                 }
             }
 
-            if (Event.current.type == EventType.repaint)
+            if (Event.current.type == EventType.Repaint)
             {
                 contentStyle.Draw(iconRect, content, false, false, false, isSelected);
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -210,7 +210,7 @@ namespace GitHub.Unity
                 ActiveView.OnGUI();
             }
 
-            if (IsBusy && activeTab != SubTab.Settings && Event.current.type == EventType.repaint)
+            if (IsBusy && activeTab != SubTab.Settings && Event.current.type == EventType.Repaint)
             {
                 if (timeSinceLastRotation < 0)
                 {

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -158,13 +158,16 @@ namespace IntegrationTests
             Exception ex = null;
 
             var setupTask = gitInstaller.SetupGitIfNeeded();
-            setupTask.OnEnd += (thisTask, path, success, exception) => {
-                result = path;
-                ex = exception;
-                autoResetEvent.Set();
+            setupTask.OnEnd += (thisTask, _, __, ___) => {
+                ((ITask<NPath>)thisTask.GetEndOfChain()).OnEnd += (t, path, success, exception) =>
+                {
+                    result = path;
+                    ex = exception;
+                    autoResetEvent.Set();
+                };
             };
-
-            if (!autoResetEvent.WaitOne(TimeSpan.FromMinutes(1)))
+            setupTask.Start();
+            if (!autoResetEvent.WaitOne(TimeSpan.FromMinutes(5)))
                 throw new TimeoutException($"Test setup unzipping {zipArchivesPath} to {pathToSetupGitInto} timed out");
 
             if (result == null)
@@ -197,7 +200,7 @@ namespace IntegrationTests
         [SetUp]
         public virtual void OnSetup()
         {
-            TestBasePath = NPath.CreateTempDirectory("integration-tests");
+            TestBasePath = NPath.CreateTempDirectory("integration tests");
             NPath.FileSystem.SetCurrentDirectory(TestBasePath);
             TestRepoMasterCleanUnsynchronized = TestBasePath.Combine("IOTestsRepo", "IOTestsRepo_master_clean_unsync");
             TestRepoMasterCleanUnsynchronizedRussianLanguage = TestBasePath.Combine("IOTestsRepo", "IOTestsRepo_master_clean_sync_with_russian_language");

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -152,7 +152,7 @@ namespace IntegrationTests
             AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", zipArchivesPath, Environment);
             AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip.md5", zipArchivesPath, Environment);
 
-            var gitInstaller = new GitInstaller(Environment, TaskManager.Token, installDetails);
+            var gitInstaller = new GitInstaller(Environment, ProcessManager, TaskManager, installDetails);
 
             NPath? result = null;
             Exception ex = null;

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -51,7 +51,7 @@ namespace IntegrationTests
 
             var gitInstaller = new GitInstaller(Environment, ProcessManager, TaskManager, installDetails);
             var startTask = gitInstaller.SetupGitIfNeeded();
-            var endTask = new FuncTask<NPath, NPath>(CancellationToken.None, (s, path) => path);
+            var endTask = new FuncTask<NPath, NPath>(TaskManager.Token, (s, path) => path);
             startTask.OnEnd += (thisTask, path, success, exception) => thisTask.GetEndOfChain().Then(endTask);
             startTask.Start();
             NPath? resultPath = null;

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -50,9 +50,12 @@ namespace IntegrationTests
             TestBasePath.Combine("git").CreateDirectory();
 
             var gitInstaller = new GitInstaller(Environment, CancellationToken.None, installDetails);
-
+            var startTask = gitInstaller.SetupGitIfNeeded();
+            var endTask = new FuncTask<NPath, NPath>(CancellationToken.None, (s, path) => path);
+            startTask.OnEnd += (thisTask, path, success, exception) => thisTask.GetEndOfChain().Then(endTask);
+            startTask.Start();
             NPath? resultPath = null;
-            Assert.DoesNotThrow(async () => resultPath = await gitInstaller.SetupGitIfNeeded().Task);
+            Assert.DoesNotThrow(async () => resultPath = await endTask.Task);
             resultPath.Should().NotBeNull();
         }
     }

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -49,7 +49,7 @@ namespace IntegrationTests
 
             TestBasePath.Combine("git").CreateDirectory();
 
-            var gitInstaller = new GitInstaller(Environment, CancellationToken.None, installDetails);
+            var gitInstaller = new GitInstaller(Environment, ProcessManager, TaskManager, installDetails);
             var startTask = gitInstaller.SetupGitIfNeeded();
             var endTask = new FuncTask<NPath, NPath>(CancellationToken.None, (s, path) => path);
             startTask.OnEnd += (thisTask, path, success, exception) => thisTask.GetEndOfChain().Then(endTask);

--- a/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
@@ -12,8 +12,6 @@ namespace IntegrationTests
         private static readonly ILogging logger = LogHelper.GetLogger<IntegrationTestEnvironment>();
         private readonly bool enableTrace;
 
-        private readonly NPath integrationTestEnvironmentPath;
-
         private DefaultEnvironment defaultEnvironment;
 
         public IntegrationTestEnvironment(ICacheContainer cacheContainer,
@@ -26,13 +24,10 @@ namespace IntegrationTests
             defaultEnvironment = new DefaultEnvironment(cacheContainer);
             defaultEnvironment.FileSystem.SetCurrentDirectory(repoPath);
             environmentPath = environmentPath ??
-                defaultEnvironment.GetSpecialFolder(Environment.SpecialFolder.LocalApplicationData)
-                                  .ToNPath()
-                                  .EnsureDirectoryExists(ApplicationInfo.ApplicationName + "-IntegrationTests");
+                defaultEnvironment.UserCachePath.EnsureDirectoryExists("IntegrationTests");
 
-            integrationTestEnvironmentPath = environmentPath.Value;
-            UserCachePath = integrationTestEnvironmentPath.Combine("User");
-            SystemCachePath = integrationTestEnvironmentPath.Combine("System");
+            UserCachePath = environmentPath.Value.Combine("User");
+            SystemCachePath = environmentPath.Value.Combine("System");
 
             var installPath = solutionDirectory.Parent.Parent.Combine("src", "GitHub.Api");
 
@@ -76,7 +71,7 @@ namespace IntegrationTests
 
         public string GetSpecialFolder(Environment.SpecialFolder folder)
         {
-            var ensureDirectoryExists = integrationTestEnvironmentPath.EnsureDirectoryExists(folder.ToString());
+            var ensureDirectoryExists = UserCachePath.Parent.EnsureDirectoryExists(folder.ToString());
             var specialFolderPath = ensureDirectoryExists.ToString();
 
             if (enableTrace)
@@ -87,7 +82,7 @@ namespace IntegrationTests
             return specialFolderPath;
         }
 
-        public string UserProfilePath => integrationTestEnvironmentPath.CreateDirectory("user-profile-path");
+        public string UserProfilePath => UserCachePath.Parent.CreateDirectory("user profile path");
 
         public NPath Path => Environment.GetEnvironmentVariable("PATH").ToNPath();
         public string NewLine => Environment.NewLine;

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -27,7 +27,7 @@ namespace IntegrationTests
 
             var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath,
                     ZipHelper.Instance,
-                    Environment.FileSystem, GitInstaller.GitInstallDetails.GitLfsExtractedMD5)
+                    Environment.FileSystem)
                 .Progress(p => 
                 {
                 });
@@ -51,7 +51,7 @@ namespace IntegrationTests
             var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
 
             var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, 
-                ZipHelper.Instance, Environment.FileSystem, "AABBCCDD");
+                ZipHelper.Instance, Environment.FileSystem);
 
             Assert.Throws<UnzipException>(async () => await unzipTask.StartAwait());
 

--- a/src/tests/IntegrationTests/UnzipTaskTests.cs
+++ b/src/tests/IntegrationTests/UnzipTaskTests.cs
@@ -36,26 +36,5 @@ namespace IntegrationTests
 
             extractedPath.DirectoryExists().Should().BeTrue();
         }
-
-        [Test]
-        public void FailsWhenMD5Incorrect()
-        {
-            InitializeTaskManager();
-
-            var cacheContainer = Substitute.For<ICacheContainer>();
-            Environment = new IntegrationTestEnvironment(cacheContainer, TestBasePath, SolutionDirectory);
-
-            var destinationPath = TestBasePath.Combine("gitlfs_zip").CreateDirectory();
-            var archiveFilePath = AssemblyResources.ToFile(ResourceType.Platform, "git-lfs.zip", destinationPath, Environment);
-
-            var extractedPath = TestBasePath.Combine("gitlfs_zip_extracted").CreateDirectory();
-
-            var unzipTask = new UnzipTask(CancellationToken.None, archiveFilePath, extractedPath, 
-                ZipHelper.Instance, Environment.FileSystem);
-
-            Assert.Throws<UnzipException>(async () => await unzipTask.StartAwait());
-
-            extractedPath.DirectoryExists().Should().BeFalse();
-        }
     }
 }

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -43,7 +43,7 @@ namespace IntegrationTests
             TaskManager.UIScheduler = new SynchronizationContextTaskScheduler(syncContext);
 
             var env = new DefaultEnvironment();
-            TestBasePath = NPath.CreateTempDirectory("integration-tests");
+            TestBasePath = NPath.CreateTempDirectory("integration tests");
             env.FileSystem.SetCurrentDirectory(TestBasePath);
 
             var repo = Substitute.For<IRepository>();

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 349a2940a5f0bb2428b4689b369e3b60
+folderAsset: yes
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux/git-lfs.zip.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux/git-lfs.zip.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 342ebfa2c8e06a24c8b445cf2f2d9784
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux/gitconfig.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/linux/gitconfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b455a70c012793a4d94fe976e18140af
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/mac/git-lfs.zip.md5.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/mac/git-lfs.zip.md5.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c1eb0d289ecf9f34bbd08287ab6c2d87
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/mac/gitconfig.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/mac/gitconfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cc881bea450edc4ca7114e23fad3cee
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/git-lfs.zip.md5.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/git-lfs.zip.md5.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b88cae02c8fab6e47999b50827bb1530
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/git.zip.md5.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/git.zip.md5.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1404afef655b1ce49bfa0ef83799bf50
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/gitconfig.meta
+++ b/unity/PackageProject/Assets/Plugins/GitHub/Editor/PlatformResources/windows/gitconfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6daa66f23a1e5324caec116fb03ca529
+timeCreated: 1521442009
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Fix the build for public contributors that don't have access to the `script` submodule.
- Fix build errors due to deprecated APIs in EventType
- Fix post-unzip md5 checksums, they're not reliable across OSes
- Fix spinner rendering in high retina displays