### PR TITLE
NeedsLoad should not create an Adapter

### DIFF
--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -123,6 +123,16 @@ namespace GitHub.Unity
             return keychainAdapter;
         }
 
+        private KeychainAdapter FindAdapter(UriString host)
+        {
+            KeychainAdapter value;
+            if (!keychainAdapters.TryGetValue(host, out value))
+            {
+                return null;
+            }
+            return value;
+        }
+
         private KeychainAdapter FindOrCreateAdapter(UriString host)
         {
             KeychainAdapter value;
@@ -323,6 +333,6 @@ namespace GitHub.Unity
         public Connection[] Connections => connections.Values.ToArray();
         public IList<UriString> Hosts => connections.Keys.ToArray();
         public bool HasKeys => connections.Any();
-        public bool NeedsLoad => HasKeys && !string.IsNullOrEmpty(FindOrCreateAdapter(connections.First().Value.Host).Credential.Token);
+        public bool NeedsLoad => HasKeys && !string.IsNullOrEmpty(FindAdapter(connections.First().Value.Host)?.Credential.Token);
     }
 }


### PR DESCRIPTION
Accept either this or #638

### Problem

https://i.imgur.com/XcbPs1q.png

```
180323-10:39:20.385 ERROR [ 1] <ApiClient>                         Error Getting Current User
System.NullReferenceException: Object reference not set to an instance of an object
  at GitHub.Unity.Keychain.get_NeedsLoad () [0x00000] in <filename unknown>:0 
  at GitHub.Unity.ApiClient+<LoadKeychainInternal>c__asyncE.MoveNext () [0x00043] in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Application\ApiClient.cs:375 
=======
   at GitHub.Unity.ApiClient+<GetCurrentUserInternal>c__asyncC.MoveNext() in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Application\ApiClient.cs:line 351
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(<GetCurrentUserInternal>c__asyncC ByRef stateMachine)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[GitHub.Unity.GitHubUser, GitHub.Api, Version=0.30.10.0, Culture=neutral, PublicKeyToken=null]].Start(<GetCurrentUserInternal>c__asyncC ByRef stateMachine)
   at GitHub.Unity.ApiClient.GetCurrentUserInternal()
   at GitHub.Unity.ApiClient+<ValidateCurrentUserInternal>c__asyncD.MoveNext() in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Application\ApiClient.cs:line 360
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(<ValidateCurrentUserInternal>c__asyncD ByRef stateMachine)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Runtime.CompilerServices.VoidTaskResult, AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87]].Start(<ValidateCurrentUserInternal>c__asyncD ByRef stateMachine)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(<ValidateCurrentUserInternal>c__asyncD ByRef stateMachine)
   at GitHub.Unity.ApiClient.ValidateCurrentUserInternal()
   at GitHub.Unity.ApiClient+<ValidateCurrentUser>c__async4.MoveNext() in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Application\ApiClient.cs:line 89
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(<ValidateCurrentUser>c__async4 ByRef stateMachine)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Runtime.CompilerServices.VoidTaskResult, AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87]].Start(<ValidateCurrentUser>c__async4 ByRef stateMachine)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(<ValidateCurrentUser>c__async4 ByRef stateMachine)
   at GitHub.Unity.ApiClient.ValidateCurrentUser(System.Action onSuccess, System.Action`1 onError)
   at GitHub.Unity.PopupWindow.OpenWindow(PopupViewType popupViewType, System.Action`1 onClose) in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\UnityExtension\Assets\Editor\GitHub.Unity\UI\PopupWindow.cs:line 31
   at GitHub.Unity.HistoryView.OnGUI() in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\UnityExtension\Assets\Editor\GitHub.Unity\UI\HistoryView.cs:line 446
   at GitHub.Unity.Window.OnUI() in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\UnityExtension\Assets\Editor\GitHub.Unity\UI\Window.cs:line 205
   at System.Reflection.MonoMethod.InternalInvoke(System.Object , System.Object[] , System.Exception ByRef )
   at System.Reflection.MonoMethod.Invoke(System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MonoMethod.cs:line 222
   at System.Reflection.MethodBase.Invoke(System.Object obj, System.Object[] parameters) in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MethodBase.cs:line 115
   at UnityEditor.HostView.Invoke(System.String methodName, System.Object obj) in C:\buildslave\unity\build\Editor\Mono\HostView.cs:line 262
   at UnityEditor.HostView.Invoke(System.String methodName) in C:\buildslave\unity\build\Editor\Mono\HostView.cs:line 255
   at UnityEditor.HostView.InvokeOnGUI(Rect onGUIPosition) in C:\buildslave\unity\build\Editor\Mono\HostView.cs:line 222
   at UnityEditor.DockArea.OnGUI() in C:\buildslave\unity\build\Editor\Mono\GUI\DockArea.cs:line 346
180323-10:42:05.717 TRACE [ 1] <ApiClient>                         Validating User
180323-10:42:05.741 TRACE [ 1] <ApiClient>                         Getting Current User
180323-10:42:19.836 ERROR [ 1] <ApiClient>                         Error Getting Current User
```

### Resolution

I don't believe `NeedsLoad` should be in the business of creating an Adapter. I added code to do a "find/return" instead of a "find/create".