### PR TITLE
Fix version comparisons bugs

### DIFF
--- a/common/SolutionInfo.cs
+++ b/common/SolutionInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("GitHub for Unity")]
-[assembly: AssemblyVersion(System.AssemblyVersionInformation.Version)]
-[assembly: AssemblyFileVersion(System.AssemblyVersionInformation.Version)]
+[assembly: AssemblyVersion(System.AssemblyVersionInformation.VersionForAssembly)]
+[assembly: AssemblyFileVersion(System.AssemblyVersionInformation.VersionForAssembly)]
 [assembly: AssemblyInformationalVersion(System.AssemblyVersionInformation.Version)]
 [assembly: ComVisible(false)]
 [assembly: AssemblyCompany("GitHub, Inc.")]
@@ -31,6 +31,9 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "0.33.1";
+        // this is for the AssemblyVersion and AssemblyVersion attributes, which can't handle alphanumerics
+        internal const string VersionForAssembly = "0.33.1";
+        // Actual real version
+        internal const string Version = "0.33.1-beta";
     }
 }

--- a/src/GitHub.Api/Application/ApplicationConfiguration.cs
+++ b/src/GitHub.Api/Application/ApplicationConfiguration.cs
@@ -5,18 +5,6 @@ namespace GitHub.Unity
     public static class ApplicationConfiguration
     {
         public const int DefaultWebTimeout = 3000;
-
-        static ApplicationConfiguration()
-        {
-            var executingAssembly = typeof(ApplicationConfiguration).Assembly;
-            AssemblyName = executingAssembly.GetName();
-        }
-
-        /// <summary>
-        ///     The currently executing assembly.
-        /// </summary>
-        public static AssemblyName AssemblyName { get; }
-
         public static int WebTimeout { get; set; } = DefaultWebTimeout;
     }
 }

--- a/src/GitHub.Api/Metrics/UsageTracker.cs
+++ b/src/GitHub.Api/Metrics/UsageTracker.cs
@@ -37,7 +37,7 @@ namespace GitHub.Unity
             this.usageLoader = usageLoader;
             this.metricsService = metricsService;
             this.userId = userId;
-            this.appVersion = ApplicationConfiguration.AssemblyName.Version.ToString();
+            this.appVersion = ApplicationInfo.Version;
             this.unityVersion = unityVersion;
             this.instanceId = instanceId;
 

--- a/src/UnityExtension/Assets/Editor/UnityTests/VersionTests.cs
+++ b/src/UnityExtension/Assets/Editor/UnityTests/VersionTests.cs
@@ -157,9 +157,21 @@ public class VersionTests
         version2 = TheVersion.Parse("1.2.3alpha1");
         Assert.IsTrue(version1 >= version2);
 
-        version1 = TheVersion.Parse("0.32.0");
-        version2 = TheVersion.Parse("0.33.0-beta");
+        version1 = TheVersion.Parse("0.33.0-beta");
+        version2 = TheVersion.Parse("0.32.0");
+        Assert.IsTrue(version1 > version2);
+
+        version1 = TheVersion.Parse("0.33.2");
+        version2 = TheVersion.Parse("0.33.3-beta");
         Assert.IsTrue(version1 < version2);
+
+        version1 = TheVersion.Parse("0.33.3-alpha");
+        version2 = TheVersion.Parse("0.33.3-beta");
+        Assert.IsTrue(version1 < version2);
+
+        version1 = TheVersion.Parse("0.33.3");
+        version2 = TheVersion.Parse("0.33.3-beta");
+        Assert.IsTrue(version1 > version2);
     }
 
     [Test]

--- a/src/tests/IntegrationTests/Metrics/MetricsTests.cs
+++ b/src/tests/IntegrationTests/Metrics/MetricsTests.cs
@@ -29,7 +29,7 @@ namespace IntegrationTests
         public void IncrementMetricsWorks(string measureName)
         {
             var userId = Guid.NewGuid().ToString();
-            var appVersion = ApplicationConfiguration.AssemblyName.Version.ToString();
+            var appVersion = ApplicationInfo.Version;
             var unityVersion = "2017.3f1";
             var instanceId = Guid.NewGuid().ToString();
             var usageLoader = Substitute.For<IUsageLoader>();
@@ -54,7 +54,7 @@ namespace IntegrationTests
         {
             InitializeEnvironment(TestBasePath, false, false);
             var userId = Guid.NewGuid().ToString();
-            var appVersion = ApplicationConfiguration.AssemblyName.Version.ToString();
+            var appVersion = ApplicationInfo.Version;
             var unityVersion = "2017.3f1";
             var instanceId = Guid.NewGuid().ToString();
             var usageStore = new UsageStore();


### PR DESCRIPTION
There were a few bugs when comparing versions, added more tests and fixed things.

Also, we should be using the full version of the package and not the silly numbers-only thing that .net requires for some of the assembly attribute fields, so unfortunately we need to keep two separate const strings of the version of the package (so be it).