### PR TITLE
Removing WebTimeout Setting

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -7,7 +7,6 @@ namespace GitHub.Unity
         public const string UsageFile = "metrics.json";
         public const string GitInstallPathKey = "GitInstallPath";
         public const string TraceLoggingKey = "EnableTraceLogging";
-        public const string WebTimeoutKey = "WebTimeout";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
         public static readonly string[] Iso8601Formats = {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -14,10 +14,8 @@ namespace GitHub.Unity
         private const string GitRepositoryTitle = "Repository Configuration";
         private const string GitRepositoryRemoteLabel = "Remote";
         private const string GitRepositorySave = "Save Repository";
-        private const string GeneralSettingsTitle = "General";
         private const string DebugSettingsTitle = "Debug";
         private const string PrivacyTitle = "Privacy";
-        private const string WebTimeoutLabel = "Timeout of web requests";
         private const string EnableTraceLoggingLabel = "Enable Trace Logging";
         private const string MetricsOptInLabel = "Help us improve by sending anonymous usage data";
         private const string DefaultRepositoryRemoteName = "origin";
@@ -40,7 +38,6 @@ namespace GitHub.Unity
         [SerializeField] private string repositoryRemoteUrl;
         [SerializeField] private Vector2 scroll;
         [SerializeField] private UserSettingsView userSettingsView = new UserSettingsView();
-        [SerializeField] private int webTimeout;
 
         public override void InitializeView(IView parent)
         {
@@ -110,7 +107,6 @@ namespace GitHub.Unity
 
                 gitPathView.OnGUI();
                 OnPrivacyGui();
-                OnGeneralSettingsGui();
                 OnLoggingSettingsGui();
             }
 
@@ -349,27 +345,6 @@ namespace GitHub.Unity
             }
             EditorGUI.EndDisabledGroup();
         }
-
-        private void OnGeneralSettingsGui()
-        {
-            GUILayout.Label(GeneralSettingsTitle, EditorStyles.boldLabel);
-
-            EditorGUI.BeginDisabledGroup(IsBusy);
-            {
-                webTimeout = ApplicationConfiguration.WebTimeout;
-                EditorGUI.BeginChangeCheck();
-                {
-                    webTimeout = EditorGUILayout.IntField(WebTimeoutLabel, webTimeout);
-                }
-                if (EditorGUI.EndChangeCheck())
-                {
-                    ApplicationConfiguration.WebTimeout = webTimeout;
-                    Manager.UserSettings.Set(Constants.WebTimeoutKey, webTimeout);
-                }
-            }
-            EditorGUI.EndDisabledGroup();
-        }
-
 
         public override bool IsBusy
         {


### PR DESCRIPTION
This setting used to control the web timeout of Octokit.NET.
We could use it to control the timeout of  other things, but it's not currently connected.
Probably best to just remove it.