### PR TITLE
Sorting GitStatus entries

### DIFF
--- a/src/GitHub.Api/Git/Tasks/GitStatusTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitStatusTask.cs
@@ -8,7 +8,7 @@ namespace GitHub.Unity
 
         public GitStatusTask(IGitObjectFactory gitObjectFactory,
             CancellationToken token, IOutputProcessor<GitStatus> processor = null)
-            : base(token, processor ?? new StatusOutputProcessor(gitObjectFactory))
+            : base(token, processor ?? new GitStatusOutputProcessor(gitObjectFactory))
         {
             Name = TaskName;
         }

--- a/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace GitHub.Unity
 {
-    class StatusOutputProcessor : BaseOutputProcessor<GitStatus>
+    class GitStatusOutputProcessor : BaseOutputProcessor<GitStatus>
     {
         private static readonly Regex branchTrackedAndDelta = new Regex(@"(.*)\.\.\.(.*)\s\[(.*)\]",
             RegexOptions.Compiled);
@@ -13,7 +13,7 @@ namespace GitHub.Unity
         private readonly IGitObjectFactory gitObjectFactory;
         GitStatus gitStatus;
         
-        public StatusOutputProcessor(IGitObjectFactory gitObjectFactory)
+        public GitStatusOutputProcessor(IGitObjectFactory gitObjectFactory)
         {
             Guard.ArgumentNotNull(gitObjectFactory, "gitObjectFactory");
             this.gitObjectFactory = gitObjectFactory;
@@ -189,6 +189,10 @@ namespace GitHub.Unity
         {
             if (gitStatus.Entries == null)
                 return;
+
+            gitStatus.Entries = gitStatus.Entries
+                                         .OrderBy(entry => entry.Path)
+                                         .ToList();
 
             RaiseOnEntry(gitStatus);
 

--- a/src/tests/IntegrationTests/ProcessManagerExtensions.cs
+++ b/src/tests/IntegrationTests/ProcessManagerExtensions.cs
@@ -50,7 +50,7 @@ namespace IntegrationTests
             NPath? gitPath = null)
         {
             var gitStatusEntryFactory = new GitObjectFactory(environment);
-            var processor = new StatusOutputProcessor(gitStatusEntryFactory);
+            var processor = new GitStatusOutputProcessor(gitStatusEntryFactory);
 
             NPath path = gitPath ?? defaultGitPath;
 

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -250,7 +250,7 @@ namespace UnitTests
             var gitObjectFactory = SubstituteFactory.CreateGitObjectFactory(TestRootPath);
 
             GitStatus? result = null;
-            var outputProcessor = new StatusOutputProcessor(gitObjectFactory);
+            var outputProcessor = new GitStatusOutputProcessor(gitObjectFactory);
             outputProcessor.OnEntry += status => { result = status; };
 
             foreach (var line in lines)

--- a/src/tests/UnitTests/ProcessManagerExtensions.cs
+++ b/src/tests/UnitTests/ProcessManagerExtensions.cs
@@ -58,7 +58,7 @@ namespace UnitTests
             NPath? gitPath = null)
         {
             var gitStatusEntryFactory = new GitObjectFactory(environment);
-            var processor = new StatusOutputProcessor(gitStatusEntryFactory);
+            var processor = new GitStatusOutputProcessor(gitStatusEntryFactory);
 
             NPath path = gitPath ?? defaultGitPath;
 


### PR DESCRIPTION
Fixes: #695 

In order to reproduce this bug, you need to be able to generate the following in a test repo.
with the command `git -c i18n.logoutputencoding=utf8 -c core.quotepath=false status -b -u --porcelain`.

```
✔ ~/Projects/RPG-Tutorial [master ↑·2|✚ 3…9]
10:49 $ git -c i18n.logoutputencoding=utf8 -c core.quotepath=false status -b -u --porcelain
## master...origin/master [ahead 2]
 M "Finished Project/Assets/New Text Document (2).txt"
 M "Finished Project/ProjectSettings/ProjectVersion.txt"
?? Finished Project/Assets/New Text Document.txt
```

Notice how the output is not sorted. This bug is caused by the tree control assuming the git status entries are already sorted. Sorting them in the output processor solves this issue.

Also renamed `StatusOutputProcessor` to `GitStatusOutputProcessor` for consistency.