### PR TITLE
Removing IsActive from GitBranch

### DIFF
--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -84,20 +84,16 @@ namespace GitHub.Unity
 
     public interface IBranchCache : IManagedCache
     {
-        GitBranch[] LocalBranches { get; set; }
-        GitBranch[] RemoteBranches { get; set; }
-        GitRemote[] Remotes { get; set; }
+        GitBranch[] LocalBranches { get; }
+        GitBranch[] RemoteBranches { get; }
+        GitRemote[] Remotes { get; }
 
         ILocalConfigBranchDictionary LocalConfigBranches { get; }
         IRemoteConfigBranchDictionary RemoteConfigBranches { get; }
         IConfigRemoteDictionary ConfigRemotes { get; }
         
-        void RemoveLocalBranch(string branch);
-        void AddLocalBranch(string branch);
-        void AddRemoteBranch(string remote, string branch);
-        void RemoveRemoteBranch(string remote, string branch);
-        void SetRemotes(Dictionary<string, ConfigRemote> remoteDictionary, Dictionary<string, Dictionary<string, ConfigBranch>> branchDictionary);
-        void SetLocals(Dictionary<string, ConfigBranch> branchDictionary);
+        void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> configBranches, GitRemote[] gitRemotes, GitBranch[] gitBranches);
+        void SetLocals(Dictionary<string, ConfigBranch> configBranches, GitBranch[] gitBranches);
     }
 
     public interface IRepositoryInfoCacheData

--- a/src/GitHub.Api/Git/GitBranch.cs
+++ b/src/GitHub.Api/Git/GitBranch.cs
@@ -9,15 +9,13 @@ namespace GitHub.Unity
 
         public string name;
         public string tracking;
-        public bool isActive;
 
-        public GitBranch(string name, string tracking, bool active)
+        public GitBranch(string name, string tracking)
         {
             Guard.ArgumentNotNullOrWhiteSpace(name, "name");
 
             this.name = name;
             this.tracking = tracking;
-            this.isActive = active;
         }
 
         public override int GetHashCode()
@@ -25,7 +23,6 @@ namespace GitHub.Unity
             int hash = 17;
             hash = hash * 23 + (name?.GetHashCode() ?? 0);
             hash = hash * 23 + (tracking?.GetHashCode() ?? 0);
-            hash = hash * 23 + isActive.GetHashCode();
             return hash;
         }
 
@@ -40,8 +37,7 @@ namespace GitHub.Unity
         {
             return
                 String.Equals(name, other.name) &&
-                String.Equals(tracking, other.tracking) &&
-                isActive == other.isActive;
+                String.Equals(tracking, other.tracking);
         }
 
         public static bool operator ==(GitBranch lhs, GitBranch rhs)
@@ -65,11 +61,10 @@ namespace GitHub.Unity
 
         public string Name => name;
         public string Tracking => tracking;
-        public bool IsActive => isActive;
 
         public override string ToString()
         {
-            return $"{Name} Tracking? {Tracking} Active? {IsActive}";
+            return $"{Name} Tracking? {Tracking}";
         }
     }
 }

--- a/src/GitHub.Api/Git/TreeData.cs
+++ b/src/GitHub.Api/Git/TreeData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography.X509Certificates;
 
 namespace GitHub.Unity
 {
@@ -11,19 +12,22 @@ namespace GitHub.Unity
     [Serializable]
     public struct GitBranchTreeData : ITreeData
     {
-        public static GitBranchTreeData Default = new GitBranchTreeData(Unity.GitBranch.Default);
+        public static GitBranchTreeData Default = new GitBranchTreeData(Unity.GitBranch.Default, false);
 
         public GitBranch GitBranch;
+        public bool isActive;
 
-        public GitBranchTreeData(GitBranch gitBranch)
+        public GitBranchTreeData(GitBranch gitBranch, bool isActive)
         {
             GitBranch = gitBranch;
+            this.isActive = isActive;
         }
 
         public override int GetHashCode()
         {
             int hash = 17;
             hash = hash * 23 + GitBranch.GetHashCode();
+            hash = hash * 23 + isActive.GetHashCode();
             return hash;
         }
 
@@ -36,7 +40,7 @@ namespace GitHub.Unity
 
         public bool Equals(GitBranchTreeData other)
         {
-            return GitBranch.Equals(other.GitBranch);
+            return GitBranch.Equals(other.GitBranch) && IsActive == other.IsActive;
         }
 
         public static bool operator ==(GitBranchTreeData lhs, GitBranchTreeData rhs)
@@ -59,7 +63,7 @@ namespace GitHub.Unity
         }
 
         public string Path => GitBranch.Name;
-        public bool IsActive => GitBranch.IsActive;
+        public bool IsActive => isActive;
     }
 
     [Serializable]

