### PR TITLE
Fixes UI unavailable when using the system git

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -99,7 +99,10 @@ namespace GitHub.Unity
             {
                 if (path.IsInitialized)
                 {
-                    var state = new GitInstaller.GitInstallationState { GitExecutablePath = path };
+                    var state = new GitInstaller.GitInstallationState {
+                        GitExecutablePath = path,
+                        GitIsValid = true
+                    };
                     endTask.PreviousResult = state;
                     endTask.Start();
                     return;

--- a/src/GitHub.Api/OutputProcessors/ProcessManager.cs
+++ b/src/GitHub.Api/OutputProcessors/ProcessManager.cs
@@ -30,18 +30,7 @@ namespace GitHub.Unity
             bool dontSetupGit = false)
              where T : IProcess
         {
-            if (executable == null)
-            {
-                if (processTask.ProcessName?.ToNPath() != null)
-                {
-                    executable = processTask.ProcessName.ToNPath();
-                }
-                else
-                {
-                    executable = environment.GitExecutablePath;
-                    dontSetupGit = environment.IsCustomGitExecutable;
-                }
-            }
+            executable = executable ?? processTask.ProcessName?.ToNPath() ?? environment.GitExecutablePath;
 
             //If this null check fails, be sure you called Configure() on your task
             Guard.ArgumentNotNull(executable, nameof(executable));


### PR DESCRIPTION
When using a git whose path is set in the settings, the UI would be disabled as if git wasn't found. This fixes that issue.

It also fixes another issue where the git environment wouldn't be set up properly if the user is not using our portable git.