### PR TITLE
Renaming metrics to indicate the user interaction that caused them

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -168,7 +168,7 @@ namespace GitHub.Unity
                 })
                 .ThenInUI(() =>
                 {
-                    TaskManager.Run(UsageTracker.IncrementNumberOfProjectsInitialized);
+                    TaskManager.Run(UsageTracker.Initialized);
                     InitializeUI();
                 });
             return task;

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -168,7 +168,7 @@ namespace GitHub.Unity
                 })
                 .ThenInUI(() =>
                 {
-                    TaskManager.Run(UsageTracker.Initialized);
+                    TaskManager.Run(UsageTracker.ProjectsInitialized);
                     InitializeUI();
                 });
             return task;

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -168,7 +168,7 @@ namespace GitHub.Unity
                 })
                 .ThenInUI(() =>
                 {
-                    TaskManager.Run(UsageTracker.ProjectsInitialized);
+                    TaskManager.Run(UsageTracker.IncrementProjectsInitialized);
                     InitializeUI();
                 });
             return task;
@@ -191,8 +191,6 @@ namespace GitHub.Unity
         {
             //Logger.Trace("Setup metrics");
 
-            var usagePath = Environment.UserCachePath.Combine(Constants.UsageFile);
-
             string userId = null;
             if (UserSettings.Exists(Constants.GuidKey))
             {
@@ -212,7 +210,7 @@ namespace GitHub.Unity
                 Environment.NodeJsExecutablePath,
                 Environment.OctorunScriptPath);
 
-            UsageTracker = new UsageTracker(metricsService, UserSettings, usagePath, userId, unityVersion, instanceId.ToString());
+            UsageTracker = new UsageTracker(metricsService, UserSettings, Environment, userId, unityVersion, instanceId.ToString());
 
             if (firstRun)
             {

--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -75,5 +75,8 @@ namespace GitHub.Unity
         ITask RemoteAdd(string remote, string url);
         ITask RemoteRemove(string remote);
         ITask Push(string remote);
+        ITask DeleteBranch(string branch, bool force);
+        ITask CreateBranch(string branch, string baseBranch);
+        ITask SwitchBranch(string branch);
     }
 }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -122,6 +122,9 @@ namespace GitHub.Unity
         public ITask DiscardChanges(GitStatusEntry[] gitStatusEntry) => repositoryManager.DiscardChanges(gitStatusEntry);
         public ITask RemoteAdd(string remote, string url) => repositoryManager.RemoteAdd(remote, url);
         public ITask RemoteRemove(string remote) => repositoryManager.RemoteRemove(remote);
+        public ITask DeleteBranch(string branch, bool force) => repositoryManager.DeleteBranch(branch, force);
+        public ITask CreateBranch(string branch, string baseBranch) => repositoryManager.CreateBranch(branch, baseBranch);
+        public ITask SwitchBranch(string branch) => repositoryManager.SwitchBranch(branch);
 
         public void CheckAndRaiseEventsIfCacheNewer(CacheType cacheType, CacheUpdateEvent cacheUpdateEvent) => cacheContainer.CheckAndRaiseEventsIfCacheNewer(cacheType, cacheUpdateEvent);
 

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -17,5 +17,7 @@
         void IncrementSettingsViewButtonLfsUnlock();
         void IncrementUnityProjectViewContextLfsLock();
         void IncrementUnityProjectViewContextLfsUnlock();
+        void IncrementPublishViewButtonPublish();
+        void IncrementApplicationMenuMenuItemCommandLine();
     }
 }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -9,7 +9,7 @@
         void HistoryViewToolbarButtonPush();
         void HistoryViewToolbarButtonPull();
         void AuthenticationViewButtonAuthentication();
-        void Initialized();
+        void ProjectsInitialized();
         void BranchesViewButtonCreateBranch();
         void BranchesViewButtonDeleteBranch();
         void BranchesViewButtonCheckoutLocalBranch();
@@ -25,7 +25,7 @@
         public void HistoryViewToolbarButtonPush() { }
         public void HistoryViewToolbarButtonPull() { }
         public void AuthenticationViewButtonAuthentication() { }
-        public void Initialized() { }
+        public void ProjectsInitialized() { }
         public void BranchesViewButtonCreateBranch() { }
         public void BranchesViewButtonDeleteBranch() { }
         public void BranchesViewButtonCheckoutLocalBranch() { }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -4,41 +4,18 @@
     {
         bool Enabled { get; set; }
         void IncrementNumberOfStartups();
-        void ChangesViewButtonCommit();
-        void HistoryViewToolbarButtonFetch();
-        void HistoryViewToolbarButtonPush();
-        void HistoryViewToolbarButtonPull();
-        void AuthenticationViewButtonAuthentication();
-        void ProjectsInitialized();
-        void BranchesViewButtonCreateBranch();
-        void BranchesViewButtonDeleteBranch();
-        void BranchesViewButtonCheckoutLocalBranch();
-        void BranchesViewButtonCheckoutRemoteBranch();
-        void SettingsViewUnlockButtonLfsUnlock();
-        void AssetExplorerContextMenuLfsLock();
-        void AssetExplorerContextMenuLfsUnlock();
-    }
-
-    class NullUsageTracker : IUsageTracker
-    {
-        public bool Enabled { get; set; }
-        public void IncrementNumberOfStartups() { }
-        public void ChangesViewButtonCommit() { }
-        public void HistoryViewToolbarButtonFetch() { }
-        public void HistoryViewToolbarButtonPush() { }
-        public void HistoryViewToolbarButtonPull() { }
-        public void AuthenticationViewButtonAuthentication() { }
-        public void ProjectsInitialized() { }
-        public void BranchesViewButtonCreateBranch() { }
-        public void BranchesViewButtonDeleteBranch() { }
-        public void BranchesViewButtonCheckoutLocalBranch() { }
-        public void BranchesViewButtonCheckoutRemoteBranch() { }
-        public void SettingsViewUnlockButtonLfsUnlock() { }
-
-        public void AssetExplorerContextMenuLfsLock() { }
-
-        public void AssetExplorerContextMenuLfsUnlock() { }
-
-        public void SetMetricsService(IMetricsService instance) { }
+        void IncrementChangesViewButtonCommit();
+        void IncrementHistoryViewToolbarButtonFetch();
+        void IncrementHistoryViewToolbarButtonPush();
+        void IncrementHistoryViewToolbarButtonPull();
+        void IncrementAuthenticationViewButtonAuthentication();
+        void IncrementProjectsInitialized();
+        void IncrementBranchesViewButtonCreateBranch();
+        void IncrementBranchesViewButtonDeleteBranch();
+        void IncrementBranchesViewButtonCheckoutLocalBranch();
+        void IncrementBranchesViewButtonCheckoutRemoteBranch();
+        void IncrementSettingsViewUnlockButtonLfsUnlock();
+        void IncrementAssetExplorerContextMenuLfsLock();
+        void IncrementAssetExplorerContextMenuLfsUnlock();
     }
 }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -5,17 +5,17 @@
         bool Enabled { get; set; }
         void IncrementNumberOfStartups();
         void IncrementChangesViewButtonCommit();
