### PR TITLE
Adding a null/empty check for last skipped version

### DIFF
--- a/src/GitHub.Api/Primitives/TheVersion.cs
+++ b/src/GitHub.Api/Primitives/TheVersion.cs
@@ -47,6 +47,8 @@ namespace GitHub.Unity
             if (initialized)
                 return;
 
+            Guard.ArgumentNotNullOrWhiteSpace(version, nameof(version));
+
             this.Version = version;
 
             isAlpha = false;

--- a/src/GitHub.Api/Primitives/TheVersion.cs
+++ b/src/GitHub.Api/Primitives/TheVersion.cs
@@ -1,3 +1,4 @@
+using GitHub.Logging;
 using System;
 using System.Text.RegularExpressions;
 
@@ -47,8 +48,6 @@ namespace GitHub.Unity
             if (initialized)
                 return;
 
-            Guard.ArgumentNotNullOrWhiteSpace(version, nameof(version));
-
             this.Version = version;
 
             isAlpha = false;
@@ -60,6 +59,9 @@ namespace GitHub.Unity
             special = null;
             parts = 0;
 
+            if (String.IsNullOrEmpty(version))
+                return;
+
             intParts = new int[PART_COUNT];
             stringParts = new string[PART_COUNT];
 
@@ -68,7 +70,10 @@ namespace GitHub.Unity
 
             var match = regex.Match(version);
             if (!match.Success)
-                throw new ArgumentException("Invalid version: " + version, "version");
+            {
+                LogHelper.Error(new ArgumentException("Invalid version: " + version, "version"));
+                return;
+            }
 
             major = int.Parse(match.Groups["major"].Value);
             intParts[0] = major;

--- a/src/GitHub.Api/Primitives/TheVersion.cs
+++ b/src/GitHub.Api/Primitives/TheVersion.cs
@@ -8,6 +8,7 @@ namespace GitHub.Unity
     {
         private const string versionRegex = @"(?<major>\d+)(\.?(?<minor>[^.]+))?(\.?(?<patch>[^.]+))?(\.?(?<build>.+))?";
         private const int PART_COUNT = 4;
+        public static TheVersion Default { get; } = default(TheVersion).Initialize(null);
 
         [NotSerialized] private int major;
         [NotSerialized] public int Major { get { Initialize(Version); return major; } }
@@ -37,16 +38,13 @@ namespace GitHub.Unity
 
         public static TheVersion Parse(string version)
         {
-            Guard.ArgumentNotNull(version, "version");
-            TheVersion ret = default(TheVersion);
-            ret.Initialize(version);
-            return ret;
+            return default(TheVersion).Initialize(version);
         }
 
-        private void Initialize(string version)
+        private TheVersion Initialize(string version)
         {
             if (initialized)
-                return;
+                return this;
 
             this.Version = version;
 
@@ -60,7 +58,7 @@ namespace GitHub.Unity
             parts = 0;
 
             if (String.IsNullOrEmpty(version))
-                return;
+                return this;
 
             intParts = new int[PART_COUNT];
             stringParts = new string[PART_COUNT];
@@ -72,7 +70,7 @@ namespace GitHub.Unity
             if (!match.Success)
             {
                 LogHelper.Error(new ArgumentException("Invalid version: " + version, "version"));
-                return;
+                return this;
             }
 
             major = int.Parse(match.Groups["major"].Value);
@@ -132,6 +130,7 @@ namespace GitHub.Unity
                 isBeta = special.IndexOf("beta") >= 0;
             }
             initialized = true;
+            return this;
         }
 
         public override string ToString()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
@@ -71,11 +71,15 @@ namespace GitHub.Unity
                         TheVersion current = TheVersion.Parse(ApplicationInfo.Version);
                         TheVersion newVersion = package.Version;
 
-                        var versionToSkip = EntryPoint.ApplicationManager.UserSettings.Get<TheVersion>(Constants.SkipVersionKey);
-                        if (versionToSkip == newVersion)
+                        var versionToSkipString = EntryPoint.ApplicationManager.UserSettings.Get<string>(Constants.SkipVersionKey);
+                        if (!string.IsNullOrEmpty(versionToSkipString))
                         {
-                            LogHelper.Info("Skipping GitHub for Unity update v" + newVersion);
-                            return;
+                            var versionToSkip = TheVersion.Parse(versionToSkipString);
+                            if (versionToSkip == newVersion)
+                            {
+                                LogHelper.Info("Skipping GitHub for Unity update v" + newVersion);
+                                return;
+                            }
                         }
 
                         if (newVersion <= current)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