--- a/src/GitHub.Api/OutputProcessors/BranchListOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/BranchListOutputProcessor.cs
@@ -36,7 +36,7 @@ namespace GitHub.Unity
                 trackingName = proc.ReadChunk('[', ']');
             }
 
-            var branch = new GitBranch(name, trackingName, active);
+            var branch = new GitBranch(name, trackingName);
 
             RaiseOnEntry(branch);
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -480,174 +480,34 @@ namespace GitHub.Unity
         public BranchesCache() : base(CacheType.Branches)
         { }
 
-        public GitBranch[] LocalBranches
-        {
-            get { return localBranches; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} localBranches:{1}", now, value);
-
-                var localBranchesIsNull = localBranches == null;
-                var valueIsNull = value == null;
-
-                if (localBranchesIsNull != valueIsNull ||
-                    !localBranchesIsNull && !localBranches.SequenceEqual(value))
-                {
-                    localBranches = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public GitBranch[] RemoteBranches
-        {
-            get { return remoteBranches; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} remoteBranches:{1}", now, value);
-
-                var remoteBranchesIsNull = remoteBranches == null;
-                var valueIsNull = value == null;
-
-                if (remoteBranchesIsNull != valueIsNull ||
-                    !remoteBranchesIsNull && !remoteBranches.SequenceEqual(value))
-                {
-                    remoteBranches = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public GitRemote[] Remotes
-        {
-            get { return remotes; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} remotes:{1}", now, value);
-
-                var remotesIsNull = remotes == null;
-                var valueIsNull = value == null;
-
-                if (remotesIsNull != valueIsNull ||
-                    !remotesIsNull && !remotes.SequenceEqual(value))
-                {
-                    remotes = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public void RemoveLocalBranch(string branch)
-        {
-            if (LocalConfigBranches.ContainsKey(branch))
-            {
-                var now = DateTimeOffset.Now;
-                LocalConfigBranches.Remove(branch);
-                Logger.Trace("RemoveLocalBranch {0} branch:{1} ", now, branch);
-                SaveData(now, true);
-            }
-            else
-            {
-                Logger.Warning("Branch {0} is not found", branch);
-            }
-        }
-
-        public void AddLocalBranch(string branch)
-        {
-            if (!LocalConfigBranches.ContainsKey(branch))
-            {
-                var now = DateTimeOffset.Now;
-                LocalConfigBranches.Add(branch, new ConfigBranch(branch));
-                Logger.Trace("AddLocalBranch {0} branch:{1} ", now, branch);
-                SaveData(now, true);
-            }
-            else
-            {
-                Logger.Warning("Branch {0} is already present", branch);
-            }
-        }
-
-        public void AddRemoteBranch(string remote, string branch)
-        {
-            Dictionary<string, ConfigBranch> branchList;
-            if (RemoteConfigBranches.TryGetValue(remote, out branchList))
-            {
-                if (!branchList.ContainsKey(branch))
-                {
-                    var now = DateTimeOffset.Now;
-                    branchList.Add(branch, new ConfigBranch(branch, ConfigRemotes[remote]));
-                    Logger.Trace("AddRemoteBranch {0} remote:{1} branch:{2} ", now, remote, branch);
-                    SaveData(now, true);
-                }
-                else
-                {
-                    Logger.Warning("Branch {0} is already present in Remote {1}", branch, remote);
-                }
-            }
-            else
-            {
-                Logger.Warning("Remote {0} is not found", remote);
-            }
-        }
-
-        public void RemoveRemoteBranch(string remote, string branch)
-        {
-            Dictionary<string, ConfigBranch> branchList;
-            if (RemoteConfigBranches.TryGetValue(remote, out branchList))
-            {
-                if (branchList.ContainsKey(branch))
-                {
-                    var now = DateTimeOffset.Now;
-                    branchList.Remove(branch);
-                    Logger.Trace("RemoveRemoteBranch {0} remote:{1} branch:{2} ", now, remote, branch);
-                    SaveData(now, true);
-                }
-                else
-                {
-                    Logger.Warning("Branch {0} is not found in Remote {1}", branch, remote);
-                }
-            }
-            else
-            {
-                Logger.Warning("Remote {0} is not found", remote);
-            }
-        }
-
-        public void SetRemotes(Dictionary<string, ConfigRemote> remoteDictionary, Dictionary<string, Dictionary<string, ConfigBranch>> branchDictionary)
+        public void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> configBranches, GitRemote[] gitRemotes, GitBranch[] gitBranches)
         {
             var now = DateTimeOffset.Now;
-            configRemotes = new ConfigRemoteDictionary(remoteDictionary);
-            remoteConfigBranches = new RemoteConfigBranchDictionary(branchDictionary);
+            configRemotes = new ConfigRemoteDictionary(remoteConfigs);
+            remoteConfigBranches = new RemoteConfigBranchDictionary(configBranches);
+            remotes = gitRemotes;
+            remoteBranches = gitBranches;
+
             Logger.Trace("SetRemotes {0}", now);
             SaveData(now, true);
         }
 
-        public void SetLocals(Dictionary<string, ConfigBranch> branchDictionary)
+        public void SetLocals(Dictionary<string, ConfigBranch> configBranches, GitBranch[] gitBranches)
         {
             var now = DateTimeOffset.Now;
-            localConfigBranches = new LocalConfigBranchDictionary(branchDictionary);
-            Logger.Trace("SetRemotes {0}", now);
+            localConfigBranches = new LocalConfigBranchDictionary(configBranches);
+            localBranches = gitBranches;
+
+            Logger.Trace("SetLocals {0}", now);
             SaveData(now, true);
         }
 
         public ILocalConfigBranchDictionary LocalConfigBranches { get { return localConfigBranches; } }
         public IRemoteConfigBranchDictionary RemoteConfigBranches { get { return remoteConfigBranches; } }
         public IConfigRemoteDictionary ConfigRemotes { get { return configRemotes; } }
+        public GitBranch[] LocalBranches { get { return localBranches; } }
+        public GitBranch[] RemoteBranches { get { return remoteBranches; } }
+        public GitRemote[] Remotes { get { return remotes; } }
         public override TimeSpan DataTimeout { get { return TimeSpan.FromDays(1); } }
     }
 

--- a/src/tests/IntegrationTests/CachingClasses.cs
+++ b/src/tests/IntegrationTests/CachingClasses.cs
@@ -458,7 +458,7 @@ namespace IntegrationTests
                 var now = DateTimeOffset.Now;
                 var isUpdated = false;
 
-                Logger.Trace("Updating: {0} localBranches:{1}", now, value);
+                Logger.Trace("Updating: {0} localBranches:{1}", now, value.Length);
 
                 var localBranchesIsNull = localBranches == null;
                 var valueIsNull = value == null;
@@ -482,7 +482,7 @@ namespace IntegrationTests
                 var now = DateTimeOffset.Now;
                 var isUpdated = false;
 
-                Logger.Trace("Updating: {0} remoteBranches:{1}", now, value);
+                Logger.Trace("Updating: {0} remoteBranches:{1}", now, value.Length);
 
                 var remoteBranchesIsNull = remoteBranches == null;
                 var valueIsNull = value == null;
@@ -506,7 +506,7 @@ namespace IntegrationTests
                 var now = DateTimeOffset.Now;
                 var isUpdated = false;
 
-                Logger.Trace("Updating: {0} remotes:{1}", now, value);
+                Logger.Trace("Updating: {0} remotes:{1}", now, value.Length);
 
                 var remotesIsNull = remotes == null;
                 var valueIsNull = value == null;
@@ -598,19 +598,19 @@ namespace IntegrationTests
             }
         }
 
-        public void SetRemotes(Dictionary<string, ConfigRemote> remoteDictionary, Dictionary<string, Dictionary<string, ConfigBranch>> branchDictionary)
+        public void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> remoteConfigBranches)
         {
             var now = DateTimeOffset.Now;
-            configRemotes = new ConfigRemoteDictionary(remoteDictionary);
-            remoteConfigBranches = new RemoteConfigBranchDictionary(branchDictionary);
+            configRemotes = new ConfigRemoteDictionary(remoteConfigs);
+            this.remoteConfigBranches = new RemoteConfigBranchDictionary(remoteConfigBranches);
             Logger.Trace("SetRemotes {0}", now);
             SaveData(now, true);
         }
 
-        public void SetLocals(Dictionary<string, ConfigBranch> branchDictionary)
+        public void SetLocals(Dictionary<string, ConfigBranch> configBranches, GitBranch[] gitBranches)
         {
             var now = DateTimeOffset.Now;
-            localConfigBranches = new LocalConfigBranchDictionary(branchDictionary);
+            this.localConfigBranches = new LocalConfigBranchDictionary(configBranches);
             Logger.Trace("SetRemotes {0}", now);
             SaveData(now, true);
         }

--- a/src/tests/IntegrationTests/CachingClasses.cs
+++ b/src/tests/IntegrationTests/CachingClasses.cs
@@ -449,160 +449,13 @@ namespace IntegrationTests
 
         public BranchesCache() : base(CacheType.Branches)
         { }
-
-        public GitBranch[] LocalBranches
-        {
-            get { return localBranches; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} localBranches:{1}", now, value.Length);
-
-                var localBranchesIsNull = localBranches == null;
-                var valueIsNull = value == null;
-
-                if (localBranchesIsNull != valueIsNull ||
-                    !localBranchesIsNull && !localBranches.SequenceEqual(value))
-                {
-                    localBranches = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public GitBranch[] RemoteBranches
-        {
-            get { return remoteBranches; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} remoteBranches:{1}", now, value.Length);
-
-                var remoteBranchesIsNull = remoteBranches == null;
-                var valueIsNull = value == null;
-
-                if (remoteBranchesIsNull != valueIsNull ||
-                    !remoteBranchesIsNull && !remoteBranches.SequenceEqual(value))
-                {
-                    remoteBranches = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public GitRemote[] Remotes
-        {
-            get { return remotes; }
-            set
-            {
-                var now = DateTimeOffset.Now;
-                var isUpdated = false;
-
-                Logger.Trace("Updating: {0} remotes:{1}", now, value.Length);
-
-                var remotesIsNull = remotes == null;
-                var valueIsNull = value == null;
-
-                if (remotesIsNull != valueIsNull ||
-                    !remotesIsNull && !remotes.SequenceEqual(value))
-                {
-                    remotes = value;
-                    isUpdated = true;
-                }
-
-                SaveData(now, isUpdated);
-            }
-        }
-
-        public void RemoveLocalBranch(string branch)
-        {
-            if (LocalConfigBranches.ContainsKey(branch))
-            {
-                var now = DateTimeOffset.Now;
-                LocalConfigBranches.Remove(branch);
-                Logger.Trace("RemoveLocalBranch {0} branch:{1} ", now, branch);
-                SaveData(now, true);
-            }
-            else
-            {
-                Logger.Warning("Branch {0} is not found", branch);
-            }
-        }
-
-        public void AddLocalBranch(string branch)
-        {
-            if (!LocalConfigBranches.ContainsKey(branch))
-            {
-                var now = DateTimeOffset.Now;
-                LocalConfigBranches.Add(branch, new ConfigBranch(branch));
-                Logger.Trace("AddLocalBranch {0} branch:{1} ", now, branch);
-                SaveData(now, true);
-            }
-            else
-            {
-                Logger.Warning("Branch {0} is already present", branch);
-            }
-        }
-
-        public void AddRemoteBranch(string remote, string branch)
-        {
-            Dictionary<string, ConfigBranch> branchList;
-            if (RemoteConfigBranches.TryGetValue(remote, out branchList))
-            {
-                if (!branchList.ContainsKey(branch))
-                {
-                    var now = DateTimeOffset.Now;
-                    branchList.Add(branch, new ConfigBranch(branch, ConfigRemotes[remote]));
-                    Logger.Trace("AddRemoteBranch {0} remote:{1} branch:{2} ", now, remote, branch);
-                    SaveData(now, true);
-                }
-                else
-                {
-                    Logger.Warning("Branch {0} is already present in Remote {1}", branch, remote);
-                }
-            }
-            else
-            {
-                Logger.Warning("Remote {0} is not found", remote);
-            }
-        }
-
-        public void RemoveRemoteBranch(string remote, string branch)
-        {
-            Dictionary<string, ConfigBranch> branchList;
-            if (RemoteConfigBranches.TryGetValue(remote, out branchList))
-            {
-                if (branchList.ContainsKey(branch))
-                {
-                    var now = DateTimeOffset.Now;
-                    branchList.Remove(branch);
-                    Logger.Trace("RemoveRemoteBranch {0} remote:{1} branch:{2} ", now, remote, branch);
-                    SaveData(now, true);
-                }
-                else
-                {
-                    Logger.Warning("Branch {0} is not found in Remote {1}", branch, remote);
-                }
-            }
-            else
-            {
-                Logger.Warning("Remote {0} is not found", remote);
-            }
-        }
-
-        public void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> remoteConfigBranches)
+        public void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> configBranches, GitRemote[] gitRemotes, GitBranch[] gitBranches)
         {
             var now = DateTimeOffset.Now;
             configRemotes = new ConfigRemoteDictionary(remoteConfigs);
-            this.remoteConfigBranches = new RemoteConfigBranchDictionary(remoteConfigBranches);
+            remoteConfigBranches = new RemoteConfigBranchDictionary(remoteConfigBranches);
+            remotes = gitRemotes;
+            remoteBranches = gitBranches;
             Logger.Trace("SetRemotes {0}", now);
             SaveData(now, true);
         }
@@ -610,11 +463,15 @@ namespace IntegrationTests
         public void SetLocals(Dictionary<string, ConfigBranch> configBranches, GitBranch[] gitBranches)
         {
             var now = DateTimeOffset.Now;
-            this.localConfigBranches = new LocalConfigBranchDictionary(configBranches);
-            Logger.Trace("SetRemotes {0}", now);
+            localConfigBranches = new LocalConfigBranchDictionary(configBranches);
+            localBranches = gitBranches;
+            Logger.Trace("SetLocals {0}", now);
             SaveData(now, true);
         }
 
+        public GitBranch[] LocalBranches { get { return localBranches; } }
+        public GitBranch[] RemoteBranches { get { return remoteBranches; } }
+        public GitRemote[] Remotes { get { return remotes; } }
         public ILocalConfigBranchDictionary LocalConfigBranches { get { return localConfigBranches; } }
         public IRemoteConfigBranchDictionary RemoteConfigBranches { get { return remoteConfigBranches; } }
         public IConfigRemoteDictionary ConfigRemotes { get { return configRemotes; } }

--- a/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
+++ b/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
@@ -23,8 +23,8 @@ namespace IntegrationTests
                 .StartAsAsync();
 
             gitBranches.Should().BeEquivalentTo(
-                new GitBranch("master", "origin/master: behind 1", true),
-                new GitBranch("feature/document", "origin/feature/document", false));
+                new GitBranch("master", "origin/master: behind 1"),
+                new GitBranch("feature/document", "origin/feature/document"));
         }
 
         [Test]

--- a/src/tests/UnitTests/IO/BranchListOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/BranchListOutputProcessorTests.cs
@@ -20,9 +20,9 @@ namespace UnitTests
 
             AssertProcessOutput(output, new[]
             {
-                new GitBranch("master", "origin/master", true),
-                new GitBranch("feature/feature-1", "", false),
-                new GitBranch("bugfixes/bugfix-1", "origin/bugfixes/bugfix-1", false),
+                new GitBranch("master", "origin/master"),
+                new GitBranch("feature/feature-1", ""),
+                new GitBranch("bugfixes/bugfix-1", "origin/bugfixes/bugfix-1"),
             });
         }
 


### PR DESCRIPTION
**_DO NOT MERGE_**: This is part of #663 

- Removing unused functions in `BranchCache`
- Consolidating means to update `BranchCache`
- Removing `IsActive` from `GitBranch`
- Changing `BranchesView` to use `RepositoryInfoCache` in addition to `BranchCache` for it's display

Fixes #668