### PR TITLE
ApiClient and keychain adapter cleanup and fixes

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -10,17 +10,6 @@ namespace GitHub.Unity
 {
     class ApiClient : IApiClient
     {
-        public static IApiClient Create(UriString repositoryUrl, IKeychain keychain, IProcessManager processManager, ITaskManager taskManager, NPath nodeJsExecutablePath, NPath octorunScriptPath)
-        {
-            logger.Trace("Creating ApiClient: {0}", repositoryUrl);
-
-            var credentialStore = keychain.Connect(repositoryUrl);
-            var hostAddress = HostAddress.Create(repositoryUrl);
-
-            return new ApiClient(repositoryUrl, keychain,
-                processManager, taskManager, nodeJsExecutablePath, octorunScriptPath);
-        }
-
         private static readonly ILogging logger = LogHelper.GetLogger<ApiClient>();
         public HostAddress HostAddress { get; }
         public UriString OriginalUrl { get; }
@@ -81,32 +70,18 @@ namespace GitHub.Unity
             await GetOrganizationInternal(onSuccess, onError);
         }
 
-        public async Task ValidateCurrentUser(Action onSuccess, Action<Exception> onError = null)
+        public async Task GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null)
         {
             Guard.ArgumentNotNull(onSuccess, nameof(onSuccess));
             try
             {
-                var keychainConnection = keychain.Connections.First();
-                var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
-                await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
-                onSuccess();
+                var user = await GetCurrentUser();
+                onSuccess(user);
             }
             catch (Exception e)
             {
                 onError?.Invoke(e);
             }
-        }
-
-        public async Task GetCurrentUser(Action<GitHubUser> callback)
-        {
-            Guard.ArgumentNotNull(callback, "callback");
-            
-            //TODO: ONE_USER_LOGIN This assumes only ever one user can login
-            var keychainConnection = keychain.Connections.First();
-            var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
-            var user = await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
-
-            callback(user);
         }
 
         public async Task Login(string username, string password, Action<LoginResult> need2faCode, Action<bool, string> result)
@@ -205,16 +180,33 @@ namespace GitHub.Unity
             return result.Code == LoginResultCodes.Success;
         }
 
