### PR TITLE
Clean up trace logging, commented-out code and superfluous whitespace

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -154,8 +154,6 @@ namespace GitHub.Unity
         {
             try
             {
-                logger.Trace("Creating repository");
-
                 var user = await GetCurrentUser();
                 var keychainAdapter = keychain.Connect(OriginalUrl);
 
@@ -209,8 +207,6 @@ namespace GitHub.Unity
         {
             try
             {
-                logger.Trace("Getting Organizations");
-
                 var user = await GetCurrentUser();
                 var keychainAdapter = keychain.Connect(OriginalUrl);
 

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -43,7 +43,6 @@ namespace GitHub.Unity
 
         public void Run(bool firstRun)
         {
-            Logger.Trace("Run - CurrentDirectory {0}", NPath.CurrentDirectory);
             isBusy = true;
 
             var thread = new Thread(obj =>
@@ -78,8 +77,6 @@ namespace GitHub.Unity
 
         public ITask InitializeRepository()
         {
-            //Logger.Trace("Running Repository Initialize");
-
             var targetPath = NPath.CurrentDirectory;
 
             var unityYamlMergeExec = Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge" + Environment.ExecutableExtension);
@@ -136,8 +133,6 @@ namespace GitHub.Unity
 
         protected void SetupMetrics(string unityVersion, bool firstRun, Guid instanceId)
         {
-            //Logger.Trace("Setup metrics");
-
             string userId = null;
             if (UserSettings.Exists(Constants.GuidKey))
             {

--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -107,8 +107,6 @@ namespace GitHub.Unity
             var keychainAdapter = FindOrCreateAdapter(host);
             var connection = GetConnection(host);
 
-            //logger.Trace($@"Loading KeychainAdapter Host:""{host}"" Cached Username:""{cachedConnection.Username}""");
-
             var keychainItem = await credentialManager.Load(host);
             if (keychainItem == null)
             {
@@ -123,7 +121,6 @@ namespace GitHub.Unity
                     logger.Warning("Keychain Username:\"{0}\" does not match cached Username:\"{1}\"; Hopefully it works", keychainItem.Username, connection.Username);
                 }
 
-                //logger.Trace("Loaded from Credential Manager Host:\"{0}\" Username:\"{1}\"", keychainItem.Host, keychainItem.Username);
                 keychainAdapter.Set(keychainItem);
             }
             return keychainAdapter;
@@ -142,14 +139,11 @@ namespace GitHub.Unity
 
         public void Initialize()
         {
-            //logger.Trace("Initialize");
             LoadConnectionsFromDisk();
         }
 
         public async Task Clear(UriString host, bool deleteFromCredentialManager)
         {
-            //logger.Trace("Clear Host:{0}", host);
-
             Guard.ArgumentNotNull(host, nameof(host));
 
             RemoveConnection(host);
@@ -160,8 +154,6 @@ namespace GitHub.Unity
 
         public async Task Save(UriString host)
         {
-            //logger.Trace("Save: {0}", host);
-
             Guard.ArgumentNotNull(host, nameof(host));
 
             var keychainAdapter = await AddCredential(host);
@@ -170,8 +162,6 @@ namespace GitHub.Unity
 
         public void SetCredentials(ICredential credential)
         {
-            //logger.Trace("SetCredentials Host:{0}", credential.Host);
-
             Guard.ArgumentNotNull(credential, nameof(credential));
 
             var keychainAdapter = GetKeychainAdapter(credential.Host);
@@ -180,8 +170,6 @@ namespace GitHub.Unity
 
         public void SetToken(UriString host, string token, string username)
         {
-            //logger.Trace("SetToken Host:{0}", host);
-
             Guard.ArgumentNotNull(host, nameof(host));
             Guard.ArgumentNotNull(token, nameof(token));
             Guard.ArgumentNotNull(username, nameof(username));
@@ -192,7 +180,6 @@ namespace GitHub.Unity
 
         private void LoadConnectionsFromDisk()
         {
-            //logger.Trace("ReadCacheFromDisk Path:{0}", cachePath.ToString());
             if (cachePath.FileExists())
             {
                 var json = cachePath.ReadAllText();
@@ -216,7 +203,6 @@ namespace GitHub.Unity
 
         private void SaveConnectionsToDisk(bool raiseChangedEvent = true)
         {
-            //logger.Trace("WriteCacheToDisk Count:{0} Path:{1}", connectionCache.Count, cachePath.ToString());
             try
             {
                 var json = connections.Values.ToJson();

--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -106,7 +106,6 @@ namespace GitHub.Unity
             var password = keychainAdapter.Credential.Token;
             try
             {
-                logger.Trace("2FA Continue");
                 loginResultData = await TryLogin(host, username, password, twofacode);
 
                 if (loginResultData.Code == LoginResultCodes.Success)

--- a/src/GitHub.Api/Events/RepositoryWatcher.cs
+++ b/src/GitHub.Api/Events/RepositoryWatcher.cs
@@ -80,7 +80,6 @@ namespace GitHub.Unity
             }
 
             Logger.Trace("Watching Path: \"{0}\"", paths.RepositoryPath.ToString());
-
             running = true;
             pauseEvent.Reset();
             Task.Factory.StartNew(WatcherLoop, cancellationToken, TaskCreationOptions.None, TaskScheduler.Default);
@@ -89,12 +88,7 @@ namespace GitHub.Unity
         public void Stop()
         {
             if (!running)
-            {
-                //Logger.Warning("Watcher already stopped");
                 return;
-            }
-
-            //Logger.Trace("Stopping watcher");
 
             running = false;
             pauseEvent.Set();
@@ -102,8 +96,6 @@ namespace GitHub.Unity
 
         private void WatcherLoop()
         {
-            //Logger.Trace("Starting watcher");
-
             while (running)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -136,9 +128,7 @@ namespace GitHub.Unity
             var fileEvents = nativeInterface.GetEvents();
             if (fileEvents.Length > 0)
             {
-                //Logger.Trace("Handling {0} Events", fileEvents.Length);
                 processedEventCount = ProcessEvents(fileEvents);
-                //Logger.Trace("Processed {0} Events", processedEventCount);
             }
 
             lastCountOfProcessedEvents = processedEventCount;
@@ -163,8 +153,6 @@ namespace GitHub.Unity
                     Stop();
                     break;
                 }
-
-                //Logger.Trace(fileEvent.Describe());
 
                 var eventDirectory = new NPath(fileEvent.Directory);
                 var fileA = eventDirectory.Combine(fileEvent.FileA);
@@ -215,28 +203,24 @@ namespace GitHub.Unity
             int eventsProcessed = 0;
             if (events.Contains(EventType.ConfigChanged))
             {
-                //Logger.Trace("ConfigChanged");
                 ConfigChanged?.Invoke();
                 eventsProcessed++;
             }
 
             if (events.Contains(EventType.HeadChanged))
             {
-                //Logger.Trace("HeadChanged");
                 HeadChanged?.Invoke();
                 eventsProcessed++;
             }
 
             if (events.Contains(EventType.LocalBranchesChanged))
             {
-                //Logger.Trace("LocalBranchesChanged");
                 LocalBranchesChanged?.Invoke();
                 eventsProcessed++;
             }
 
             if (events.Contains(EventType.RemoteBranchesChanged))
             {
-                //Logger.Trace("RemoteBranchesChanged");
                 RemoteBranchesChanged?.Invoke();
                 eventsProcessed++;
             }
@@ -245,7 +229,6 @@ namespace GitHub.Unity
             {
                 if (!events.Contains(EventType.RepositoryChanged))
                 {
-                    //Logger.Trace("IndexChanged");
                     IndexChanged?.Invoke();
                     eventsProcessed++;
                 }
@@ -253,14 +236,12 @@ namespace GitHub.Unity
 
             if (events.Contains(EventType.RepositoryChanged))
             {
-                //Logger.Trace("RepositoryChanged");
                 RepositoryChanged?.Invoke();
                 eventsProcessed++;
             }
 
             if (events.Contains(EventType.RepositoryCommitted))
             {
-                //Logger.Trace("RepositoryCommitted");
                 RepositoryCommitted?.Invoke();
                 eventsProcessed++;
             }

--- a/src/GitHub.Api/Git/GitClient.cs
+++ b/src/GitHub.Api/Git/GitClient.cs
@@ -10,88 +10,36 @@ namespace GitHub.Unity
     public interface IGitClient
     {
         ITask<ValidateGitInstallResult> ValidateGitInstall(NPath path, bool isCustomGit);
-
         ITask Init(IOutputProcessor<string> processor = null);
-
         ITask LfsInstall(IOutputProcessor<string> processor = null);
-
-        ITask<GitAheadBehindStatus> AheadBehindStatus(string gitRef, string otherRef, 
-            IOutputProcessor<GitAheadBehindStatus> processor = null);
-
+        ITask<GitAheadBehindStatus> AheadBehindStatus(string gitRef, string otherRef, IOutputProcessor<GitAheadBehindStatus> processor = null);
         ITask<GitStatus> Status(IOutputProcessor<GitStatus> processor = null);
-
-        ITask<string> GetConfig(string key, GitConfigSource configSource,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> SetConfig(string key, string value, GitConfigSource configSource,
-            IOutputProcessor<string> processor = null);
-
+        ITask<string> GetConfig(string key, GitConfigSource configSource, IOutputProcessor<string> processor = null);
+        ITask<string> SetConfig(string key, string value, GitConfigSource configSource, IOutputProcessor<string> processor = null);
         ITask<GitUser> GetConfigUserAndEmail();
-
-        ITask<List<GitLock>> ListLocks(bool local,
-            BaseOutputListProcessor<GitLock> processor = null);
-
-        ITask<string> Pull(string remote, string branch,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Push(string remote, string branch,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Revert(string changeset,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Fetch(string remote,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> SwitchBranch(string branch,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> DeleteBranch(string branch, bool deleteUnmerged = false,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> CreateBranch(string branch, string baseBranch,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> RemoteAdd(string remote, string url,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> RemoteRemove(string remote,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> RemoteChange(string remote, string url,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Commit(string message, string body,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Add(IList<string> files,
-            IOutputProcessor<string> processor = null);
-
+        ITask<List<GitLock>> ListLocks(bool local, BaseOutputListProcessor<GitLock> processor = null);
+        ITask<string> Pull(string remote, string branch, IOutputProcessor<string> processor = null);
+        ITask<string> Push(string remote, string branch, IOutputProcessor<string> processor = null);
+        ITask<string> Revert(string changeset, IOutputProcessor<string> processor = null);
+        ITask<string> Fetch(string remote, IOutputProcessor<string> processor = null);
+        ITask<string> SwitchBranch(string branch, IOutputProcessor<string> processor = null);
+        ITask<string> DeleteBranch(string branch, bool deleteUnmerged = false, IOutputProcessor<string> processor = null);
+        ITask<string> CreateBranch(string branch, string baseBranch, IOutputProcessor<string> processor = null);
+        ITask<string> RemoteAdd(string remote, string url, IOutputProcessor<string> processor = null);
+        ITask<string> RemoteRemove(string remote, IOutputProcessor<string> processor = null);
+        ITask<string> RemoteChange(string remote, string url, IOutputProcessor<string> processor = null);
+        ITask<string> Commit(string message, string body, IOutputProcessor<string> processor = null);
+        ITask<string> Add(IList<string> files, IOutputProcessor<string> processor = null);
         ITask<string> AddAll(IOutputProcessor<string> processor = null);
-
-        ITask<string> Discard(IList<string> files,
-            IOutputProcessor<string> processor = null);
-
+        ITask<string> Discard(IList<string> files, IOutputProcessor<string> processor = null);
         ITask<string> DiscardAll(IOutputProcessor<string> processor = null);
-
-        ITask<string> Remove(IList<string> files,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> AddAndCommit(IList<string> files, string message, string body,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Lock(string file,
-            IOutputProcessor<string> processor = null);
-
-        ITask<string> Unlock(string file, bool force,
-            IOutputProcessor<string> processor = null);
-
+        ITask<string> Remove(IList<string> files, IOutputProcessor<string> processor = null);
+        ITask<string> AddAndCommit(IList<string> files, string message, string body, IOutputProcessor<string> processor = null);
+        ITask<string> Lock(string file, IOutputProcessor<string> processor = null);
+        ITask<string> Unlock(string file, bool force, IOutputProcessor<string> processor = null);
         ITask<List<GitLogEntry>> Log(BaseOutputListProcessor<GitLogEntry> processor = null);
-
         ITask<Version> Version(IOutputProcessor<Version> processor = null);
-
         ITask<Version> LfsVersion(IOutputProcessor<Version> processor = null);
-
         ITask<GitUser> SetConfigNameAndEmail(string username, string email);
     }
 
@@ -145,64 +93,48 @@ namespace GitHub.Unity
 
         public ITask LfsInstall(IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("LfsInstall");
-
             return new GitLfsInstallTask(cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<GitStatus> Status(IOutputProcessor<GitStatus> processor = null)
         {
-            //Logger.Trace("Status");
-
             return new GitStatusTask(new GitObjectFactory(environment), cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<GitAheadBehindStatus> AheadBehindStatus(string gitRef, string otherRef, IOutputProcessor<GitAheadBehindStatus> processor = null)
         {
-            //Logger.Trace("AheadBehindStatus");
-
             return new GitAheadBehindStatusTask(gitRef, otherRef, cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<List<GitLogEntry>> Log(BaseOutputListProcessor<GitLogEntry> processor = null)
         {
-            //Logger.Trace("Log");
-
             return new GitLogTask(new GitObjectFactory(environment), cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<Version> Version(IOutputProcessor<Version> processor = null)
         {
-            //Logger.Trace("Version");
-
             return new GitVersionTask(cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<Version> LfsVersion(IOutputProcessor<Version> processor = null)
         {
-            //Logger.Trace("LfsVersion");
-
             return new GitLfsVersionTask(cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<string> GetConfig(string key, GitConfigSource configSource, IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("GetConfig: {0}", key);
-
             return new GitConfigGetTask(key, configSource, cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<string> SetConfig(string key, string value, GitConfigSource configSource, IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("SetConfig");
-
             return new GitConfigSetTask(key, value, configSource, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -226,7 +158,6 @@ namespace GitHub.Unity
                             email = value;
                         }
                     })).Then(success => {
-                //Logger.Trace("{0}:{1} {2}:{3}", UserNameConfigKey, username, UserEmailConfigKey, email);
                 return new GitUser(username, email);
             });
         }
@@ -240,16 +171,12 @@ namespace GitHub.Unity
 
         public ITask<List<GitLock>> ListLocks(bool local, BaseOutputListProcessor<GitLock> processor = null)
         {
-            //Logger.Trace("ListLocks");
-
             return new GitListLocksTask(new GitObjectFactory(environment), local, cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<string> Pull(string remote, string branch, IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Pull");
-
             return new GitPullTask(remote, branch, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -257,16 +184,12 @@ namespace GitHub.Unity
         public ITask<string> Push(string remote, string branch,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Push");
-
             return new GitPushTask(remote, branch, true, cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<string> Revert(string changeset, IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Revert");
-
             return new GitRevertTask(changeset, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -274,16 +197,12 @@ namespace GitHub.Unity
         public ITask<string> Fetch(string remote,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Fetch");
-
             return new GitFetchTask(remote, cancellationToken, processor: processor)
                 .Configure(processManager);
         }
 
         public ITask<string> SwitchBranch(string branch, IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("SwitchBranch");
-
             return new GitSwitchBranchesTask(branch, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -291,8 +210,6 @@ namespace GitHub.Unity
         public ITask<string> DeleteBranch(string branch, bool deleteUnmerged = false,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("DeleteBranch");
-
             return new GitBranchDeleteTask(branch, deleteUnmerged, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -300,8 +217,6 @@ namespace GitHub.Unity
         public ITask<string> CreateBranch(string branch, string baseBranch,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("CreateBranch");
-
             return new GitBranchCreateTask(branch, baseBranch, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -309,8 +224,6 @@ namespace GitHub.Unity
         public ITask<string> RemoteAdd(string remote, string url,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("RemoteAdd");
-
             return new GitRemoteAddTask(remote, url, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -318,8 +231,6 @@ namespace GitHub.Unity
         public ITask<string> RemoteRemove(string remote,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("RemoteRemove");
-
             return new GitRemoteRemoveTask(remote, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -327,8 +238,6 @@ namespace GitHub.Unity
         public ITask<string> RemoteChange(string remote, string url,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("RemoteChange");
-
             return new GitRemoteChangeTask(remote, url, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -336,16 +245,12 @@ namespace GitHub.Unity
         public ITask<string> Commit(string message, string body,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Commit");
-
             return new GitCommitTask(message, body, cancellationToken, processor)
                 .Configure(processManager);
         }
 
         public ITask<string> AddAll(IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Add all files");
-
             return new GitAddTask(cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -353,8 +258,6 @@ namespace GitHub.Unity
         public ITask<string> Add(IList<string> files,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Add Files");
-
             GitAddTask last = null;
             foreach (var batch in files.Spool(5000))
             {
@@ -376,8 +279,6 @@ namespace GitHub.Unity
         public ITask<string> Discard( IList<string> files,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Checkout Files");
-
             GitCheckoutTask last = null;
             foreach (var batch in files.Spool(5000))
             {
@@ -398,8 +299,6 @@ namespace GitHub.Unity
 
         public ITask<string> DiscardAll(IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Checkout all files");
-
             return new GitCheckoutTask(cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -407,8 +306,6 @@ namespace GitHub.Unity
         public ITask<string> Remove(IList<string> files,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Remove");
-
             return new GitRemoveFromIndexTask(files, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -416,8 +313,6 @@ namespace GitHub.Unity
         public ITask<string> AddAndCommit(IList<string> files, string message, string body,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("AddAndCommit");
-
             return Add(files)
                 .Then(new GitCommitTask(message, body, cancellationToken)
                     .Configure(processManager));
@@ -426,8 +321,6 @@ namespace GitHub.Unity
         public ITask<string> Lock(string file,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Lock");
-
             return new GitLockTask(file, cancellationToken, processor)
                 .Configure(processManager);
         }
@@ -435,8 +328,6 @@ namespace GitHub.Unity
         public ITask<string> Unlock(string file, bool force,
             IOutputProcessor<string> processor = null)
         {
-            //Logger.Trace("Unlock");
-
             return new GitUnlockTask(file, force, cancellationToken, processor)
                 .Configure(processManager);
         }

--- a/src/GitHub.Api/Git/GitCredentialManager.cs
+++ b/src/GitHub.Api/Git/GitCredentialManager.cs
@@ -31,8 +31,6 @@ namespace GitHub.Unity
 
         public async Task Delete(UriString host)
         {
-            //Logger.Trace("Delete: {0}", host);
-
             if (!await LoadCredentialHelper())
                 return;
 
@@ -47,8 +45,6 @@ namespace GitHub.Unity
 
         public async Task<ICredential> Load(UriString host)
         {
-            //Logger.Trace("Load: {0}", host);
-
             if (credential == null)
             {
                 if (!await LoadCredentialHelper())
@@ -100,8 +96,6 @@ namespace GitHub.Unity
         {
             this.credential = cred;
 
-            //Logger.Trace("Save: {0}", credential.Host);
-
             if (!await LoadCredentialHelper())
                 return;
 
@@ -126,8 +120,6 @@ namespace GitHub.Unity
             if (credHelper != null)
                 return true;
 
-            //Logger.Trace("Loading Credential Helper");
-
             credHelper = await new GitConfigGetTask("credential.helper", GitConfigSource.NonSpecified, taskManager.Token)
                 .Configure(processManager)
                 .StartAwait();
@@ -145,8 +137,6 @@ namespace GitHub.Unity
 
         private ITask<string> RunCredentialHelper(string action, string[] lines)
         {
-            //Logger.Trace("RunCredentialHelper helper:\"{0}\" action:\"{1}\"", credHelper, action);
-
             SimpleProcessTask task;
             if (credHelper.StartsWith('!'))
             {

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -72,7 +72,6 @@ namespace GitHub.Unity
 
         public void Initialize(IRepositoryManager theRepositoryManager, ITaskManager theTaskManager)
         {
-            //Logger.Trace("Initialize");
             Guard.ArgumentNotNull(theRepositoryManager, nameof(theRepositoryManager));
             Guard.ArgumentNotNull(theTaskManager, nameof(theTaskManager));
 
@@ -442,19 +441,16 @@ namespace GitHub.Unity
 
         private void GitUserCacheOnCacheInvalidated()
         {
-            //Logger.Trace("GitUserCache Invalidated");
             UpdateUserAndEmail();
         }
 
         private void HandleUserCacheUpdatedEvent(CacheUpdateEvent cacheUpdateEvent)
         {
-            //Logger.Trace("GitUserCache Updated {0}", cacheUpdateEvent.UpdatedTime);
             Changed?.Invoke(cacheUpdateEvent);
         }
 
         private void UpdateUserAndEmail()
         {
-            //Logger.Trace("UpdateUserAndEmail");
             if (gitClient == null)
             {
                 needsRefresh = true;

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -155,19 +155,16 @@ namespace GitHub.Unity
 
         public void Initialize()
         {
-            //Logger.Trace("Initialize");
             watcher.Initialize();
         }
 
         public void Start()
         {
-            //Logger.Trace("Start");
             watcher.Start();
         }
 
         public void Stop()
         {
-            //Logger.Trace("Stop");
             watcher.Stop();
         }
 
@@ -393,9 +390,6 @@ namespace GitHub.Unity
             ConfigBranch? branch;
             ConfigRemote? remote;
             GetCurrentBranchAndRemote(out branch, out remote);
-
-            Logger.Trace("CurrentBranch: {0}", branch.HasValue ? branch.Value.ToString() : "[NULL]");
-            Logger.Trace("CurrentRemote: {0}", remote.HasValue ? remote.Value.ToString() : "[NULL]");
             CurrentBranchUpdated?.Invoke(branch, remote);
         }
 
@@ -450,13 +444,11 @@ namespace GitHub.Unity
             {
                 if (isExclusive)
                 {
-                    //Logger.Trace("Starting Operation - Setting Busy Flag");
                     IsBusy = true;
                 }
 
                 if (filesystemChangesExpected)
                 {
-                    //Logger.Trace("Starting Operation - Disable Watcher");
                     watcher.Stop();
                 }
             };
@@ -483,13 +475,11 @@ namespace GitHub.Unity
             var isExclusive = task.IsChainExclusive();
             if (filesystemChangesExpected)
             {
-                //Logger.Trace("Ended Operation - Enable Watcher");
                 watcher.Start();
             }
 
             if (isExclusive)
             {
-                //Logger.Trace("Ended Operation - Clearing Busy Flag");
                 IsBusy = false;
             }
         }
@@ -501,13 +491,11 @@ namespace GitHub.Unity
 
         private void WatcherOnRemoteBranchesChanged()
         {
-            //Logger.Trace("WatcherOnRemoteBranchesChanged");
             DataNeedsRefreshing?.Invoke(CacheType.Branches);
         }
 
         private void WatcherOnLocalBranchesChanged()
         {
-            //Logger.Trace("WatcherOnLocalBranchesChanged");
             DataNeedsRefreshing?.Invoke(CacheType.Branches);
             // the watcher should tell us what branch has changed so we can fire this only
             // when the active branch has changed
@@ -517,20 +505,17 @@ namespace GitHub.Unity
 
         private void WatcherOnRepositoryCommitted()
         {
-            //Logger.Trace("WatcherOnRepositoryCommitted");
             DataNeedsRefreshing?.Invoke(CacheType.GitLog);
             DataNeedsRefreshing?.Invoke(CacheType.GitStatus);
         }
 
         private void WatcherOnRepositoryChanged()
         {
-            //Logger.Trace("WatcherOnRepositoryChanged");
             DataNeedsRefreshing?.Invoke(CacheType.GitStatus);
         }
 
         private void WatcherOnConfigChanged()
         {
-            //Logger.Trace("WatcherOnConfigChanged");
             config.Reset();
             DataNeedsRefreshing?.Invoke(CacheType.Branches);
             DataNeedsRefreshing?.Invoke(CacheType.RepositoryInfo);
@@ -539,7 +524,6 @@ namespace GitHub.Unity
 
         private void WatcherOnHeadChanged()
         {
-            //Logger.Trace("WatcherOnHeadChanged");
             DataNeedsRefreshing?.Invoke(CacheType.RepositoryInfo);
             DataNeedsRefreshing?.Invoke(CacheType.GitLog);
             DataNeedsRefreshing?.Invoke(CacheType.GitAheadBehind);
@@ -547,18 +531,13 @@ namespace GitHub.Unity
 
         private void WatcherOnIndexChanged()
         {
-            //Logger.Trace("WatcherOnIndexChanged");
             DataNeedsRefreshing?.Invoke(CacheType.GitStatus);
         }
 
         private void UpdateLocalBranches()
         {
-            //Logger.Trace("UpdateLocalBranches");
-
             var branches = new Dictionary<string, ConfigBranch>();
             UpdateLocalBranches(branches, repositoryPaths.BranchesPath, config.GetBranches().Where(x => x.IsTracking), "");
-
-            Logger.Trace("OnLocalBranchListUpdated {0} branches", branches.Count);
             LocalBranchesUpdated?.Invoke(branches);
         }
 
@@ -584,8 +563,6 @@ namespace GitHub.Unity
 
         private void UpdateRemoteBranches()
         {
-            //Logger.Trace("UpdateRemoteBranches");
-
             var remotes = config.GetRemotes().ToArray().ToDictionary(x => x.Name, x => x);
             var remoteBranches = new Dictionary<string, Dictionary<string, ConfigBranch>>();
 
@@ -607,9 +584,7 @@ namespace GitHub.Unity
                 }
             }
 
-            Logger.Trace("OnRemoteBranchListUpdated {0} remotes", remotes.Count);
             RemoteBranchesUpdated?.Invoke(remotes, remoteBranches);
-
             UpdateGitAheadBehindStatus();
         }
 
@@ -652,7 +627,6 @@ namespace GitHub.Unity
             {
                 if (isBusy != value)
                 {
-                    //Logger.Trace("IsBusyChanged Value:{0}", value);
                     isBusy = value;
                     IsBusyChanged?.Invoke(isBusy);
                 }

--- a/src/GitHub.Api/Helpers/SimpleJson.cs
+++ b/src/GitHub.Api/Helpers/SimpleJson.cs
@@ -2170,6 +2170,7 @@ namespace GitHub.Unity
         static JsonSerializationStrategy publicUpperCaseStrategy = new JsonSerializationStrategy(false, true);
         static JsonSerializationStrategy privateLowerCaseStrategy = new JsonSerializationStrategy(true, false);
         static JsonSerializationStrategy privateUpperCaseStrategy = new JsonSerializationStrategy(false, false);
+
         public static string ToJson<T>(this T model, bool lowerCase = false, bool onlyPublic = true)
         {
             return SimpleJson.SerializeObject(model, GetStrategy(lowerCase, onlyPublic));

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -34,7 +34,6 @@ namespace GitHub.Unity
 
         public GitInstallationState SetupGitIfNeeded()
         {
-            //Logger.Trace("SetupGitIfNeeded");
             var state = new GitInstallationState();
             state = VerifyGitFromSettings(state);
             if (state.GitIsValid && state.GitLfsIsValid)
@@ -233,7 +232,6 @@ namespace GitHub.Unity
                     var source = path;
                     target.DeleteIfExists();
                     target.EnsureParentDirectoryExists();
-                    Logger.Trace($"Moving '{source}' to '{target}'");
                     source.Move(target);
                     state.GitIsValid = true;
                 }
@@ -254,7 +252,6 @@ namespace GitHub.Unity
                     var source = path.Combine(installDetails.GitLfsExecutable);
                     target.DeleteIfExists();
                     target.EnsureParentDirectoryExists();
-                    Logger.Trace($"Moving '{source}' to '{target}'");
                     source.Move(target);
                     state.GitLfsIsValid = true;
                 }

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -26,11 +26,8 @@ namespace GitHub.Unity
 
         public NPath SetupOctorunIfNeeded()
         {
-            //Logger.Trace("SetupOctorunIfNeeded");
-
             NPath path = NPath.Default;
             var isOctorunExtracted = IsOctorunExtracted();
-            Logger.Trace("isOctorunExtracted: {0}", isOctorunExtracted);
             if (isOctorunExtracted)
                 path = installDetails.ExecutablePath;
             GrabZipFromResources();
@@ -61,8 +58,6 @@ namespace GitHub.Unity
         private NPath MoveOctorun(NPath fromPath)
         {
             var toPath = installDetails.InstallationPath;
-            Logger.Trace($"Moving tempDirectory:'{fromPath}' to extractTarget:'{toPath}'");
-
             toPath.DeleteIfExists();
             toPath.EnsureParentDirectoryExists();
             fromPath.Move(toPath);
@@ -73,13 +68,11 @@ namespace GitHub.Unity
         {
             if (!installDetails.InstallationPath.DirectoryExists())
             {
-                //Logger.Warning($"{octorunPath} does not exist");
                 return false;
             }
 
             if (!installDetails.VersionFile.FileExists())
             {
-                //Logger.Warning($"{versionFilePath} does not exist");
                 return false;
             }
 

--- a/src/GitHub.Api/Metrics/UsageTracker.cs.orig
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs.orig
@@ -2,6 +2,10 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+<<<<<<< HEAD
+using System.Globalization;
+=======
+>>>>>>> origin/master
 using System.Threading;
 using Timer = System.Threading.Timer;
 using GitHub.Logging;
@@ -23,7 +27,7 @@ namespace GitHub.Unity
 
         public UsageTracker(IMetricsService metricsService, ISettings userSettings,
             IEnvironment environment, string userId, string unityVersion, string instanceId)
-                : this(metricsService, userSettings, 
+                : this(metricsService, userSettings,
                       new UsageLoader(environment.UserCachePath.Combine(Constants.UsageFile)),
                       userId, unityVersion, instanceId)
         {
@@ -48,6 +52,7 @@ namespace GitHub.Unity
 
         private void RunTimer(int seconds)
         {
+            Logger.Trace($"Scheduling timer for {seconds} seconds from now");
             timer = new Timer(async _ =>
             {
                 try
@@ -71,6 +76,8 @@ namespace GitHub.Unity
 
             if (usageStore.LastUpdated.Date != DateTimeOffset.UtcNow.Date)
             {
+                Logger.Trace("Sending Usage");
+
                 var currentTimeOffset = DateTimeOffset.UtcNow;
                 var beforeDate = currentTimeOffset.Date;
 
@@ -281,6 +288,8 @@ namespace GitHub.Unity
             string json = null;
             if (path.FileExists())
             {
+                LogHelper.Instance.Trace("LoadUsage: \"{0}\"", path);
+
                 try
                 {
                     json = path.ReadAllText(Encoding.UTF8);

--- a/src/GitHub.Api/OutputProcessors/LockOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/LockOutputProcessor.cs
@@ -29,7 +29,6 @@ namespace GitHub.Unity
             {
                 return;
             }
-            Logger.Trace(line);
             var path = proc.ReadUntil('\t').Trim();
             var user = proc.ReadUntilLast("ID:").Trim();
             proc.MoveToAfter("ID:");

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -76,21 +76,15 @@ namespace GitHub.Unity
         {
             Guard.NotNull(this, FileSystem, nameof(FileSystem));
 
-            //Logger.Trace("InitializeRepository expectedRepositoryPath:{0}", repositoryPath);
-
             NPath expectedRepositoryPath;
             if (!RepositoryPath.IsInitialized)
             {
                 Guard.NotNull(this, UnityProjectPath, nameof(UnityProjectPath));
 
-                //Logger.Trace("RepositoryPath is null");
-
                 expectedRepositoryPath = repositoryPath != null ? repositoryPath.Value : UnityProjectPath;
 
                 if (!expectedRepositoryPath.DirectoryExists(".git"))
                 {
-                    Logger.Trace(".git folder exists");
-
                     NPath reporoot = UnityProjectPath.RecursiveParents.FirstOrDefault(d => d.DirectoryExists(".git"));
                     if (reporoot.IsInitialized)
                         expectedRepositoryPath = reporoot;
@@ -98,14 +92,12 @@ namespace GitHub.Unity
             }
             else
             {
-                //Logger.Trace("Set to RepositoryPath");
                 expectedRepositoryPath = RepositoryPath;
             }
 
             FileSystem.SetCurrentDirectory(expectedRepositoryPath);
             if (expectedRepositoryPath.DirectoryExists(".git"))
             {
-                //Logger.Trace("Determined expectedRepositoryPath:{0}", expectedRepositoryPath);
                 RepositoryPath = expectedRepositoryPath;
                 Repository = new Repository(RepositoryPath, CacheContainer);
             }

--- a/src/GitHub.Api/Platform/Settings.cs
+++ b/src/GitHub.Api/Platform/Settings.cs
@@ -149,8 +149,6 @@ namespace GitHub.Unity
 
         private void LoadFromCache(string path)
         {
-            logger.Trace("LoadFromCache: {0}", path);
-
             EnsureCachePath(path);
 
             if (!fileExists(path))
@@ -195,8 +193,6 @@ namespace GitHub.Unity
 
         private bool SaveToCache(string path)
         {
-            logger.Trace("SaveToCache: {0}", path);
-
             EnsureCachePath(path);
 
             try

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -323,7 +323,6 @@ namespace GitHub.Unity
         {
             if (Task.Status == TaskStatus.Created)
             {
-                //Logger.Trace($"Starting {Affinity} {ToString()}");
                 Task.Start(scheduler);
             }
             return this;
@@ -348,7 +347,6 @@ namespace GitHub.Unity
         {
             if (continuationOnAlways != null)
             {
-                //Logger.Trace($"Setting ContinueWith {Affinity} {continuation}");
                 SetContinuation(continuationOnAlways, runAlwaysOptions);
             }
         }
@@ -409,7 +407,6 @@ namespace GitHub.Unity
 
         protected virtual void RaiseOnStart()
         {
-            //Logger.Trace($"Executing {ToString()}");
             OnStart?.Invoke(this);
         }
 
@@ -436,7 +433,6 @@ namespace GitHub.Unity
             OnEnd?.Invoke(this, !taskFailed, exception);
             SetupContinuations();
             hasRun = true;
-            //Logger.Trace($"Finished {ToString()}");
         }
 
         protected void SetupContinuations()
@@ -667,7 +663,6 @@ namespace GitHub.Unity
 
         protected override void RaiseOnStart()
         {
-            //Logger.Trace($"Executing {ToString()}");
             OnStart?.Invoke(this);
             base.RaiseOnStart();
         }
@@ -678,7 +673,6 @@ namespace GitHub.Unity
             OnEnd?.Invoke(this, result, !taskFailed, exception);
             SetupContinuations();
             hasRun = true;
-            //Logger.Trace($"Finished {ToString()} {result}");
         }
 
         protected override void CallFinallyHandler()

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -38,8 +38,6 @@ namespace GitHub.Unity
 
         public void Load(IEnumerable<TData> treeDatas)
         {
-            //Logger.Trace("Load");
-
             var collapsedFolders = new HashSet<string>(GetCollapsedFolders());
             var checkedFiles = new HashSet<string>(GetCheckedFiles());
             var folders = new HashSet<string>();
@@ -74,8 +72,6 @@ namespace GitHub.Unity
                         {
                             if (PromoteNode(lastAddedNode, label))
                             {
-                                //Logger.Trace("Promoting Node Label:{0}", lastAddedNode.Label);
-
                                 parentIsPromoted = true;
                                 lastAddedNode.IsContainer = true;
                             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -199,7 +199,6 @@ namespace GitHub.Unity
         {
             if (!isInvalidating)
             {
-                Logger.Trace("Invalidate");
                 isInvalidating = true;
                 LastUpdatedAt = DateTimeOffset.MinValue;
                 CacheInvalidated.SafeInvoke(CacheType);
@@ -220,7 +219,6 @@ namespace GitHub.Unity
 
             if (isChanged)
             {
-                Logger.Trace("Updated: {0}", now);
                 CacheUpdated.SafeInvoke(CacheType, now);
             }
         }
@@ -529,8 +527,6 @@ namespace GitHub.Unity
             remoteConfigBranches = new RemoteConfigBranchDictionary(configBranches);
             remotes = gitRemotes;
             remoteBranches = gitBranches;
-
-            Logger.Trace("SetRemotes {0}", now);
             SaveData(now, true);
         }
 
@@ -539,8 +535,6 @@ namespace GitHub.Unity
             var now = DateTimeOffset.Now;
             localConfigBranches = new LocalConfigBranchDictionary(configBranches);
             localBranches = gitBranches;
-
-            Logger.Trace("SetLocals {0}", now);
             SaveData(now, true);
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
@@ -41,7 +41,6 @@ namespace GitHub.Unity
 
         protected override void SetProjectToTextSerialization()
         {
-            //Logger.Trace("SetProjectToTextSerialization");
             EditorSettings.serializationMode = SerializationMode.ForceText;
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
@@ -190,8 +190,6 @@ namespace GitHub.Unity
 
         private void DoRequire2fa(string msg)
         {
-            Logger.Trace("Starting 2FA - Message:\"{0}\"", msg);
-
             need2fa = true;
             errorMessage = msg;
             isBusy = false;
@@ -208,10 +206,7 @@ namespace GitHub.Unity
 
         private void DoResult(bool success, string msg)
         {
-            Logger.Trace("DoResult - Success:{0} Message:\"{1}\"", success, msg);
-
             isBusy = false;
-
             if (success)
             {
                 TaskManager.Run(UsageTracker.IncrementAuthenticationViewButtonAuthentication);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BaseWindow.cs
@@ -15,7 +15,6 @@ namespace GitHub.Unity
 
         public virtual void Initialize(IApplicationManager applicationManager)
         {
-            //Logger.Trace("Initialize ApplicationManager:{0} Initialized:{1}", applicationManager, initialized);
         }
 
         public void InitializeWindow(IApplicationManager applicationManager, bool requiresRedraw = true)
@@ -37,7 +36,6 @@ namespace GitHub.Unity
 
         public virtual void Refresh()
         {
-            //Logger.Debug("Refresh");
         }
 
         public virtual void Finish(bool result)
@@ -45,14 +43,12 @@ namespace GitHub.Unity
 
         public virtual void Awake()
         {
-            //Logger.Trace("Awake Initialized:{0}", initialized);
             if (!initialized)
                 InitializeWindow(EntryPoint.ApplicationManager, false);
         }
 
         public virtual void OnEnable()
         {
-            //Logger.Trace("OnEnable Initialized:{0}", initialized);
             if (!initialized)
                 InitializeWindow(EntryPoint.ApplicationManager, false);
         }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
@@ -137,29 +137,18 @@ namespace GitHub.Unity
                         GUI.FocusControl(null);
                         isBusy = true;
 
-                        newGitExec = gitExec;
-                        CheckEnteredGitPath();
-
                         new FindExecTask("git", Manager.CancellationToken)
                             .Configure(Manager.ProcessManager, dontSetupGit: true)
                             .Catch(ex => true)
                             .FinallyInUI((success, ex, path) => {
                                 if (success)
                                 {
-                                    Logger.Trace("FindGit Path:{0}", path);
                                     newGitExec = path;
                                     CheckEnteredGitPath();
                                 }
                                 else
                                 {
-                                    if (ex != null)
-                                    {
-                                        Logger.Error(ex, "FindGit Error Path:{0}", path);
-                                    }
-                                    else
-                                    {
-                                        Logger.Error("FindGit Failed Path:{0}", path);
-                                    }
+                                    Logger.Error(ex, "FindGit Error Path:{0}", path);
                                 }
 
                                 isBusy = false;
@@ -207,7 +196,6 @@ namespace GitHub.Unity
                 {
                     newGitExec = gitExec = Environment.GitExecutablePath.ToString();
                     gitExecParent = Environment.GitExecutablePath.Parent.ToString();
-
                     CheckEnteredGitPath();
                 }
 
@@ -223,11 +211,8 @@ namespace GitHub.Unity
         private void CheckEnteredGitPath()
         {
             isValueChanged = !string.IsNullOrEmpty(newGitExec) && newGitExec != gitExec;
-
             isValueChangedAndFileExists = isValueChanged && newGitExec.ToNPath().FileExists();
-
             gitFileErrorMessage = isValueChanged && !isValueChangedAndFileExists ? ErrorInvalidPathMessage : null;
-
             gitVersionErrorMessage = null;
         }
 
@@ -237,8 +222,6 @@ namespace GitHub.Unity
 
             if (value == portableGitPath)
             {
-                Logger.Trace("Attempting to restore portable Git Path:{0}", value);
-
                 var gitInstaller = new GitInstaller(Environment, Manager.ProcessManager,
                     TaskManager, Manager.SystemSettings);
 
@@ -248,8 +231,6 @@ namespace GitHub.Unity
                     })
                     .FinallyInUI((success, exception, installationState) =>
                     {
-                        Logger.Trace("Setup Git Using the installer:{0}", success);
-
                         if (!success)
                         {
                             Logger.Error(exception, ErrorInstallingInternalGit);
@@ -261,19 +242,14 @@ namespace GitHub.Unity
                             Environment.GitExecutablePath = installationState.GitExecutablePath;
                             Environment.GitLfsExecutablePath = installationState.GitLfsExecutablePath;
                             Environment.IsCustomGitExecutable = false;
-
                             gitExecHasChanged = true;
                         }
-
                         isBusy = false;
                     }).Start();
             }
             else
             {
-                //Logger.Trace("Validating Git Path:{0}", value);
-
                 gitVersionErrorMessage = null;
-
                 GitClient.ValidateGitInstall(value.ToNPath(), true)
                     .ThenInUI((success, result) =>
                     {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LfsLocksModificationProcessor.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LfsLocksModificationProcessor.cs
@@ -18,7 +18,6 @@ namespace GitHub.Unity
 
         public static void Initialize(IEnvironment env, IPlatform plat)
         {
-            //Logger.Trace("Initialize HasRepository:{0}", repo != null);
             environment = env;
             platform = plat;
             platform.Keychain.ConnectionsChanged += UserMayHaveChanged;
@@ -33,25 +32,21 @@ namespace GitHub.Unity
 
         public static string[] OnWillSaveAssets(string[] paths)
         {
-            //Logger.Trace("OnWillSaveAssets: [{0}]", string.Join(", ", paths));
             return paths;
         }
 
         public static AssetMoveResult OnWillMoveAsset(string oldPath, string newPath)
         {
-            //Logger.Trace("OnWillMoveAsset:{0}->{1}", oldPath, newPath);
             return IsLocked(oldPath) || IsLocked(newPath) ? AssetMoveResult.FailedMove : AssetMoveResult.DidNotMove;
         }
 
         public static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions option)
         {
-            //Logger.Trace("OnWillDeleteAsset:{0}", assetPath);
             return IsLocked(assetPath) ? AssetDeleteResult.FailedDelete : AssetDeleteResult.DidNotDelete;
         }
 
         public static bool IsOpenForEdit(string assetPath, out string message)
         {
-            //Logger.Trace("IsOpenForEdit:{0}", assetPath);
             var lck = GetLock(assetPath);
             message = lck.HasValue ? "File is locked for editing by " + lck.Value.User : null;
             return !lck.HasValue;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
@@ -113,32 +113,25 @@ namespace GitHub.Unity
             OnClose.SafeInvoke(false);
             OnClose = null;
 
-            //Logger.Trace("OpenView: {0}", popupViewType.ToString());
-
             var viewNeedsAuthentication = popupViewType == PopupViewType.PublishView;
             if (viewNeedsAuthentication)
             {
-                //Logger.Trace("Validating to open view");
-
-                Client.GetCurrentUser(user => {
-
-                    //Logger.Trace("User validated opening view");
-
+                Client.GetCurrentUser(user =>
+                {
                     OpenInternal(popupViewType, onClose);
                     shouldCloseOnFinish = true;
 
-                }, exception => {
-                    //Logger.Trace("User required validation opening AuthenticationView");
+                },
+                exception =>
+                {
                     authenticationView.Initialize(exception);
-                    OpenInternal(PopupViewType.AuthenticationView, completedAuthentication => {
+                    OpenInternal(PopupViewType.AuthenticationView, completedAuthentication =>
+                    {
                         if (completedAuthentication)
                         {
-                            //Logger.Trace("User completed validation opening view: {0}", popupViewType.ToString());
-
                             Open(popupViewType, onClose);
                         }
                     });
-
                     shouldCloseOnFinish = false;
                 });
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -25,8 +25,6 @@ namespace GitHub.Unity
 
         public static void Initialize(IRepository repo)
         {
-            //Logger.Trace("Initialize HasRepository:{0}", repo != null);
-
             EditorApplication.projectWindowItemOnGUI -= OnProjectWindowItemGUI;
             EditorApplication.projectWindowItemOnGUI += OnProjectWindowItemGUI;
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PublishView.cs
@@ -97,12 +97,8 @@ namespace GitHub.Unity
             //TODO: ONE_USER_LOGIN This assumes only ever one user can login
             username = keychainConnections.First().Username;
 
-            //Logger.Trace("Loading Owners");
-
             Client.GetOrganizations(orgs =>
             {
-                //Logger.Trace("Loaded {0} Owners", orgs.Length);
-
                 publishOwners = orgs
                     .OrderBy(organization => organization.Login)
                     .Select(organization => organization.Login)
@@ -113,14 +109,14 @@ namespace GitHub.Unity
                 isBusy = false;
 
                 Redraw();
-            }, exception =>
+            },
+            exception =>
             {
                 isBusy = false;
 
                 var keychainEmptyException = exception as KeychainEmptyException;
                 if (keychainEmptyException != null)
                 {
-                    //Logger.Trace("Keychain empty");
                     PopupWindow.OpenWindow(PopupWindow.PopupViewType.AuthenticationView);
                     return;
                 }
@@ -167,7 +163,6 @@ namespace GitHub.Unity
                             if (ex != null)
                             {
                                 Logger.Error(ex, "Repository Create Error Type:{0}", ex.GetType().ToString());
-
                                 error = GetPublishErrorMessage(ex);
                                 isBusy = false;
                                 return;
@@ -181,9 +176,6 @@ namespace GitHub.Unity
                                 isBusy = false;
                                 return;
                             }
-
-                            Logger.Trace("Repository Created");
-
                             Repository.RemoteAdd("origin", repository.CloneUrl)
                                 .Then(Repository.Push("origin"))
                                 .ThenInUI(Finish)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
@@ -11,36 +11,29 @@ namespace GitHub.Unity
         public virtual void InitializeView(IView parent)
         {
             Debug.Assert(parent != null, NullParentError);
-            //Logger.Trace("InitializeView");
             Parent = parent;
         }
 
         public virtual void OnEnable()
-        {
-            //Logger.Trace("OnEnable");
-        }
+        {}
 
         public virtual void OnDisable()
-        {
-            //Logger.Trace("OnDisable");
-        }
+        {}
 
         public virtual void OnDataUpdate()
         {}
 
         public virtual void OnGUI()
-        { }
+        {}
 
         public virtual void OnSelectionChange()
-        { }
+        {}
 
         public virtual void OnFocusChanged()
-        { }
+        {}
 
         public virtual void Refresh()
-        {
-            Logger.Trace("Refresh");
-        }
+        {}
 
         public virtual void Redraw()
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/UserSettingsView.cs
@@ -89,7 +89,6 @@ namespace GitHub.Unity
 
         private void UserOnChanged(CacheUpdateEvent cacheUpdateEvent)
         {
-            //Logger.Trace("UserOnChanged");
             lastCheckUserChangedEvent = cacheUpdateEvent;
             userHasChanges = true;
             isBusy = false;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -105,7 +105,6 @@ namespace GitHub.Unity
 
             if (!HasRepository)
             {
-                //Logger.Trace("Initialize set all tabs to InitProject");
                 changeTab = activeTab = SubTab.InitProject;
             }
         }
@@ -160,8 +159,6 @@ namespace GitHub.Unity
             {
                 if (activeTab == SubTab.InitProject)
                 {
-                    //Logger.Trace("OnRepositoryChanged set changeTab to History");
-
                     changeTab = SubTab.History;
                     UpdateActiveTab();
                 }
@@ -170,8 +167,6 @@ namespace GitHub.Unity
             {
                 if (activeTab != SubTab.InitProject)
                 {
-                    //Logger.Trace("OnRepositoryChanged set changeTab to InitProject");
-
                     changeTab = SubTab.InitProject;
                     UpdateActiveTab();
                 }


### PR DESCRIPTION
There's way too much noise in the code and in the logs, clean things up a bit. We can add logging back as we need to, when actually debugging issues.