-        void IncrementHistoryViewToolbarButtonFetch();
-        void IncrementHistoryViewToolbarButtonPush();
-        void IncrementHistoryViewToolbarButtonPull();
+        void IncrementHistoryViewToolbarFetch();
+        void IncrementHistoryViewToolbarPush();
+        void IncrementHistoryViewToolbarPull();
         void IncrementAuthenticationViewButtonAuthentication();
         void IncrementProjectsInitialized();
         void IncrementBranchesViewButtonCreateBranch();
         void IncrementBranchesViewButtonDeleteBranch();
         void IncrementBranchesViewButtonCheckoutLocalBranch();
         void IncrementBranchesViewButtonCheckoutRemoteBranch();
-        void IncrementSettingsViewUnlockButtonLfsUnlock();
-        void IncrementAssetExplorerContextMenuLfsLock();
-        void IncrementAssetExplorerContextMenuLfsUnlock();
+        void IncrementSettingsViewButtonLfsUnlock();
+        void IncrementUnityProjectViewContextLfsLock();
+        void IncrementUnityProjectViewContextLfsUnlock();
     }
 }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -5,9 +5,9 @@
         bool Enabled { get; set; }
         void IncrementNumberOfStartups();
         void ChangesViewButtonCommit();
-        void HistoryToolbarButtonFetch();
-        void HistoryToolbarButtonPush();
-        void HistoryToolbarButtonPull();
+        void HistoryViewToolbarButtonFetch();
+        void HistoryViewToolbarButtonPush();
+        void HistoryViewToolbarButtonPull();
         void AuthenticationViewButtonAuthentication();
         void Initialized();
         void BranchesViewButtonCreateBranch();
@@ -21,9 +21,9 @@
         public bool Enabled { get; set; }
         public void IncrementNumberOfStartups() { }
         public void ChangesViewButtonCommit() { }
-        public void HistoryToolbarButtonFetch() { }
-        public void HistoryToolbarButtonPush() { }
-        public void HistoryToolbarButtonPull() { }
+        public void HistoryViewToolbarButtonFetch() { }
+        public void HistoryViewToolbarButtonPush() { }
+        public void HistoryViewToolbarButtonPull() { }
         public void AuthenticationViewButtonAuthentication() { }
         public void Initialized() { }
         public void BranchesViewButtonCreateBranch() { }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -14,6 +14,9 @@
         void BranchesViewButtonDeleteBranch();
         void BranchesViewButtonCheckoutLocalBranch();
         void BranchesViewButtonCheckoutRemoteBranch();
+        void SettingsViewUnlockButtonLfsUnlock();
+        void AssetExplorerContextMenuLfsLock();
+        void AssetExplorerContextMenuLfsUnlock();
     }
 
     class NullUsageTracker : IUsageTracker
@@ -30,6 +33,12 @@
         public void BranchesViewButtonDeleteBranch() { }
         public void BranchesViewButtonCheckoutLocalBranch() { }
         public void BranchesViewButtonCheckoutRemoteBranch() { }
+        public void SettingsViewUnlockButtonLfsUnlock() { }
+
+        public void AssetExplorerContextMenuLfsLock() { }
+
+        public void AssetExplorerContextMenuLfsUnlock() { }
+
         public void SetMetricsService(IMetricsService instance) { }
     }
 }

--- a/src/GitHub.Api/Metrics/IUsageTracker.cs
+++ b/src/GitHub.Api/Metrics/IUsageTracker.cs
@@ -4,32 +4,32 @@
     {
         bool Enabled { get; set; }
         void IncrementNumberOfStartups();
-        void IncrementNumberOfCommits();
-        void IncrementNumberOfFetches();
-        void IncrementNumberOfPushes();
-        void IncrementNumberOfPulls();
-        void IncrementNumberOfAuthentications();
-        void IncrementNumberOfProjectsInitialized();
-        void IncrementNumberOfLocalBranchCreations();
-        void IncrementNumberOfLocalBranchDeletions();
-        void IncrementNumberOfLocalBranchCheckouts();
-        void IncrementNumberOfRemoteBranchCheckouts();
+        void ChangesViewButtonCommit();
+        void HistoryToolbarButtonFetch();
+        void HistoryToolbarButtonPush();
+        void HistoryToolbarButtonPull();
+        void AuthenticationViewButtonAuthentication();
+        void Initialized();
+        void BranchesViewButtonCreateBranch();
+        void BranchesViewButtonDeleteBranch();
+        void BranchesViewButtonCheckoutLocalBranch();
+        void BranchesViewButtonCheckoutRemoteBranch();
     }
 
     class NullUsageTracker : IUsageTracker
     {
         public bool Enabled { get; set; }
         public void IncrementNumberOfStartups() { }
-        public void IncrementNumberOfCommits() { }
-        public void IncrementNumberOfFetches() { }
-        public void IncrementNumberOfPushes() { }
-        public void IncrementNumberOfPulls() { }
-        public void IncrementNumberOfAuthentications() { }
-        public void IncrementNumberOfProjectsInitialized() { }
-        public void IncrementNumberOfLocalBranchCreations() { }
-        public void IncrementNumberOfLocalBranchDeletions() { }
-        public void IncrementNumberOfLocalBranchCheckouts() { }
-        public void IncrementNumberOfRemoteBranchCheckouts() { }
+        public void ChangesViewButtonCommit() { }
+        public void HistoryToolbarButtonFetch() { }
+        public void HistoryToolbarButtonPush() { }
+        public void HistoryToolbarButtonPull() { }
+        public void AuthenticationViewButtonAuthentication() { }
+        public void Initialized() { }
+        public void BranchesViewButtonCreateBranch() { }
+        public void BranchesViewButtonDeleteBranch() { }
+        public void BranchesViewButtonCheckoutLocalBranch() { }
+        public void BranchesViewButtonCheckoutRemoteBranch() { }
         public void SetMetricsService(IMetricsService instance) { }
     }
 }

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -40,6 +40,8 @@ namespace GitHub.Unity
         public int SettingsViewButtonLfsUnlock { get; set; }
         public int UnityProjectViewContextLfsLock { get; set; }
         public int UnityProjectViewContextLfsUnlock { get; set; }
