### PR TITLE
Fixing Profile button

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -481,7 +481,10 @@ namespace GitHub.Unity
 
         private void GoToProfile(object obj)
         {
-            Application.OpenURL(Platform.CredentialManager.CachedCredentials.Host.Combine(Platform.CredentialManager.CachedCredentials.Username));
+            //TODO: ONE_USER_LOGIN This assumes only ever one user can login
+            var keychainConnection = Platform.Keychain.Connections.First();
+            var uriString = new UriString(keychainConnection.Host).Combine(keychainConnection.Username);
+            Application.OpenURL(uriString);
         }
 
         private void SignOut(object obj)


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

Fixes #535 

Getting the profile url from the keychain connection list
Which does not require us loading the keychain from the system