+        private async Task<GitHubUser> GetCurrentUser()
+        {
+            //TODO: ONE_USER_LOGIN This assumes we only support one login
+            var keychainConnection = keychain.Connections.FirstOrDefault();
+            if (keychainConnection == null)
+                throw new KeychainEmptyException();
+
+            var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
+
+            // we can't trust that the system keychain has the username filled out correctly.
+            // if it doesn't, we need to grab the username from the server and check it
+            // unfortunately this means that things will be slower when the keychain doesn't have all the info
+            if (keychainConnection.User == null || keychainAdapter.Credential.Username != keychainConnection.Username)
+            {
+                keychainConnection.User = await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
+            }
+            return keychainConnection.User;
+        }
+
         private async Task<GitHubRepository> CreateRepositoryInternal(string repositoryName, string organization, string description, bool isPrivate)
         {
             try
             {
                 logger.Trace("Creating repository");
 
-                //TODO: ONE_USER_LOGIN This assumes only ever one user can login
-                var keychainConnection = keychain.Connections.First();
-                var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
-                await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
+                var user = await GetCurrentUser();
+                var keychainAdapter = keychain.Connect(OriginalUrl);
 
                 var command = new StringBuilder("publish -r \"");
                 command.Append(repositoryName);
@@ -240,7 +232,7 @@ namespace GitHub.Unity
                 }
 
                 var octorunTask = new OctorunTask(taskManager.Token, nodeJsExecutablePath, octorunScriptPath, command.ToString(),
-                    user: keychainAdapter.Credential.Username, userToken: keychainAdapter.Credential.Token)
+                    user: user.Login, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
                 var ret = await octorunTask.StartAwait();
@@ -273,13 +265,11 @@ namespace GitHub.Unity
             {
                 logger.Trace("Getting Organizations");
 
-                //TODO: ONE_USER_LOGIN This assumes only ever one user can login
-                var keychainConnection = keychain.Connections.First();
-                var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
-                await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
+                var user = await GetCurrentUser();
+                var keychainAdapter = keychain.Connect(OriginalUrl);
 
                 var octorunTask = new OctorunTask(taskManager.Token, nodeJsExecutablePath, octorunScriptPath, "organizations",
-                        user: keychainAdapter.Credential.Username, userToken: keychainAdapter.Credential.Token)
+                        user: user.Login, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
                 var ret = await octorunTask.StartAsAsync();
@@ -315,27 +305,22 @@ namespace GitHub.Unity
 
         private async Task<IKeychainAdapter> GetValidatedKeychainAdapter(Connection keychainConnection)
         {
-            if (keychain.HasKeys)
+            var keychainAdapter = await keychain.Load(keychainConnection.Host);
+            if (keychainAdapter == null)
+                throw new KeychainEmptyException();
+
+            if (string.IsNullOrEmpty(keychainAdapter.Credential?.Username))
             {
-                var keychainAdapter = await keychain.Load(keychainConnection.Host);
-
-                if (string.IsNullOrEmpty(keychainAdapter.Credential?.Username))
-                {
-                    logger.Warning("LoadKeychainInternal: Username is empty");
-                    throw new TokenUsernameMismatchException(keychainConnection.Username);
-                }
-
-                if (keychainAdapter.Credential.Username != keychainConnection.Username)
-                {
-                    logger.Warning("LoadKeychainInternal: Token username does not match");
-                    throw new TokenUsernameMismatchException(keychainConnection.Username, keychainAdapter.Credential.Username);
-                }
-
-                return keychainAdapter;
+                logger.Warning("LoadKeychainInternal: Username is empty");
+                throw new TokenUsernameMismatchException(keychainConnection.Username);
             }
 
-            logger.Warning("LoadKeychainInternal: No keys to load");
-            throw new KeychainEmptyException();
+            if (keychainAdapter.Credential.Username != keychainConnection.Username)
+            {
+                logger.Warning("LoadKeychainInternal: Token username does not match");
+            }
+
+            return keychainAdapter;
         }
 
         private async Task<GitHubUser> GetValidatedGitHubUser(Connection keychainConnection, IKeychainAdapter keychainAdapter)
@@ -343,7 +328,7 @@ namespace GitHub.Unity
             try
             {
                 var octorunTask = new OctorunTask(taskManager.Token, nodeJsExecutablePath, octorunScriptPath, "validate",
-                        user: keychainAdapter.Credential.Username, userToken: keychainAdapter.Credential.Token)
+                        user: keychainConnection.Username, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
                 var ret = await octorunTask.StartAsAsync();

--- a/src/GitHub.Api/Application/IApiClient.cs
+++ b/src/GitHub.Api/Application/IApiClient.cs
@@ -14,7 +14,6 @@ namespace GitHub.Unity
         Task ContinueLogin(LoginResult loginResult, string code);
         Task<bool> LoginAsync(string username, string password, Func<LoginResult, string> need2faCode);
         Task Logout(UriString host);
-        Task GetCurrentUser(Action<GitHubUser> callback);
-        Task ValidateCurrentUser(Action onSuccess, Action<Exception> onError = null);
+        Task GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null);
     }
 }

