### PR TITLE
Don't throw errors if we can't download the latest json feed

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
@@ -60,7 +60,8 @@ namespace GitHub.Unity
 
         public static void CheckForUpdates()
         {
-            var download = new DownloadTask(TaskManager.Instance.Token, EntryPoint.Environment.FileSystem, UpdateFeedUrl, EntryPoint.Environment.UserCachePath);
+            var download = new DownloadTask(TaskManager.Instance.Token, EntryPoint.Environment.FileSystem, UpdateFeedUrl, EntryPoint.Environment.UserCachePath)
+                .Catch(e => true);
             download.OnEnd += (thisTask, result, success, exception) =>
             {
                 if (success)


### PR DESCRIPTION
We don't care if the download fails, that just means we can't check for updates.