### PR TITLE
Window.currentBranchAndRemoteHasUpdate never reset to false

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -279,6 +279,8 @@ namespace GitHub.Unity
             {
                 if (repoBranch == null || repoRemote == null || currentBranchAndRemoteHasUpdate)
                 {
+                    currentBranchAndRemoteHasUpdate = false;
+
                     var repositoryCurrentBranch = Repository.CurrentBranch;
                     var updatedRepoBranch = repositoryCurrentBranch.HasValue ? repositoryCurrentBranch.Value.Name : null;
 


### PR DESCRIPTION
The value that conveys if we need to update from the cache is never reset to false.
This causes needless recreations of Content items that aren't changing.