### PR TITLE
Fixing Windows Credential Refresh Error

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -379,12 +379,19 @@ namespace GitHub.Unity
                 logger.Trace("LoadKeychainInternal: Loading");
 
                 //TODO: ONE_USER_LOGIN This assumes only ever one user can login
-                var uriString = keychain.Connections.First().Host;
+                var connection = keychain.Connections.First();
+                var uriString = connection.Host;
 
                 var keychainAdapter = await keychain.Load(uriString);
                 logger.Trace("LoadKeychainInternal: Loaded");
 
-                return keychainAdapter.Credential.Token != null;
+                var keychainUsername = keychainAdapter.Credential?.Username;
+                if (keychainUsername == null || connection.Username != keychainUsername)
+                {
+                    throw new TokenUsernameMismatchException(connection.Username, keychainUsername);
+                }
+
+                return keychainAdapter.Credential?.Token != null;
             }
 
             logger.Trace("LoadKeychainInternal: No keys to load");

--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -323,6 +323,6 @@ namespace GitHub.Unity
         public Connection[] Connections => connections.Values.ToArray();
         public IList<UriString> Hosts => connections.Keys.ToArray();
         public bool HasKeys => connections.Any();
-        public bool NeedsLoad => HasKeys && !string.IsNullOrEmpty(FindOrCreateAdapter(connections.First().Value.Host).Credential.Token);
+        public bool NeedsLoad => HasKeys && string.IsNullOrEmpty(FindOrCreateAdapter(connections.First().Value.Host).Credential?.Token);
     }
 }


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

Fixes #651 

- Logic in NeedsLoad was incorrect
  - It needs to expect that Credential may be null from the LoadOrCreateMethod
  - The `!string.IsNullOrEmpty(...)` is incorrect, it needs load if the string IS null or empty.
- `ValidateKeychain` does not get enough information to perform it's job.
  - It only throws an error if the token is null, but it should also throw an error if they keychain adapter's username does not match what is expected
  - `LoadKeychainInternal` is the only method called by `ValidateKeychain` and has access to the `IKeychainAdapter` in question
    - Until some refactoring can be implemented, I'm going to perform the check in `LoadKeychainInternal`