### PR TITLE
Always deleting octorun zip file when extracting

### DIFF
--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -56,10 +56,10 @@ namespace GitHub.Unity
 
         private NPath GrabZipFromResources()
         {
-            if (!installDetails.ZipFile.FileExists())
-            {
-                AssemblyResources.ToFile(ResourceType.Generic, "octorun.zip", installDetails.BaseZipPath, environment);
-            }
+            installDetails.ZipFile.DeleteIfExists();
+            
+            AssemblyResources.ToFile(ResourceType.Generic, "octorun.zip", installDetails.BaseZipPath, environment);
+            
             return installDetails.ZipFile;
         }
 


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

After experimenting with PR #648 I realized that the plugin was unable to restore the original contents of the zip as found in master.
In the event of a version mismatch with octorun, the zip file that is currently in the extract from resources location is never changed/overwritten.
That possibly incorrect zip file is used to populate octorun everytime.