### PR TITLE
Fix to cache updating

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -409,7 +409,10 @@ namespace GitHub.Unity
             Guard.ArgumentNotNull(client, nameof(client));
             gitClient = client;
             if (needsRefresh)
-                cacheContainer.GitUserCache.InvalidateData();
+            {
+                needsRefresh = false;
+                UpdateUserAndEmail();
+            }
         }
 
         public void SetNameAndEmail(string name, string email)


### PR DESCRIPTION
Fixes: #709 

After we get the invalidation event form the cache, the cache will not send another invalidation event until it gets a new data set. User should retrieve the data after it has been initialized if the cache has previously signaled the data is invalid.

This is the same bug as #679 and same fix as #689, just in the user object instead.