### PR TITLE
Fixing Asset Explorer icon overlays

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -185,7 +185,6 @@ namespace GitHub.Unity
             {
                 var path = entries[index].ProjectPath;
                 var guid = AssetDatabase.AssetPathToGUID(path);
-
                 guids.Add(guid);
             }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -183,25 +183,9 @@ namespace GitHub.Unity
             guids.Clear();
             for (var index = 0; index < entries.Count; ++index)
             {
-                var gitStatusEntry = entries[index];
-
-                var path = gitStatusEntry.ProjectPath;
-                if (gitStatusEntry.Status == GitFileStatus.Ignored)
-                {
-                    continue;
-                }
-
-                if (!path.StartsWith("Assets", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (path.EndsWith(".meta", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    continue;
-                }
-
+                var path = entries[index].ProjectPath;
                 var guid = AssetDatabase.AssetPathToGUID(path);
+
                 guids.Add(guid);
             }
 


### PR DESCRIPTION
Fixes #696 

Instead of a dictionary as in the Changes view. Here `guids` is used as a positional marker in the entries array. It should be populated with all entries regardless if they are assets or not.