### PR TITLE
Fixes #699

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -90,7 +90,6 @@ namespace GitHub.Unity
                                  favoriteIconOff,
                                  smallLogoIcon,
                                  bigLogoIcon,
-                                 defaultAssetIcon,
                                  folderIcon,
                                  mergeIcon,
                                  dotIcon,
@@ -781,19 +780,6 @@ namespace GitHub.Unity
                 }
 
                 return localCommitIcon;
-            }
-        }
-
-        public static Texture2D DefaultAssetIcon
-        {
-            get
-            {
-                if (defaultAssetIcon == null)
-                {
-                    defaultAssetIcon = EditorGUIUtility.FindTexture("DefaultAsset Icon");
-                }
-
-                return defaultAssetIcon;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -163,16 +163,12 @@ namespace GitHub.Unity
             {
                 if (!string.IsNullOrEmpty(node.ProjectPath))
                 {
-                    nodeIcon = AssetDatabase.GetCachedIcon(node.ProjectPath);
+                    nodeIcon = UnityEditorInternal.InternalEditorUtility.GetIconForFile(node.ProjectPath);
                 }
 
                 if (nodeIcon != null)
                 {
                     nodeIcon.hideFlags = HideFlags.HideAndDontSave;
-                }
-                else
-                {
-                    nodeIcon = Styles.DefaultAssetIcon;
                 }
             }
 


### PR DESCRIPTION
### Description of the Change

This fixes the problem where the icons do not show on .meta or other icon files that is not cached.

We used `AssetDatabase.GetCachedIcon` which only works for assets that show up in the Project window, and the icond for the assets were not the icons that should show up.

In 2018 version, `EditorGUIUtility.FindTexture("DefaultAsset Icon")` returns null cause it does not check for it. ([Source](https://gist.github.com/ThomasAunvik/3bc1902eb9b043cc718f9c5fbd67c45f))

### Alternate Designs

`AssetPreview.GetMiniTypeThumbnail(typeof(DefaultAsset))` for getting the Default Asset Icon, but that was not needed since `InternalEditorUtility.GetIconForFile(node.ProjectPath)` returns the default asset icon if nothing else is found.

### Benefits

There is no need for the default asset icon anymore, since it was only used once for this, and `GetIconForFile` already gets back the default asset icon if there is no other available icon.

Files now show icons that you see in the Project window.

### Possible Drawbacks

People getting fascinated over how the files look.