### PR TITLE
Fix discarding when repo path != project path

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -271,7 +271,7 @@ namespace GitHub.Unity
 
             repositoryManager?.Dispose();
 
-            repositoryManager = Unity.RepositoryManager.CreateInstance(Platform, TaskManager, GitClient, Environment.FileSystem, Environment.RepositoryPath);
+            repositoryManager = Unity.RepositoryManager.CreateInstance(Platform, TaskManager, GitClient, Environment.RepositoryPath);
             repositoryManager.Initialize();
             Environment.Repository.Initialize(repositoryManager, TaskManager);
             repositoryManager.Start();

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -110,7 +110,7 @@ namespace IntegrationTests
             DotGitHead = DotGitPath.Combine("HEAD");
             DotGitConfig = DotGitPath.Combine("config");
 
-            RepositoryManager = GitHub.Unity.RepositoryManager.CreateInstance(Platform, TaskManager, GitClient, Environment.FileSystem, repoPath);
+            RepositoryManager = GitHub.Unity.RepositoryManager.CreateInstance(Platform, TaskManager, GitClient, repoPath);
             RepositoryManager.Initialize();
 
             onRepositoryManagerCreated?.Invoke(RepositoryManager);


### PR DESCRIPTION
If the repo root is not the same directory as the project path, discard fails trying to delete a file (since the process current directory is the project path, not the repo path)