### PR TITLE
Add a refresh button to the action bar

### DIFF
--- a/src/GitHub.Api/Git/IRepository.cs
+++ b/src/GitHub.Api/Git/IRepository.cs
@@ -78,5 +78,6 @@ namespace GitHub.Unity
         ITask DeleteBranch(string branch, bool force);
         ITask CreateBranch(string branch, string baseBranch);
         ITask SwitchBranch(string branch);
+        void Refresh(CacheType cacheType);
     }
 }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -162,14 +162,16 @@ namespace GitHub.Unity
 
         private void RefreshCache(CacheType cacheType)
         {
-            taskManager.RunInUI(() =>
+            taskManager.RunInUI(() => Refresh(cacheType));
+        }
+
+        public void Refresh(CacheType cacheType)
             {
                 var cache = cacheContainer.GetCache(cacheType);
                 // if the cache has valid data, we need to force an invalidation to refresh it
                 // if it doesn't have valid data, it will trigger an invalidation automatically
                 if (cache.ValidateData())
                     cache.InvalidateData();
-            });
         }
 
         private void CacheHasBeenInvalidated(CacheType cacheType)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -62,7 +62,7 @@ namespace GitHub.Unity
                                 headerRepoLabelStyle,
                                 headerTitleStyle,
                                 headerDescriptionStyle,
-                                historyToolbarButtonStyle,
+                                toolbarButtonStyle,
                                 historyLockStyle,
                                 historyEntrySummaryStyle,
                                 historyEntryDetailsStyle,
@@ -378,18 +378,18 @@ namespace GitHub.Unity
             }
         }
 
-        public static GUIStyle HistoryToolbarButtonStyle
+        public static GUIStyle ToolbarButtonStyle
         {
             get
             {
-                if (historyToolbarButtonStyle == null)
+                if (toolbarButtonStyle == null)
                 {
-                    historyToolbarButtonStyle = new GUIStyle(EditorStyles.toolbarButton);
-                    historyToolbarButtonStyle.name = "HistoryToolbarButtonStyle";
-                    historyToolbarButtonStyle.richText = true;
-                    historyToolbarButtonStyle.wordWrap = true;
+                    toolbarButtonStyle = new GUIStyle(EditorStyles.toolbarButton);
+                    toolbarButtonStyle.name = "HistoryToolbarButtonStyle";
+                    toolbarButtonStyle.richText = true;
+                    toolbarButtonStyle.wordWrap = true;
                 }
-                return historyToolbarButtonStyle;
+                return toolbarButtonStyle;
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -92,6 +92,13 @@ namespace GitHub.Unity
             DetachHandlers(Repository);
         }
 
+        public override void Refresh()
+        {
+            base.Refresh();
+            Repository.Refresh(CacheType.Branches);
+            Repository.Refresh(CacheType.RepositoryInfo);
+        }
+
         public override void OnDataUpdate()
         {
             base.OnDataUpdate();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -60,6 +60,14 @@ namespace GitHub.Unity
             DetachHandlers(Repository);
         }
 
+        public override void Refresh()
+        {
+            base.Refresh();
+            Repository.Refresh(CacheType.GitStatus);
+            Repository.Refresh(CacheType.RepositoryInfo);
+            Repository.Refresh(CacheType.GitLocks);
+        }
+
         public override void OnDataUpdate()
         {
             base.OnDataUpdate();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -345,6 +345,13 @@ namespace GitHub.Unity
             DetachHandlers(Repository);
         }
 
+        public override void Refresh()
+        {
+            base.Refresh();
+            Repository.Refresh(CacheType.GitLog);
+            Repository.Refresh(CacheType.GitAheadBehind);
+        }
+
         public override void OnDataUpdate()
         {
             base.OnDataUpdate();
@@ -389,11 +396,11 @@ namespace GitHub.Unity
                 // Top bar for scrolling to selection or clearing it
                 GUILayout.BeginHorizontal(EditorStyles.toolbar);
                 {
-                    if (GUILayout.Button(CommitDetailsTitle, Styles.HistoryToolbarButtonStyle))
+                    if (GUILayout.Button(CommitDetailsTitle, Styles.ToolbarButtonStyle))
                     {
                         historyControl.ScrollTo(historyControl.SelectedIndex);
                     }
-                    if (GUILayout.Button(ClearSelectionButton, Styles.HistoryToolbarButtonStyle, GUILayout.ExpandWidth(false)))
+                    if (GUILayout.Button(ClearSelectionButton, Styles.ToolbarButtonStyle, GUILayout.ExpandWidth(false)))
                     {
                         selectedEntry = GitLogEntry.Default;
                         historyControl.SelectedIndex = -1;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -87,6 +87,8 @@ namespace GitHub.Unity
             base.Refresh();
             gitPathView.Refresh();
             userSettingsView.Refresh();
+            if (Repository != null)
+                Repository.Refresh(CacheType.GitLocks);
         }
 
         public override void OnGUI()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -482,7 +482,7 @@ namespace GitHub.Unity
                     EditorGUI.BeginDisabledGroup(currentRemoteName == null);
                     {
                         // Fetch button
-                        var fetchClicked = GUILayout.Button(Localization.FetchButtonText, Styles.HistoryToolbarButtonStyle);
+                        var fetchClicked = GUILayout.Button(Localization.FetchButtonText, Styles.ToolbarButtonStyle);
                         if (fetchClicked)
                         {
                             Fetch();
@@ -490,7 +490,7 @@ namespace GitHub.Unity
 
                         // Pull button
                         var pullButtonText = statusBehind > 0 ? String.Format(Localization.PullButtonCount, statusBehind) : Localization.PullButton;
-                        var pullClicked = GUILayout.Button(pullButtonText, Styles.HistoryToolbarButtonStyle);
+                        var pullClicked = GUILayout.Button(pullButtonText, Styles.ToolbarButtonStyle);
 
                         if (pullClicked &&
                             EditorUtility.DisplayDialog(Localization.PullConfirmTitle,
@@ -508,7 +508,7 @@ namespace GitHub.Unity
                     EditorGUI.BeginDisabledGroup(currentRemoteName == null || statusBehind != 0);
                     {
                         var pushButtonText = statusAhead > 0 ? String.Format(Localization.PushButtonCount, statusAhead) : Localization.PushButton;
-                        var pushClicked = GUILayout.Button(pushButtonText, Styles.HistoryToolbarButtonStyle);
+                        var pushClicked = GUILayout.Button(pushButtonText, Styles.ToolbarButtonStyle);
 
                         if (pushClicked &&
                             EditorUtility.DisplayDialog(Localization.PushConfirmTitle,
@@ -525,11 +525,15 @@ namespace GitHub.Unity
                 else
                 {
                     // Publishing a repo
-                    var publishedClicked = GUILayout.Button(Localization.PublishButton, Styles.HistoryToolbarButtonStyle);
-                    if (publishedClicked)
+                    if (GUILayout.Button(Localization.PublishButton, Styles.ToolbarButtonStyle))
                     {
                         PopupWindow.OpenWindow(PopupWindow.PopupViewType.PublishView);
                     }
+                }
+
+                if (GUILayout.Button(Localization.RefreshButton, Styles.ToolbarButtonStyle))
+                {
+                    Refresh();
                 }
 
                 GUILayout.FlexibleSpace();


### PR DESCRIPTION
There may be times when the filesystem has changed but Unity reloads the domain too fast for us to invalidate the cache, at which point the data will be stale and won't be automatically updated.
