### PR TITLE
Avoiding the update of the username when we need 2fa

### DIFF
--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -72,7 +72,11 @@ namespace GitHub.Unity
                         throw new InvalidOperationException("Returned token is null or empty");
                     }
 
-                    username = await RetrieveUsername(loginResultData, username);
+                    if (loginResultData.Code == LoginResultCodes.Success)
+                    {
+                        username = await RetrieveUsername(loginResultData, username);
+                    }
+
                     keychain.SetToken(host, loginResultData.Token, username);
 
                     if (loginResultData.Code == LoginResultCodes.Success)


### PR DESCRIPTION
Additional fix to #690 and #685 

Edit by @shana: We should not be updating the username until the login process is done, we don't have a valid token to use to access user data until then.