### PR TITLE
Fix Asset Explorer updating

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -34,9 +34,8 @@ namespace GitHub.Unity
 
             if (repository != null)
             {
-                repository.TrackingStatusChanged += RepositoryOnStatusChanged;
+                repository.StatusEntriesChanged += RepositoryOnStatusEntriesChanged;
                 repository.LocksChanged += RepositoryOnLocksChanged;
-
             }
         }
 
@@ -46,7 +45,7 @@ namespace GitHub.Unity
             repository.CheckAndRaiseEventsIfCacheNewer(CacheType.GitLocks, lastLocksChangedEvent);
         }
 
-        private static void RepositoryOnStatusChanged(CacheUpdateEvent cacheUpdateEvent)
+        private static void RepositoryOnStatusEntriesChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             if (!lastRepositoryStatusChangedEvent.Equals(cacheUpdateEvent))
             {


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

It seems that during refactoring the `ProjectWindowInterface` was changed to listen to the incorrect event.

Fixes #669