+        public int PublishViewButtonPublish { get; set; }
+        public int ApplicationMenuMenuItemCommandLine { get; set; }
     }
 
     class UsageModel

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -29,7 +29,7 @@ namespace GitHub.Unity
         public int HistoryViewToolbarButtonFetch { get; set; }
         public int HistoryViewToolbarButtonPush { get; set; }
         public int HistoryViewToolbarButtonPull { get; set; }
-        public int Initialized { get; set; }
+        public int ProjectsInitialized { get; set; }
         public int AuthenticationViewButtonAuthentication { get; set; }
         public int BranchesViewButtonCreateBranch { get; set; }
         public int BranchesViewButtonDeleteBranch { get; set; }

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -27,19 +27,19 @@ namespace GitHub.Unity
     public class Measures
     {
         public int NumberOfStartups { get; set; }
-        public int ChangesViewButtonCommit { get; set; }
-        public int HistoryViewToolbarButtonFetch { get; set; }
-        public int HistoryViewToolbarButtonPush { get; set; }
-        public int HistoryViewToolbarButtonPull { get; set; }
         public int ProjectsInitialized { get; set; }
+        public int ChangesViewButtonCommit { get; set; }
+        public int HistoryViewToolbarFetch { get; set; }
+        public int HistoryViewToolbarPush { get; set; }
+        public int HistoryViewToolbarPull { get; set; }
         public int AuthenticationViewButtonAuthentication { get; set; }
         public int BranchesViewButtonCreateBranch { get; set; }
         public int BranchesViewButtonDeleteBranch { get; set; }
         public int BranchesViewButtonCheckoutLocalBranch { get; set; }
         public int BranchesViewButtonCheckoutRemoteBranch { get; set; }
-        public int SettingsViewUnlockButtonLfsUnlock { get; set; }
-        public int AssetExplorerContextMenuLfsLock { get; set; }
-        public int AssetExplorerContextMenuLfsUnlock { get; set; }
+        public int SettingsViewButtonLfsUnlock { get; set; }
+        public int UnityProjectViewContextLfsLock { get; set; }
+        public int UnityProjectViewContextLfsUnlock { get; set; }
     }
 
     class UsageModel

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -25,16 +25,16 @@ namespace GitHub.Unity
     public class Measures
     {
         public int NumberOfStartups { get; set; }
-        public int Commits { get; set; }
-        public int Fetches { get; set; }
-        public int Pushes { get; set; }
-        public int Pulls { get; set; }
-        public int ProjectsInitialized { get; set; }
-        public int Authentications { get; set; }
-        public int LocalBranchCreations { get; set; }
-        public int LocalBranchDeletion { get; set; }
-        public int LocalBranchCheckouts { get; set; }
-        public int RemoteBranchCheckouts { get; set; }
+        public int ChangesViewButtonCommit { get; set; }
+        public int HistoryToolbarButtonFetch { get; set; }
+        public int HistoryToolbarButtonPush { get; set; }
+        public int HistoryToolbarButtonPull { get; set; }
+        public int Initialized { get; set; }
+        public int AuthenticationViewButtonAuthentication { get; set; }
+        public int BranchesViewButtonCreateBranch { get; set; }
+        public int BranchesViewButtonDeleteBranch { get; set; }
+        public int BranchesViewButtonCheckoutLocalBranch { get; set; }
+        public int BranchesViewButtonCheckoutRemoteBranch { get; set; }
     }
 
     class UsageModel

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -35,6 +35,9 @@ namespace GitHub.Unity
         public int BranchesViewButtonDeleteBranch { get; set; }
         public int BranchesViewButtonCheckoutLocalBranch { get; set; }
         public int BranchesViewButtonCheckoutRemoteBranch { get; set; }
