### PR TITLE
Setting UnityYamlMerge options on repo initialization

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -165,26 +165,7 @@ namespace GitHub.Unity
             {
                 if (Environment.RepositoryPath.IsInitialized)
                 {
-                    var unityYamlMergeExec = Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge" + Environment.ExecutableExtension);
-                    var yamlMergeCommand = Environment.IsWindows
-                        ? $@"'{unityYamlMergeExec}' merge -p ""$BASE"" ""$REMOTE"" ""$LOCAL"" ""$MERGED"""
-                        : $@"'{unityYamlMergeExec}' merge -p '$BASE' '$REMOTE' '$LOCAL' '$MERGED'";
-
-                    GitClient.SetConfig("merge.unityyamlmerge.cmd", yamlMergeCommand, GitConfigSource.Local)
-                        .Catch(e =>
-                        {
-                            Logger.Error(e, "Error setting merge.unityyamlmerge.cmd");
-                            return true;
-                        })
-                        .RunWithReturn(true);
-
-                    GitClient.SetConfig("merge.unityyamlmerge.trustExitCode", "false", GitConfigSource.Local)
-                        .Catch(e =>
-                        {
-                            Logger.Error(e, "Error setting merge.unityyamlmerge.trustExitCode");
-                            return true;
-                        })
-                        .RunWithReturn(true);
+                    ConfigureMergeSettings();
 
                     GitClient.LfsInstall()
                         .Catch(e =>
@@ -236,6 +217,8 @@ namespace GitHub.Unity
                     var filesForInitialCommit = new List<string> { gitignore, gitAttrs, assetsGitignore };
 
                     GitClient.Init().RunWithReturn(true);
+
+                    ConfigureMergeSettings();
                     GitClient.LfsInstall().RunWithReturn(true);
                     AssemblyResources.ToFile(ResourceType.Generic, ".gitignore", targetPath, Environment);
                     AssemblyResources.ToFile(ResourceType.Generic, ".gitattributes", targetPath, Environment);
@@ -259,6 +242,25 @@ namespace GitHub.Unity
                 isBusy = false;
             });
             thread.Start();
+        }
+
+        private void ConfigureMergeSettings()
+        {
+            var unityYamlMergeExec =
+                Environment.UnityApplicationContents.Combine("Tools", "UnityYAMLMerge" + Environment.ExecutableExtension);
+            var yamlMergeCommand = Environment.IsWindows
+                ? $@"'{unityYamlMergeExec}' merge -p ""$BASE"" ""$REMOTE"" ""$LOCAL"" ""$MERGED"""
+                : $@"'{unityYamlMergeExec}' merge -p '$BASE' '$REMOTE' '$LOCAL' '$MERGED'";
+
+            GitClient.SetConfig("merge.unityyamlmerge.cmd", yamlMergeCommand, GitConfigSource.Local).Catch(e => {
+                Logger.Error(e, "Error setting merge.unityyamlmerge.cmd");
+                return true;
+            }).RunWithReturn(true);
+
+            GitClient.SetConfig("merge.unityyamlmerge.trustExitCode", "false", GitConfigSource.Local).Catch(e => {
+                Logger.Error(e, "Error setting merge.unityyamlmerge.trustExitCode");
+                return true;
+            }).RunWithReturn(true);
         }
 
         public void RestartRepository()


### PR DESCRIPTION
I realized we might as well set UnityYamlMerge settings as soon as the person initializes the repo.

This pull request targets:
- [ ] #743 