### PR TITLE
Only clearing the commit message and body on commit success

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -355,10 +355,10 @@ namespace GitHub.Unity
                         if (success)
                         {
                             TaskManager.Run(UsageTracker.IncrementChangesViewButtonCommit);
-                        }
 
-                        commitMessage = "";
-                        commitBody = "";
+                            commitMessage = "";
+                            commitBody = "";
+                        }
                     }).Start();
         }
     }


### PR DESCRIPTION
In the event there is an error during commit, we should not clear the text boxes so the user can try again.