### PR TITLE
Simplify git validation code

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
@@ -218,7 +218,7 @@ namespace GitHub.Unity
             gitVersionErrorMessage = null;
 
             GitClient.ValidateGitInstall(value.ToNPath())
-                .FinallyInUI((success, exception, result) =>
+                .ThenInUI((success, result) =>
                 {
                     if (!success)
                     {


### PR DESCRIPTION
The code added in #658 to fix the validation of the git path is overly complex, this pattern is simpler.