### PR TITLE
Fix wrong output path

### DIFF
--- a/src/GitHub.Api/Primitives/Package.cs
+++ b/src/GitHub.Api/Primitives/Package.cs
@@ -44,7 +44,7 @@ namespace GitHub.Unity
             if (!feed.IsInitialized)
             {
                 // try from assembly resources
-                feed = AssemblyResources.ToFile(ResourceType.Platform, packageFeed.Filename, environment.UserCachePath.Combine(packageFeed.Filename), environment);
+                feed = AssemblyResources.ToFile(ResourceType.Platform, packageFeed.Filename, environment.UserCachePath, environment);
             }
 
             if (feed.IsInitialized)


### PR DESCRIPTION
Bug, doh! The filename is passed in the `packageFeed.Filename` if it's needed.