### PR TITLE
Add more EditorConfig options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,5 @@ root = true
 [*.cs]
 indent_style = space
 indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
### Description of the Change

This adds a few more common properties that are often found in EditorConfig files. I have outlined much of the rational in a comment: https://github.com/github-for-unity/Unity/issues/248#issuecomment-375104375

### Alternate Designs

N/A

### Benefits

It is general best practice to include a newline at the end of a file, as well as remove trailing whitespace from lines

### Possible Drawbacks

None that I can think of

### Applicable Issues

#248
