### PR TITLE
Ensure log path exists

### DIFF
--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -46,6 +46,7 @@ namespace GitHub.Unity
             {
                 LogPath = UserCachePath.Combine(logFile);
             }
+            LogPath.EnsureParentDirectoryExists();
         }
 
         public DefaultEnvironment(ICacheContainer cacheContainer) : this()


### PR DESCRIPTION
Nothing else creates the directory, and on mac the log is not in the default user cache path like on Windows, which means we can't rely on the settings class to create the log path