+        public int SettingsViewUnlockButtonLfsUnlock { get; set; }
+        public int AssetExplorerContextMenuLfsLock { get; set; }
+        public int AssetExplorerContextMenuLfsUnlock { get; set; }
     }
 
     class UsageModel

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -17,7 +17,7 @@ namespace GitHub.Unity
     public class Dimensions
     {
         public string Guid { get; set; }
-        public DateTime Date { get; set; }
+        public DateTimeOffset Date { get; set; }
         public string AppVersion { get; set; }
         public string UnityVersion { get; set; }
         public string Lang { get; set; }
@@ -54,7 +54,7 @@ namespace GitHub.Unity
             Guard.ArgumentNotNullOrWhiteSpace(appVersion, "appVersion");
             Guard.ArgumentNotNullOrWhiteSpace(unityVersion, "unityVersion");
 
-            var date = DateTime.UtcNow.Date;
+            var now = DateTimeOffset.Now;
             if (currentUsage == null)
             {
                 currentUsage = Reports
@@ -67,7 +67,7 @@ namespace GitHub.Unity
                 {
                     InstanceId = instanceId,
                     Dimensions = {
-                        Date = date,
+                        Date = now,
                         Guid = Guid,
                         AppVersion = appVersion,
                         UnityVersion = unityVersion,
@@ -94,7 +94,7 @@ namespace GitHub.Unity
 
     class UsageStore
     {
-        public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.Now;
         public UsageModel Model { get; set; } = new UsageModel();
 
         public Measures GetCurrentMeasures(string appVersion, string unityVersion, string instanceId)

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -26,9 +26,9 @@ namespace GitHub.Unity
     {
         public int NumberOfStartups { get; set; }
         public int ChangesViewButtonCommit { get; set; }
-        public int HistoryToolbarButtonFetch { get; set; }
-        public int HistoryToolbarButtonPush { get; set; }
-        public int HistoryToolbarButtonPull { get; set; }
+        public int HistoryViewToolbarButtonFetch { get; set; }
+        public int HistoryViewToolbarButtonPush { get; set; }
+        public int HistoryViewToolbarButtonPull { get; set; }
         public int Initialized { get; set; }
         public int AuthenticationViewButtonAuthentication { get; set; }
         public int BranchesViewButtonCreateBranch { get; set; }

--- a/src/GitHub.Api/Metrics/UsageModel.cs
+++ b/src/GitHub.Api/Metrics/UsageModel.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using GitHub.Logging;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace GitHub.Unity
 {
@@ -94,5 +96,10 @@ namespace GitHub.Unity
     {
         public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
         public UsageModel Model { get; set; } = new UsageModel();
+
+        public Measures GetCurrentMeasures(string appVersion, string unityVersion, string instanceId)
+        {
+            return Model.GetCurrentUsage(appVersion, unityVersion, instanceId).Measures;
+        }
     }
 }

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -249,6 +249,36 @@ namespace GitHub.Unity
             SaveUsage(usageStore);
         }
 
+        public void SettingsViewUnlockButtonLfsUnlock()
+        {
+            var usageStore = LoadUsage();
+            var usage = GetCurrentUsage(usageStore);
+
+            usage.Measures.SettingsViewUnlockButtonLfsUnlock++;
+
+            SaveUsage(usageStore);
+        }
+
+        public void AssetExplorerContextMenuLfsLock()
+        {
+            var usageStore = LoadUsage();
+            var usage = GetCurrentUsage(usageStore);
+
+            usage.Measures.AssetExplorerContextMenuLfsLock++;
+
+            SaveUsage(usageStore);
+        }
+
+        public void AssetExplorerContextMenuLfsUnlock()
+        {
+            var usageStore = LoadUsage();
+            var usage = GetCurrentUsage(usageStore);
+
+            usage.Measures.AssetExplorerContextMenuLfsUnlock++;
+
+            SaveUsage(usageStore);
+        }
+
         public void HistoryViewToolbarButtonPull()
         {
             var usageStore = LoadUsage();

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -301,7 +301,7 @@ namespace GitHub.Unity
         {
             try
             {
-                var json = this.ToJson(lowerCase: true);
+                var json = store.ToJson(lowerCase: true);
                 path.WriteAllText(json, Encoding.UTF8);
             }
             catch (Exception ex)

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -223,6 +223,22 @@ namespace GitHub.Unity
             usageLoader.Save(usage);
         }
 
+        public void IncrementPublishViewButtonPublish()
+        {
+            var usage = usageLoader.Load(userId);
+            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
+                 .PublishViewButtonPublish++;
+            usageLoader.Save(usage);
+        }
+
+        public void IncrementApplicationMenuMenuItemCommandLine()
+        {
+            var usage = usageLoader.Load(userId);
+            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
+                 .ApplicationMenuMenuItemCommandLine++;
+            usageLoader.Save(usage);
+        }
+
         public bool Enabled
         {
             get

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -2,8 +2,6 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Timers;
-using System.Globalization;
 using System.Threading;
 using Timer = System.Threading.Timer;
 using GitHub.Logging;
@@ -121,6 +119,14 @@ namespace GitHub.Unity
             usageLoader.Save(usage);
         }
 
+        public void IncrementProjectsInitialized()
+        {
+            var usage = usageLoader.Load(userId);
+            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
+                .ProjectsInitialized++;
+            usageLoader.Save(usage);
+        }
+
         public void IncrementChangesViewButtonCommit()
         {
             var usage = usageLoader.Load(userId);
@@ -129,27 +135,27 @@ namespace GitHub.Unity
             usageLoader.Save(usage);
         }
 
-        public void IncrementHistoryViewToolbarButtonFetch()
+        public void IncrementHistoryViewToolbarFetch()
         {
             var usage = usageLoader.Load(userId);
             usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .HistoryViewToolbarButtonFetch++;
+                .HistoryViewToolbarFetch++;
             usageLoader.Save(usage);
         }
 
-        public void IncrementHistoryViewToolbarButtonPush()
+        public void IncrementHistoryViewToolbarPush()
         {
             var usage = usageLoader.Load(userId);
             usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .HistoryViewToolbarButtonPush++;
+                .HistoryViewToolbarPush++;
             usageLoader.Save(usage);
         }
 
-        public void IncrementProjectsInitialized()
+        public void IncrementHistoryViewToolbarPull()
         {
             var usage = usageLoader.Load(userId);
             usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .ProjectsInitialized++;
+                .HistoryViewToolbarPull++;
             usageLoader.Save(usage);
         }
 
@@ -185,35 +191,11 @@ namespace GitHub.Unity
             usageLoader.Save(usage);
         }
 
-        public void IncrementSettingsViewUnlockButtonLfsUnlock()
+        public void IncrementSettingsViewButtonLfsUnlock()
         {
             var usage = usageLoader.Load(userId);
             usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .SettingsViewUnlockButtonLfsUnlock++;
-            usageLoader.Save(usage);
-        }
-
-        public void IncrementAssetExplorerContextMenuLfsLock()
-        {
-            var usage = usageLoader.Load(userId);
-            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .AssetExplorerContextMenuLfsLock++;
-            usageLoader.Save(usage);
-        }
-
-        public void IncrementAssetExplorerContextMenuLfsUnlock()
-        {
-            var usage = usageLoader.Load(userId);
-            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .AssetExplorerContextMenuLfsUnlock++;
-            usageLoader.Save(usage);
-        }
-
-        public void IncrementHistoryViewToolbarButtonPull()
-        {
-            var usage = usageLoader.Load(userId);
-            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
-                .HistoryViewToolbarButtonPull++;
+                .SettingsViewButtonLfsUnlock++;
             usageLoader.Save(usage);
         }
 
@@ -222,6 +204,22 @@ namespace GitHub.Unity
             var usage = usageLoader.Load(userId);
             usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
                 .AuthenticationViewButtonAuthentication++;
+            usageLoader.Save(usage);
+        }
+
+        public void IncrementUnityProjectViewContextLfsLock()
+        {
+            var usage = usageLoader.Load(userId);
+            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
+                .UnityProjectViewContextLfsLock++;
+            usageLoader.Save(usage);
+        }
+
+        public void IncrementUnityProjectViewContextLfsUnlock()
+        {
+            var usage = usageLoader.Load(userId);
+            usage.GetCurrentMeasures(appVersion, unityVersion, instanceId)
+                .UnityProjectViewContextLfsUnlock++;
             usageLoader.Save(usage);
         }
 

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -179,22 +179,22 @@ namespace GitHub.Unity
             SaveUsage(usageStore);
         }
 
-        public void HistoryToolbarButtonFetch()
+        public void HistoryViewToolbarButtonFetch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.HistoryToolbarButtonFetch++;
+            usage.Measures.HistoryViewToolbarButtonFetch++;
 
             SaveUsage(usageStore);
         }
 
-        public void HistoryToolbarButtonPush()
+        public void HistoryViewToolbarButtonPush()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.HistoryToolbarButtonPush++;
+            usage.Measures.HistoryViewToolbarButtonPush++;
 
             SaveUsage(usageStore);
         }
@@ -249,12 +249,12 @@ namespace GitHub.Unity
             SaveUsage(usageStore);
         }
 
