### PR TITLE
git fetch should also fetch tags

### DIFF
--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -276,7 +276,7 @@ namespace GitHub.Unity
         {
             //Logger.Trace("Fetch");
 
-            return new GitFetchTask(remote, cancellationToken, true, processor)
+            return new GitFetchTask(remote, cancellationToken, true, true, processor)
                 .Configure(processManager);
         }
 

--- a/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
@@ -10,21 +10,21 @@ namespace GitHub.Unity
         private readonly string arguments;
 
         public GitFetchTask(string remote,
-            CancellationToken token, bool all = false, bool prune = false, IOutputProcessor<string> processor = null)
+            CancellationToken token, bool tags = false, bool prune = false, IOutputProcessor<string> processor = null)
             : base(token, processor ?? new SimpleOutputProcessor())
         {
             Name = TaskName;
             var stringBuilder = new StringBuilder();
             stringBuilder.Append("fetch");
-
-            if (all)
-            {
-                stringBuilder.Append(" --all");
-            }
-
+            
             if (prune)
             {
                 stringBuilder.Append(" -p");
+            }
+
+            if (tags)
+            {
+                stringBuilder.Append(" --tags");
             }
 
             if (!String.IsNullOrEmpty(remote))

--- a/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
@@ -10,7 +10,7 @@ namespace GitHub.Unity
         private readonly string arguments;
 
         public GitFetchTask(string remote,
-            CancellationToken token, bool tags = false, bool prune = false, IOutputProcessor<string> processor = null)
+            CancellationToken token, bool prune = false, bool tags = false, IOutputProcessor<string> processor = null)
             : base(token, processor ?? new SimpleOutputProcessor())
         {
             Name = TaskName;

--- a/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
+++ b/src/GitHub.Api/Git/Tasks/GitFetchTask.cs
@@ -10,12 +10,17 @@ namespace GitHub.Unity
         private readonly string arguments;
 
         public GitFetchTask(string remote,
-            CancellationToken token, bool prune = false, IOutputProcessor<string> processor = null)
+            CancellationToken token, bool all = false, bool prune = false, IOutputProcessor<string> processor = null)
             : base(token, processor ?? new SimpleOutputProcessor())
         {
             Name = TaskName;
             var stringBuilder = new StringBuilder();
             stringBuilder.Append("fetch");
+
+            if (all)
+            {
+                stringBuilder.Append(" --all");
+            }
 
             if (prune)
             {


### PR DESCRIPTION
Fixes #572 

### Description of the Change

Adds `--all` in the arguments whenever you want to fetch all in `GitFetchTask`, third parameter, 

### Benefits

Fetches Tags

### Possible Drawbacks

Possible longer time to finish fetch task.