### PR TITLE
Calling CacheHasBeenInvalidated instead of RefreshCache

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -92,7 +92,7 @@ namespace GitHub.Unity
         {
             foreach (var cacheType in cacheInvalidationRequests)
             {
-                RefreshCache(cacheType);
+                CacheHasBeenInvalidated(cacheType);
             }
         }
 


### PR DESCRIPTION
Fixes #679 

At the point that cacheInvalidationRequests are being handled, we already know the data is invalid.
There is no reason to call RefreshCache on them and go through that pipeline again.
Furthermore that pipeline is currently waiting for valid data, so it will not fire off the invalidation events a second time.