-        public void HistoryToolbarButtonPull()
+        public void HistoryViewToolbarButtonPull()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.HistoryToolbarButtonPull++;
+            usage.Measures.HistoryViewToolbarButtonPull++;
 
             SaveUsage(usageStore);
         }

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -199,12 +199,12 @@ namespace GitHub.Unity
             SaveUsage(usageStore);
         }
 
-        public void Initialized()
+        public void ProjectsInitialized()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Initialized++;
+            usage.Measures.ProjectsInitialized++;
 
             SaveUsage(usageStore);
         }

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -169,102 +169,102 @@ namespace GitHub.Unity
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfCommits()
+        public void ChangesViewButtonCommit()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Commits++;
+            usage.Measures.ChangesViewButtonCommit++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfFetches()
+        public void HistoryToolbarButtonFetch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Fetches++;
+            usage.Measures.HistoryToolbarButtonFetch++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfPushes()
+        public void HistoryToolbarButtonPush()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Pushes++;
+            usage.Measures.HistoryToolbarButtonPush++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfProjectsInitialized()
+        public void Initialized()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.ProjectsInitialized++;
+            usage.Measures.Initialized++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfLocalBranchCreations()
+        public void BranchesViewButtonCreateBranch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.LocalBranchCreations++;
+            usage.Measures.BranchesViewButtonCreateBranch++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfLocalBranchDeletions()
+        public void BranchesViewButtonDeleteBranch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.LocalBranchDeletion++;
+            usage.Measures.BranchesViewButtonDeleteBranch++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfLocalBranchCheckouts()
+        public void BranchesViewButtonCheckoutLocalBranch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.LocalBranchCheckouts++;
+            usage.Measures.BranchesViewButtonCheckoutLocalBranch++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfRemoteBranchCheckouts()
+        public void BranchesViewButtonCheckoutRemoteBranch()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.RemoteBranchCheckouts++;
+            usage.Measures.BranchesViewButtonCheckoutRemoteBranch++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfPulls()
+        public void HistoryToolbarButtonPull()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Pulls++;
+            usage.Measures.HistoryToolbarButtonPull++;
 
             SaveUsage(usageStore);
         }
 
-        public void IncrementNumberOfAuthentications()
+        public void AuthenticationViewButtonAuthentication()
         {
             var usageStore = LoadUsage();
             var usage = GetCurrentUsage(usageStore);
 
-            usage.Measures.Authentications++;
+            usage.Measures.AuthenticationViewButtonAuthentication++;
 
             SaveUsage(usageStore);
         }