--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -12,6 +12,7 @@ namespace GitHub.Unity
     {
         public string Host { get; set; }
         public string Username { get; set; }
+        [NonSerialized] internal GitHubUser User;
 
         // for json serialization
         public Connection()
@@ -99,7 +100,7 @@ namespace GitHub.Unity
 
         public async Task<IKeychainAdapter> Load(UriString host)
         {
-            KeychainAdapter keychainAdapter = FindOrCreateAdapter(host);
+            var keychainAdapter = FindOrCreateAdapter(host);
             var connection = GetConnection(host);
 
             //logger.Trace($@"Loading KeychainAdapter Host:""{host}"" Cached Username:""{cachedConnection.Username}""");
@@ -109,6 +110,7 @@ namespace GitHub.Unity
             {
                 logger.Warning("Cannot load host from Credential Manager; removing from cache");
                 await Clear(host, false);
+                keychainAdapter = null;
             }
             else
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Services/AuthenticationService.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Services/AuthenticationService.cs
@@ -10,7 +10,7 @@ namespace GitHub.Unity
 
         public AuthenticationService(UriString host, IKeychain keychain, NPath nodeJsExecutablePath, NPath octorunExecutablePath)
         {
-            client = ApiClient.Create(host, keychain, EntryPoint.ApplicationManager.ProcessManager, EntryPoint.ApplicationManager.TaskManager, nodeJsExecutablePath, octorunExecutablePath);
+            client = new ApiClient(host, keychain, EntryPoint.ApplicationManager.ProcessManager, EntryPoint.ApplicationManager.TaskManager, nodeJsExecutablePath, octorunExecutablePath);
         }
 
         public void Login(string username, string password, Action<string> twofaRequired, Action<bool, string> authResult)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
@@ -120,7 +120,7 @@ namespace GitHub.Unity
             {
                 //Logger.Trace("Validating to open view");
 
-                Client.ValidateCurrentUser(() => {
+                Client.GetCurrentUser(user => {
 
                     //Logger.Trace("User validated opening view");
 
@@ -192,7 +192,7 @@ namespace GitHub.Unity
                         host = UriString.ToUriString(HostAddress.GitHubDotComHostAddress.WebUri);
                     }
 
-                    client = ApiClient.Create(host, Platform.Keychain, Manager.ProcessManager, TaskManager, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
+                    client = new ApiClient(host, Platform.Keychain, Manager.ProcessManager, TaskManager, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
                 }
 
                 return client;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
@@ -52,7 +52,7 @@ namespace GitHub.Unity
                         host = UriString.ToUriString(HostAddress.GitHubDotComHostAddress.WebUri);
                     }
 
-                    client = ApiClient.Create(host, Platform.Keychain, Manager.ProcessManager, TaskManager, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
+                    client = new ApiClient(host, Platform.Keychain, Manager.ProcessManager, TaskManager, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
                 }
 
                 return client;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -497,7 +497,7 @@ namespace GitHub.Unity
                 host = UriString.ToUriString(HostAddress.GitHubDotComHostAddress.WebUri);
             }
 
-            var apiClient = ApiClient.Create(host, Platform.Keychain, null, null, NPath.Default, NPath.Default);
+            var apiClient = new ApiClient(host, Platform.Keychain, null, null, NPath.Default, NPath.Default);
             apiClient.Logout(host);
         }
 

--- a/src/tests/UnitTests/Authentication/KeychainTests.cs
+++ b/src/tests/UnitTests/Authentication/KeychainTests.cs
@@ -223,7 +223,7 @@ namespace UnitTests
 
             var uriString = keychain.Hosts.FirstOrDefault();
             var keychainAdapter = keychain.Load(uriString).Result;
-            keychainAdapter.Credential.Should().BeNull();
+            keychainAdapter.Should().BeNull();
 
             fileSystem.DidNotReceive().FileExists(Args.String);
             fileSystem.DidNotReceive().ReadAllText(Args.String);


### PR DESCRIPTION
Dedupe code in ApiClient. Also, cache user data and avoid using the keychain username

The system keychain may have a valid token with an invalid username because every git client fills out that information slightly different and the username is not relevant for accessing the API (only the token is needed). If we encounter a mismatch, don't throw immediately (the token might be perfectly valid), but always doublecheck the github user to make sure the username of the connection matches the user that the token is associated with.

Cache the GitHubUser object in the Connection list (non serialized) so that if we fill out once and all the information matches, we can reuse it and avoid pinging the API every time. If another git client tramples all over our keychain, it's highly likely that they'll also not fill out the username information anyway, and we always grab the user from GitHub if that happens so we should be relatively safe trusting the cached GitHubUser object (it'll get thrown away whenever Unity reloads so it's also likely that we'll keep refreshing it anyways)

In the process of this, cleaned up some duplicated and uneeded code that could lead to issues later on.