### PR TITLE
Restoring the original UsageTracker timeout

### DIFF
--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -31,7 +31,7 @@ namespace GitHub.Unity
 
             Logger.Trace("guid:{0}", guid);
             if (Enabled)
-                RunTimer(3*10);
+                RunTimer(3*60);
         }
 
         private UsageStore LoadUsage()


### PR DESCRIPTION
During the programming of OctoRun the timeout was changed to facilitate testing. The original timeout was never restored.