### PR TITLE
Fix Successful state of process task

### DIFF
--- a/src/GitHub.Api/Tasks/ProcessTask.cs
+++ b/src/GitHub.Api/Tasks/ProcessTask.cs
@@ -213,6 +213,7 @@ namespace GitHub.Unity
     {
         private IOutputProcessor<T> outputProcessor;
         private ProcessWrapper wrapper;
+        private bool finished = false;
 
         public event Action<string> OnErrorData;
         public event Action<IProcess> OnStartProcess;
@@ -302,6 +303,7 @@ namespace GitHub.Unity
                 RaiseOnStart,
                 () =>
                 {
+                    finished = true;
                     try
                     {
                         if (outputProcessor != null)
@@ -350,7 +352,7 @@ namespace GitHub.Unity
 
         public Process Process { get; set; }
         public int ProcessId { get { return Process.Id; } }
-        public override bool Successful { get { return !taskFailed && Task.Status == TaskStatus.RanToCompletion && Process.ExitCode == 0; } }
+        public override bool Successful { get { return finished && ((!taskFailed && Process.ExitCode == 0) || (taskFailed && exceptionWasHandled)); } }
         public StreamWriter StandardInput { get { return wrapper?.Input; } }
         public virtual string ProcessName { get; protected set; }
         public virtual string ProcessArguments { get; }

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -491,7 +491,7 @@ namespace GitHub.Unity
             return $"{Task?.Id ?? -1} {Name} {GetType()}";
         }
 
-        public virtual bool Successful { get { return !taskFailed || exceptionWasHandled; /*Task.Status == TaskStatus.RanToCompletion && Task.Status != TaskStatus.Faulted;*/ } }
+        public virtual bool Successful { get { return !taskFailed || exceptionWasHandled; } }
         public string Errors { get; protected set; }
         public Task Task { get; protected set; }
         public bool IsCompleted { get { return hasRun; /*(Task as IAsyncResult).IsCompleted;*/ } }


### PR DESCRIPTION
If we're running tasks directly with RunWithReturn, the Task object never gets go a completion state, which means Successful would always return false.

This was breaking setting paths on mac.