@@ -71,15 +71,11 @@ namespace GitHub.Unity
                         TheVersion current = TheVersion.Parse(ApplicationInfo.Version);
                         TheVersion newVersion = package.Version;
 
-                        var versionToSkipString = EntryPoint.ApplicationManager.UserSettings.Get<string>(Constants.SkipVersionKey);
-                        if (!string.IsNullOrEmpty(versionToSkipString))
+                        var versionToSkip = EntryPoint.ApplicationManager.UserSettings.Get<TheVersion>(Constants.SkipVersionKey);
+                        if (versionToSkip == newVersion)
                         {
-                            var versionToSkip = TheVersion.Parse(versionToSkipString);
-                            if (versionToSkip == newVersion)
-                            {
-                                LogHelper.Info("Skipping GitHub for Unity update v" + newVersion);
-                                return;
-                            }
+                            LogHelper.Info("Skipping GitHub for Unity update v" + newVersion);
+                            return;
                         }
 
                         if (newVersion <= current)

--- a/src/UnityExtension/Assets/Editor/UnityTests/VersionTests.cs
+++ b/src/UnityExtension/Assets/Editor/UnityTests/VersionTests.cs
@@ -186,4 +186,15 @@ public class VersionTests
         version = TheVersion.Parse("1.2.3.4whatever");
         Assert.IsTrue(version.IsUnstable);
     }
+
+    [Test]
+    public void ParsingInvalidVersionStringsWorks()
+    {
+        var ret = TheVersion.Parse(null);
+        Assert.AreEqual(TheVersion.Default, ret);
+        ret = TheVersion.Parse("");
+        Assert.AreEqual(TheVersion.Default, ret);
+        ret = TheVersion.Parse("bla");
+        Assert.AreEqual(TheVersion.Default, ret);
+    }
 }


### PR DESCRIPTION
While test #720 I discovered that if a user does not already have a skipped version they will run into a runtime error.

```
System.ArgumentNullException: Argument cannot be null.
Parameter name: input
  at System.Text.RegularExpressions.Regex.Match (System.String input, Int32 startat) [0x00000] in <filename unknown>:0 
  at System.Text.RegularExpressions.Regex.Match (System.String input) [0x00000] in <filename unknown>:0 
  at GitHub.Unity.TheVersion.Initialize (System.String version) [0x0009f] in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Primitives\TheVersion.cs:67 
  at GitHub.Unity.TheVersion.get_Major () [0x00008] in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Primitives\TheVersion.cs:12 
  at GitHub.Unity.TheVersion.op_Equality (TheVersion lhs, TheVersion rhs) [0x00022] in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\GitHub.Api\Primitives\TheVersion.cs:172 
  at GitHub.Unity.UpdateCheckWindow.<CheckForUpdates>m__0 (ITask`1 thisTask, NPath result, Boolean success, System.Exception exception) [0x0005f] in C:\Users\StanleyGoldman\Projects\GitHub\Unity\src\UnityExtension\Assets\Editor\GitHub.Unity\UpdateCheck.cs:75 
UnityEngine.Debug:LogError(Object)
GitHub.Unity.UpdateCheckWindow:<CheckForUpdates>m__0(ITask`1, NPath, Boolean, Exception) (at C:/Users/StanleyGoldman/Projects/GitHub/Unity/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs:95)
GitHub.Unity.TaskBase`1:RaiseOnEnd(NPath) (at C:/Users/StanleyGoldman/Projects/GitHub/Unity/src/GitHub.Api/Tasks/TaskBase.cs:678)
GitHub.Unity.DownloadTask:RunWithReturn(Boolean) (at C:/Users/StanleyGoldman/Projects/GitHub/Unity/src/GitHub.Api/Tasks/DownloadTask.cs:70)
GitHub.Unity.TaskBase`1:<TaskBase>m__0() (at C:/Users/StanleyGoldman/Projects/GitHub/Unity/src/GitHub.Api/Tasks/TaskBase.cs:528)
System.Threading.Tasks.TaskScheduler:TryExecuteTask(Task)
GitHub.Unity.<QueueTask>c__AnonStorey0:<>m__0() (at C:/Users/StanleyGoldman/Projects/GitHub/Unity/src/GitHub.Api/Tasks/ConcurrentExclusiveInterleave.cs:440)
```