### PR TITLE
Fix recursive filesystem enumeration

### DIFF
--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -67,23 +67,16 @@ namespace GitHub.Unity
             if (state.GitIsValid)
                 state.GitInstallationPath = state.GitExecutablePath.Parent.Parent;
 
-            var isDefaultGitLfs = !state.GitLfsExecutablePath.IsInitialized;
-            if (isDefaultGitLfs)
+            if (!state.GitLfsExecutablePath.IsInitialized)
             {
-                state.GitLfsExecutablePath = ProcessManager.FindExecutableInPath(installDetails.GitLfsExecutable, false, state.GitExecutablePath.Parent);
-                if (!state.GitLfsExecutablePath.IsInitialized)
-                    state.GitLfsExecutablePath = ProcessManager.FindExecutableInPath(installDetails.GitLfsExecutable, true, state.GitInstallationPath);
+                // look for it in the directory where we would install it from the bundle
+                state.GitLfsExecutablePath = installDetails.GitLfsExecutablePath;
             }
 
             state = ValidateGitLfsVersion(state);
 
             if (state.GitLfsIsValid)
-            {
-                if (isDefaultGitLfs)
-                    state.GitLfsInstallationPath = state.GitInstallationPath;
-                else
-                    state.GitLfsInstallationPath = state.GitLfsExecutablePath.Parent;
-            }
+                state.GitLfsInstallationPath = state.GitLfsExecutablePath.Parent;
 
             return state;
         }
@@ -111,7 +104,7 @@ namespace GitHub.Unity
                 state.GitLfsExecutablePath = gitLfsPath;
                 state = ValidateGitLfsVersion(state);
                 if (state.GitLfsIsValid)
-                    state.GitLfsInstallationPath = gitLfsPath.Parent;
+                    state.GitLfsInstallationPath = state.GitLfsExecutablePath.Parent;
             }
             return state;
         }
@@ -128,10 +121,7 @@ namespace GitHub.Unity
             if (!state.GitLfsIsValid)
             {
                 state.GitLfsExecutablePath = installDetails.GitLfsExecutablePath;
-                if (state.GitIsValid && state.GitInstallationPath != installDetails.GitInstallationPath)
-                    state.GitLfsInstallationPath = state.GitLfsExecutablePath.Parent;
-                else
-                    state.GitLfsInstallationPath = installDetails.GitInstallationPath;
+                state.GitLfsInstallationPath = state.GitLfsExecutablePath.Parent;
                 state = ValidateGitLfsVersion(state);
             }
             return state;

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -67,9 +67,13 @@ namespace GitHub.Unity
             if (state.GitIsValid)
                 state.GitInstallationPath = state.GitExecutablePath.Parent.Parent;
 
-            var isDefaultGitLfs = !state.GitLfsExecutablePath.IsInitialized || state.GitLfsInstallationPath == state.GitInstallationPath;
+            var isDefaultGitLfs = !state.GitLfsExecutablePath.IsInitialized;
             if (isDefaultGitLfs)
-                state.GitLfsExecutablePath = ProcessManager.FindExecutableInPath(installDetails.GitLfsExecutable, true, state.GitInstallationPath);
+            {
+                state.GitLfsExecutablePath = ProcessManager.FindExecutableInPath(installDetails.GitLfsExecutable, false, state.GitExecutablePath.Parent);
+                if (!state.GitLfsExecutablePath.IsInitialized)
+                    state.GitLfsExecutablePath = ProcessManager.FindExecutableInPath(installDetails.GitLfsExecutable, true, state.GitInstallationPath);
+            }
 
             state = ValidateGitLfsVersion(state);
 

--- a/src/GitHub.Api/Platform/ProcessEnvironment.cs
+++ b/src/GitHub.Api/Platform/ProcessEnvironment.cs
@@ -37,6 +37,7 @@ namespace GitHub.Unity
             var pathEntries = new List<string>();
             string separator = Environment.IsWindows ? ";" : ":";
 
+            NPath libexecPath = NPath.Default;
             if (Environment.GitInstallPath.IsInitialized)
             {
                 var gitPathRoot = Environment.GitExecutablePath.Resolve().Parent.Parent;
@@ -53,9 +54,9 @@ namespace GitHub.Unity
                     binPath = baseExecPath.Combine("bin");
                 }
 
-                var execPath = baseExecPath.Combine("libexec", "git-core");
-                if (!execPath.DirectoryExists())
-                    execPath = NPath.Default;
+                libexecPath = baseExecPath.Combine("libexec", "git-core");
+                if (!libexecPath.DirectoryExists())
+                    libexecPath = NPath.Default;
 
                 if (Environment.IsWindows)
                 {
@@ -66,17 +67,17 @@ namespace GitHub.Unity
                     pathEntries.Add(gitExecutableDir.ToString());
                 }
 
-                if (execPath.IsInitialized)
-                    pathEntries.Add(execPath);
+                if (libexecPath.IsInitialized)
+                    pathEntries.Add(libexecPath);
                 pathEntries.Add(binPath);
 
                 // we can only set this env var if there is a libexec/git-core. git will bypass internally bundled tools if this env var
                 // is set, which will break Apple's system git on certain tools (like osx-credentialmanager)
-                if (execPath.IsInitialized)
-                    psi.EnvironmentVariables["GIT_EXEC_PATH"] = execPath.ToString();
+                if (libexecPath.IsInitialized)
+                    psi.EnvironmentVariables["GIT_EXEC_PATH"] = libexecPath.ToString();
             }
 
-            if (Environment.GitLfsInstallPath.IsInitialized && Environment.GitInstallPath != Environment.GitLfsInstallPath)
+            if (Environment.GitLfsInstallPath.IsInitialized && libexecPath != Environment.GitLfsInstallPath)
             {
                 pathEntries.Add(Environment.GitLfsInstallPath);
             }


### PR DESCRIPTION
The default GetFiles recursive method on Mono goes into an infinite loop when encountering symlinks that point to ./.

Switch to yield for recursive filesystem enumeration so we can abort early

In the process, change the way we search for git-lfs if there's a custom git set but no custom git-lfs set: just look in the directory where we would expect to find it if we installed git-lfs from the bundle, it's most likely there. And if it isn't, the next step is to look for git-lfs in the system via `which/where` commands anyway, so it'll get found. This way there's no need for recursive enumeration (but it's fixed anyway)

