### PR TITLE
Validating cached data on initialize in Project explorer

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -34,6 +34,7 @@ namespace GitHub.Unity
             {
                 repository.StatusEntriesChanged += RepositoryOnStatusEntriesChanged;
                 repository.LocksChanged += RepositoryOnLocksChanged;
+                ValidateCachedData(repository);
             }
         }
 


### PR DESCRIPTION
I found that the status icons in the project explorer are not refreshed after a domain reload.
Calling ValidateCachedData performs the necessary data updates.