--- a/src/GitHub.Logging/LogHelper.cs
+++ b/src/GitHub.Logging/LogHelper.cs
@@ -18,7 +18,7 @@ namespace GitHub.Logging
                 if (tracingEnabled != value)
                 {
                     tracingEnabled = value;
-                    Instance?.Info("Trace Logging " + (value ? "Enabled" : "Disabled"));
+                    Instance.Info("Trace Logging " + (value ? "Enabled" : "Disabled"));
                 }
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
@@ -214,7 +214,7 @@ namespace GitHub.Unity
 
             if (success)
             {
-                TaskManager.Run(UsageTracker.IncrementNumberOfAuthentications);
+                TaskManager.Run(UsageTracker.AuthenticationViewButtonAuthentication);
 
                 Clear();
                 Finish(true);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
@@ -214,7 +214,7 @@ namespace GitHub.Unity
 
             if (success)
             {
-                TaskManager.Run(UsageTracker.AuthenticationViewButtonAuthentication);
+                TaskManager.Run(UsageTracker.IncrementAuthenticationViewButtonAuthentication);
 
                 Clear();
                 Finish(true);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -309,7 +309,7 @@ namespace GitHub.Unity
                             {
                                 if (success)
                                 {
-                                    TaskManager.Run(UsageTracker.BranchesViewButtonCreateBranch);
+                                    TaskManager.Run(UsageTracker.IncrementBranchesViewButtonCreateBranch);
                                     Redraw();
                                 }
                                 else
@@ -479,7 +479,7 @@ namespace GitHub.Unity
                         {
                             if (success)
                             {
-                                TaskManager.Run(UsageTracker.BranchesViewButtonCheckoutRemoteBranch);
+                                TaskManager.Run(UsageTracker.IncrementBranchesViewButtonCheckoutRemoteBranch);
                                 Redraw();
                             }
                             else
@@ -502,7 +502,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.BranchesViewButtonCheckoutLocalBranch);
+                            TaskManager.Run(UsageTracker.IncrementBranchesViewButtonCheckoutLocalBranch);
                             Redraw();
                         }
                         else
@@ -524,7 +524,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.BranchesViewButtonDeleteBranch);
+                            TaskManager.Run(UsageTracker.IncrementBranchesViewButtonDeleteBranch);
                         }
                     })
                     .Start();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -304,7 +304,7 @@ namespace GitHub.Unity
                     // Effectuate create
                     if (createBranch)
                     {
-                        GitClient.CreateBranch(newBranchName, treeLocals.SelectedNode.Path)
+                        Repository.CreateBranch(newBranchName, treeLocals.SelectedNode.Path)
                             .FinallyInUI((success, e) =>
                             {
                                 if (success)
@@ -474,7 +474,7 @@ namespace GitHub.Unity
 
                 if (confirmCheckout)
                 {
-                    GitClient.CreateBranch(branchName, branch)
+                    Repository.CreateBranch(branchName, branch)
                         .FinallyInUI((success, e) =>
                         {
                             if (success)
@@ -497,7 +497,7 @@ namespace GitHub.Unity
             if (EditorUtility.DisplayDialog(ConfirmSwitchTitle, String.Format(ConfirmSwitchMessage, branch), ConfirmSwitchOK,
                 ConfirmSwitchCancel))
             {
-                GitClient.SwitchBranch(branch)
+                Repository.SwitchBranch(branch)
                     .FinallyInUI((success, e) =>
                     {
                         if (success)
@@ -519,14 +519,8 @@ namespace GitHub.Unity
             var dialogMessage = string.Format(DeleteBranchMessageFormatString, branch);
             if (EditorUtility.DisplayDialog(DeleteBranchTitle, dialogMessage, DeleteBranchButton, CancelButtonLabel))
             {
-                GitClient.DeleteBranch(branch, true)
-                    .FinallyInUI((success, e) =>
-                    {
-                        if (success)
-                        {
-                            TaskManager.Run(UsageTracker.IncrementBranchesViewButtonDeleteBranch);
-                        }
-                    })
+                Repository.DeleteBranch(branch, true)
+                    .Then(UsageTracker.IncrementBranchesViewButtonDeleteBranch)
                     .Start();
             }
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -309,7 +309,7 @@ namespace GitHub.Unity
                             {
                                 if (success)
                                 {
-                                    TaskManager.Run(UsageTracker.IncrementNumberOfLocalBranchCreations);
+                                    TaskManager.Run(UsageTracker.BranchesViewButtonCreateBranch);
                                     Redraw();
                                 }
                                 else
@@ -479,7 +479,7 @@ namespace GitHub.Unity
                         {
                             if (success)
                             {
-                                TaskManager.Run(UsageTracker.IncrementNumberOfRemoteBranchCheckouts);
+                                TaskManager.Run(UsageTracker.BranchesViewButtonCheckoutRemoteBranch);
                                 Redraw();
                             }
                             else
@@ -502,7 +502,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.IncrementNumberOfLocalBranchCheckouts);
+                            TaskManager.Run(UsageTracker.BranchesViewButtonCheckoutLocalBranch);
                             Redraw();
                         }
                         else
@@ -524,7 +524,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.IncrementNumberOfLocalBranchDeletions);
+                            TaskManager.Run(UsageTracker.BranchesViewButtonDeleteBranch);
                         }
                     })
                     .Start();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -357,7 +357,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.ChangesViewButtonCommit);
+                            TaskManager.Run(UsageTracker.IncrementChangesViewButtonCommit);
                         }
 
                         commitMessage = "";

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -357,7 +357,7 @@ namespace GitHub.Unity
                     {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.IncrementNumberOfCommits);
+                            TaskManager.Run(UsageTracker.ChangesViewButtonCommit);
                         }
 
                         commitMessage = "";

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -705,7 +705,7 @@ namespace GitHub.Unity
                     .FinallyInUI((success, e) => {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.HistoryViewToolbarButtonPull);
+                            TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonPull);
 
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
                                 String.Format(Localization.PullSuccessDescription, currentRemoteName),
@@ -729,7 +729,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (success)
                     {
-                        TaskManager.Run(UsageTracker.HistoryViewToolbarButtonPush);
+                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonPush);
 
                         EditorUtility.DisplayDialog(Localization.PushActionTitle,
                             String.Format(Localization.PushSuccessDescription, currentRemoteName),
@@ -752,7 +752,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (!success)
                     {
-                        TaskManager.Run(UsageTracker.HistoryViewToolbarButtonFetch);
+                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonFetch);
 
                         EditorUtility.DisplayDialog(FetchActionTitle, FetchFailureDescription,
                             Localization.Ok);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -705,7 +705,7 @@ namespace GitHub.Unity
                     .FinallyInUI((success, e) => {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.IncrementNumberOfPulls);
+                            TaskManager.Run(UsageTracker.HistoryToolbarButtonPull);
 
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
                                 String.Format(Localization.PullSuccessDescription, currentRemoteName),
@@ -729,7 +729,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (success)
                     {
-                        TaskManager.Run(UsageTracker.IncrementNumberOfPushes);
+                        TaskManager.Run(UsageTracker.HistoryToolbarButtonPush);
 
                         EditorUtility.DisplayDialog(Localization.PushActionTitle,
                             String.Format(Localization.PushSuccessDescription, currentRemoteName),
@@ -752,7 +752,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (!success)
                     {
-                        TaskManager.Run(UsageTracker.IncrementNumberOfFetches);
+                        TaskManager.Run(UsageTracker.HistoryToolbarButtonFetch);
 
                         EditorUtility.DisplayDialog(FetchActionTitle, FetchFailureDescription,
                             Localization.Ok);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -705,7 +705,7 @@ namespace GitHub.Unity
                     .FinallyInUI((success, e) => {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.HistoryToolbarButtonPull);
+                            TaskManager.Run(UsageTracker.HistoryViewToolbarButtonPull);
 
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
                                 String.Format(Localization.PullSuccessDescription, currentRemoteName),
@@ -729,7 +729,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (success)
                     {
-                        TaskManager.Run(UsageTracker.HistoryToolbarButtonPush);
+                        TaskManager.Run(UsageTracker.HistoryViewToolbarButtonPush);
 
                         EditorUtility.DisplayDialog(Localization.PushActionTitle,
                             String.Format(Localization.PushSuccessDescription, currentRemoteName),
@@ -752,7 +752,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (!success)
                     {
-                        TaskManager.Run(UsageTracker.HistoryToolbarButtonFetch);
+                        TaskManager.Run(UsageTracker.HistoryViewToolbarButtonFetch);
 
                         EditorUtility.DisplayDialog(FetchActionTitle, FetchFailureDescription,
                             Localization.Ok);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -696,7 +696,7 @@ namespace GitHub.Unity
                     .FinallyInUI((success, e) => {
                         if (success)
                         {
-                            TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonPull);
+                            TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarPull);
 
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
                                 String.Format(Localization.PullSuccessDescription, currentRemoteName),
@@ -720,7 +720,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (success)
                     {
-                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonPush);
+                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarPush);
 
                         EditorUtility.DisplayDialog(Localization.PushActionTitle,
                             String.Format(Localization.PushSuccessDescription, currentRemoteName),
@@ -743,7 +743,7 @@ namespace GitHub.Unity
                 .FinallyInUI((success, e) => {
                     if (!success)
                     {
-                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarButtonFetch);
+                        TaskManager.Run(UsageTracker.IncrementHistoryViewToolbarFetch);
 
                         EditorUtility.DisplayDialog(FetchActionTitle, FetchFailureDescription,
                             Localization.Ok);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -693,15 +693,6 @@ namespace GitHub.Unity
             {
                 Repository
                     .Pull()
-                    // we need the error propagated from the original git command to handle things appropriately
-                    .Then(success => {
-                        if (!success)
-                        {
-                            // if Pull fails we need to parse the output of the command, figure out
-                            // whether pull triggered a merge or a rebase, and abort the operation accordingly
-                            // (either git rebase --abort or git merge --abort)
-                        }
-                    }, runOptions: TaskRunOptions.OnAlways)
                     .FinallyInUI((success, e) => {
                         if (success)
                         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -109,6 +109,8 @@ namespace GitHub.Unity
                 .RequestLock(repositoryPath)
                 .ThenInUI(_ =>
                 {
+                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.AssetExplorerContextMenuLfsLock);
+
                     isBusy = false;
                     Selection.activeGameObject = null;
                     EditorApplication.RepaintProjectWindow();
@@ -150,6 +152,8 @@ namespace GitHub.Unity
                 .ReleaseLock(repositoryPath, false)
                 .ThenInUI(_ =>
                 {
+                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.AssetExplorerContextMenuLfsUnlock);
+
                     isBusy = false;
                     Selection.activeGameObject = null;
                     EditorApplication.RepaintProjectWindow();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -107,9 +107,12 @@ namespace GitHub.Unity
 
             repository
                 .RequestLock(repositoryPath)
-                .ThenInUI(_ =>
+                .FinallyInUI((success, ex) =>
                 {
-                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsLock);
+                    if (success)
+                    {
+                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsLock);
+                    }
 
                     isBusy = false;
                     Selection.activeGameObject = null;
@@ -150,10 +153,12 @@ namespace GitHub.Unity
 
             repository
                 .ReleaseLock(repositoryPath, false)
-                .ThenInUI(_ =>
+                .FinallyInUI((success, ex) =>
                 {
-                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsUnlock);
-
+                    if (success)
+                    {
+                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsUnlock);
+                    }
                     isBusy = false;
                     Selection.activeGameObject = null;
                     EditorApplication.RepaintProjectWindow();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -109,7 +109,7 @@ namespace GitHub.Unity
                 .RequestLock(repositoryPath)
                 .ThenInUI(_ =>
                 {
-                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.AssetExplorerContextMenuLfsLock);
+                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsLock);
 
                     isBusy = false;
                     Selection.activeGameObject = null;
@@ -152,7 +152,7 @@ namespace GitHub.Unity
                 .ReleaseLock(repositoryPath, false)
                 .ThenInUI(_ =>
                 {
-                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.AssetExplorerContextMenuLfsUnlock);
+                    EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsUnlock);
 
                     isBusy = false;
                     Selection.activeGameObject = null;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -111,7 +111,7 @@ namespace GitHub.Unity
                 {
                     if (success)
                     {
-                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsLock);
+                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementUnityProjectViewContextLfsLock);
                     }
 
                     isBusy = false;
@@ -157,7 +157,7 @@ namespace GitHub.Unity
                 {
                     if (success)
                     {
-                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementAssetExplorerContextMenuLfsUnlock);
+                        EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementUnityProjectViewContextLfsUnlock);
                     }
                     isBusy = false;
                     Selection.activeGameObject = null;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
@@ -173,6 +173,8 @@ namespace GitHub.Unity
                                 return;
                             }
 
+                            TaskManager.Run(UsageTracker.IncrementPublishViewButtonPublish);
+
                             if (repository == null)
                             {
                                 Logger.Warning("Returned Repository is null");

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -292,9 +292,9 @@ namespace GitHub.Unity
                                 GUILayout.FlexibleSpace();
                                 if (GUILayout.Button("Unlock"))
                                 {
-                                    Repository.ReleaseLock(lck.Path, true).FinallyInUI((b, exception) => {
-                                        TaskManager.Run(UsageTracker.IncrementSettingsViewUnlockButtonLfsUnlock);
-                                    }).Start();
+                                    Repository.ReleaseLock(lck.Path, true)
+                                        .Then(UsageTracker.IncrementSettingsViewUnlockButtonLfsUnlock)
+                                        .Start();
                                 }
                             }
                             GUILayout.EndHorizontal();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -293,7 +293,7 @@ namespace GitHub.Unity
                                 if (GUILayout.Button("Unlock"))
                                 {
                                     Repository.ReleaseLock(lck.Path, false).FinallyInUI((b, exception) => {
-                                        TaskManager.Run(UsageTracker.SettingsViewUnlockButtonLfsUnlock);
+                                        TaskManager.Run(UsageTracker.IncrementSettingsViewUnlockButtonLfsUnlock);
                                     }).Start();
                                 }
                             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -292,7 +292,9 @@ namespace GitHub.Unity
                                 GUILayout.FlexibleSpace();
                                 if (GUILayout.Button("Unlock"))
                                 {
-                                    Repository.ReleaseLock(lck.Path, false).Start();
+                                    Repository.ReleaseLock(lck.Path, false).FinallyInUI((b, exception) => {
+                                        TaskManager.Run(UsageTracker.SettingsViewUnlockButtonLfsUnlock);
+                                    }).Start();
                                 }
                             }
                             GUILayout.EndHorizontal();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -293,7 +293,7 @@ namespace GitHub.Unity
                                 if (GUILayout.Button("Unlock"))
                                 {
                                     Repository.ReleaseLock(lck.Path, true)
-                                        .Then(UsageTracker.IncrementSettingsViewUnlockButtonLfsUnlock)
+                                        .Then(UsageTracker.IncrementSettingsViewButtonLfsUnlock)
                                         .Start();
                                 }
                             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -58,6 +58,7 @@ namespace GitHub.Unity
         public static void GitHub_CommandLine()
         {
             EntryPoint.ApplicationManager.ProcessManager.RunCommandLineWindow(NPath.CurrentDirectory);
+            EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementApplicationMenuMenuItemCommandLine);
         }
 
 #if DEBUG 

--- a/src/tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/IntegrationTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Git\GitClientTests.cs" />
     <Compile Include="IntegrationTestEnvironment.cs" />
     <Compile Include="Installer\GitInstallerTests.cs" />
+    <Compile Include="Metrics\MetricsTests.cs" />
     <Compile Include="ProcessManagerExtensions.cs" />
     <Compile Include="Process\ProcessManagerIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/tests/IntegrationTests/Metrics/MetricsTests.cs
+++ b/src/tests/IntegrationTests/Metrics/MetricsTests.cs
@@ -1,0 +1,54 @@
+﻿using GitHub.Unity;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace IntegrationTests
+{
+    [TestFixture]
+    class MetricsTests : BaseIntegrationTest
+    {
+
+        [TestCase(nameof(Measures.AssetExplorerContextMenuLfsLock))]
+        [TestCase(nameof(Measures.AssetExplorerContextMenuLfsUnlock))]
+        [TestCase(nameof(Measures.AuthenticationViewButtonAuthentication))]
+        [TestCase(nameof(Measures.BranchesViewButtonCheckoutLocalBranch))]
+        [TestCase(nameof(Measures.BranchesViewButtonCheckoutRemoteBranch))]
+        [TestCase(nameof(Measures.BranchesViewButtonCreateBranch))]
+        [TestCase(nameof(Measures.BranchesViewButtonDeleteBranch))]
+        [TestCase(nameof(Measures.ChangesViewButtonCommit))]
+        [TestCase(nameof(Measures.HistoryViewToolbarButtonFetch))]
+        [TestCase(nameof(Measures.HistoryViewToolbarButtonPull))]
+        [TestCase(nameof(Measures.HistoryViewToolbarButtonPush))]
+        [TestCase(nameof(Measures.NumberOfStartups))]
+        [TestCase(nameof(Measures.ProjectsInitialized))]
+        [TestCase(nameof(Measures.SettingsViewUnlockButtonLfsUnlock))]
+        public void IncrementMetricsWorks(string measureName)
+        {
+            InitializeEnvironment(TestBasePath, null, false, false);
+            var userId = Guid.NewGuid().ToString();
+            var appVersion = ApplicationConfiguration.AssemblyName.Version.ToString();
+            var unityVersion = "2017.3f1";
+            var instanceId = Guid.NewGuid().ToString();
+            var usageLoader = Substitute.For<IUsageLoader>();
+            var usageStore = new UsageStore();
+            usageStore.Model.Guid = userId;
+            usageLoader.Load(Arg.Is<string>(userId)).Returns(usageStore);
+
+            var usageTracker = new UsageTracker(Substitute.For<IMetricsService>(), Substitute.For<ISettings>(),
+                usageLoader, userId, unityVersion, instanceId);
+
+            var currentUsage = usageStore.GetCurrentMeasures(appVersion, unityVersion, instanceId);
+            var prop = currentUsage.GetType().GetProperty(measureName);
+            Assert.AreEqual(0, prop.GetValue(currentUsage, null));
+            var meth = usageTracker.GetType().GetMethod("Increment" + measureName);
+            meth.Invoke(usageTracker, null);
+            currentUsage = usageStore.GetCurrentMeasures(appVersion, unityVersion, instanceId);
+            Assert.AreEqual(1, prop.GetValue(currentUsage, null));
+        }
+    }
+}

--- a/src/tests/IntegrationTests/Metrics/MetricsTests.cs
+++ b/src/tests/IntegrationTests/Metrics/MetricsTests.cs
@@ -12,20 +12,20 @@ namespace IntegrationTests
     [TestFixture]
     class MetricsTests : BaseIntegrationTest
     {
-        [TestCase(nameof(Measures.AssetExplorerContextMenuLfsLock))]
-        [TestCase(nameof(Measures.AssetExplorerContextMenuLfsUnlock))]
+        [TestCase(nameof(Measures.UnityProjectViewContextLfsLock))]
+        [TestCase(nameof(Measures.UnityProjectViewContextLfsUnlock))]
         [TestCase(nameof(Measures.AuthenticationViewButtonAuthentication))]
         [TestCase(nameof(Measures.BranchesViewButtonCheckoutLocalBranch))]
         [TestCase(nameof(Measures.BranchesViewButtonCheckoutRemoteBranch))]
         [TestCase(nameof(Measures.BranchesViewButtonCreateBranch))]
         [TestCase(nameof(Measures.BranchesViewButtonDeleteBranch))]
         [TestCase(nameof(Measures.ChangesViewButtonCommit))]
-        [TestCase(nameof(Measures.HistoryViewToolbarButtonFetch))]
-        [TestCase(nameof(Measures.HistoryViewToolbarButtonPull))]
-        [TestCase(nameof(Measures.HistoryViewToolbarButtonPush))]
+        [TestCase(nameof(Measures.HistoryViewToolbarFetch))]
+        [TestCase(nameof(Measures.HistoryViewToolbarPull))]
+        [TestCase(nameof(Measures.HistoryViewToolbarPush))]
         [TestCase(nameof(Measures.NumberOfStartups))]
         [TestCase(nameof(Measures.ProjectsInitialized))]
-        [TestCase(nameof(Measures.SettingsViewUnlockButtonLfsUnlock))]
+        [TestCase(nameof(Measures.SettingsViewButtonLfsUnlock))]
         public void IncrementMetricsWorks(string measureName)
         {
             var userId = Guid.NewGuid().ToString();

--- a/src/tests/UnitTests/UnitTests.csproj
+++ b/src/tests/UnitTests/UnitTests.csproj
@@ -125,6 +125,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="..\..\..\common\nativelibraries.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
These are the UI metrics being tracked in this PR:

- numberOfStartups
- projectsInitialized (repository initialized)
- changesViewButtonCommit (commit from changes view)
- historyViewToolbarFetch (fetch from toolbar in history view)
- historyViewToolbarPush (push from toolbar in history view)
- historyViewToolbarButtonPull (pull from toolbar in history view)
- authenticationViewButtonAuthentication (authentication from auth window)
- branchesViewButtonCreateBranch (create branch from branches view)
- branchesViewButtonDeleteBranch (delete branch from branches view)
- branchesViewButtonCheckoutLocalBranch (checkout local branch from branches view)
- branchesViewButtonCheckoutRemoteBranch (checkout remote branch from branches view)
- settingsViewUnlockButtonLfsUnlock (lfs unlock from settings view)
- unityProjectViewContextLfsLock (lfs lock from Unity project window)
- unityProjectViewContextLfsUnlock (lfs unlock from Unity project window)
