### PR TITLE
Fix support for 5.4

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -338,7 +338,7 @@ namespace GitHub.Unity
 
         private void OnTreeGUI(Rect rect)
         {
-            var treeRenderRect = Rect.zero;
+            var treeRenderRect = new Rect(0f, 0f, 0f, 0f);
             if (treeLocals != null && treeRemotes != null)
             {
                 treeLocals.FolderStyle = Styles.Foldout;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -498,7 +498,7 @@ namespace GitHub.Unity
                     {
                         var borderLeft = Styles.Label.margin.left;
                         var treeControlRect = new Rect(rect.x + borderLeft, rect.y, Position.width - borderLeft * 2, Position.height - rect.height + Styles.CommitAreaPadding);
-                        var treeRect = Rect.zero;
+                        var treeRect = new Rect(0f, 0f, 0f, 0f);
                         if (treeChanges != null)
                         {
                             treeChanges.FolderStyle = Styles.Foldout;


### PR DESCRIPTION
Rect.zero was introduced in 5.5 as a shortcut to `new Rect(0f, 0f, 0f, 0f)`

Fixes #675 
