### PR TITLE
Making sure path for console matches ProcessEnvironment

### DIFF
--- a/src/GitHub.Api/OutputProcessors/ProcessManager.cs
+++ b/src/GitHub.Api/OutputProcessors/ProcessManager.cs
@@ -87,7 +87,7 @@ namespace GitHub.Unity
                 var envVars = startInfo.EnvironmentVariables;
                 var scriptContents = new[] {
                     $"cd \"{envVars["GHU_WORKINGDIR"]}\"",
-                    $"PATH=\"{envVars["GHU_FULLPATH"]}\":$PATH /bin/bash"
+                    $"PATH=\"{envVars["GHU_FULLPATH"]}\" /bin/bash"
                 };
                 environment.FileSystem.WriteAllLines(envVarFile, scriptContents);
                 Mono.Unix.Native.Syscall.chmod(envVarFile, (Mono.Unix.Native.FilePermissions)493); // -rwxr-xr-x mode (0755)


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

Part of the problems identified in #659 

`ProcessEnvironment` sets the `PATH` variable to `GHU_FULLPATH` exactly.
When opening a console window `ProcessManager` pre-pends `GHU_FULLPATH` to the current `PATH`
Which has the effect of hiding the git lfs error in #659.

Instead it should be setting path to exactly `GHU_FULLPATH`.