### PR TITLE
Using git errors in popup messages

### DIFF
--- a/src/GitHub.Api/Localization.Designer.cs
+++ b/src/GitHub.Api/Localization.Designer.cs
@@ -430,7 +430,7 @@ namespace GitHub.Unity {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Pull ({0}).
         /// </summary>
         public static string PullButtonCount {
             get {
@@ -511,7 +511,7 @@ namespace GitHub.Unity {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Push ({0}).
         /// </summary>
         public static string PushButtonCount {
             get {

--- a/src/GitHub.Api/Localization.Designer.cs
+++ b/src/GitHub.Api/Localization.Designer.cs
@@ -583,6 +583,15 @@ namespace GitHub.Unity {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Release Lock.
+        /// </summary>
+        public static string ReleaseLockActionTitle {
+            get {
+                return ResourceManager.GetString("ReleaseLockActionTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Access.
         /// </summary>
         public static string RemoteAccessTitle {
@@ -624,6 +633,15 @@ namespace GitHub.Unity {
         public static string RemoteUserTitle {
             get {
                 return ResourceManager.GetString("RemoteUserTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Request Lock.
+        /// </summary>
+        public static string RequestLockActionTitle {
+            get {
+                return ResourceManager.GetString("RequestLockActionTitle", resourceCulture);
             }
         }
         

--- a/src/GitHub.Api/Localization.resx
+++ b/src/GitHub.Api/Localization.resx
@@ -345,4 +345,10 @@
   <data name="Window_RepoUrlTooltip" xml:space="preserve">
     <value>Url of the {0} remote</value>
   </data>
+  <data name="ReleaseLockActionTitle" xml:space="preserve">
+    <value>Release Lock</value>
+  </data>
+  <data name="RequestLockActionTitle" xml:space="preserve">
+    <value>Request Lock</value>
+  </data>
 </root>

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -108,6 +108,12 @@ namespace GitHub.Unity
                     {
                         EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementUnityProjectViewContextLfsLock);
                     }
+                    else
+                    {
+                        EditorUtility.DisplayDialog(Localization.RequestLockActionTitle,
+                            ex.Message,
+                            Localization.Ok);
+                    }
 
                     isBusy = false;
                     Selection.activeGameObject = null;
@@ -154,6 +160,13 @@ namespace GitHub.Unity
                     {
                         EntryPoint.ApplicationManager.TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementUnityProjectViewContextLfsUnlock);
                     }
+                    else
+                    {
+                        EditorUtility.DisplayDialog(Localization.ReleaseLockActionTitle,
+                            ex.Message,
+                            Localization.Ok);
+                    }
+
                     isBusy = false;
                     Selection.activeGameObject = null;
                     EditorApplication.RepaintProjectWindow();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -295,7 +295,19 @@ namespace GitHub.Unity
                                 if (GUILayout.Button("Unlock"))
                                 {
                                     Repository.ReleaseLock(lck.Path, true)
-                                        .Then(UsageTracker.IncrementSettingsViewButtonLfsUnlock)
+                                        .FinallyInUI((success, ex) =>
+                                        {
+                                            if (success)
+                                            {
+                                                TaskManager.Run(UsageTracker.IncrementSettingsViewButtonLfsUnlock);
+                                            }
+                                            else
+                                            {
+                                                EditorUtility.DisplayDialog(Localization.ReleaseLockActionTitle,
+                                                    ex.Message,
+                                                    Localization.Ok);
+                                            }
+                                        })
                                         .Start();
                                 }
                             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -566,7 +566,7 @@ namespace GitHub.Unity
                         else
                         {
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
-                                Localization.PullFailureDescription,
+                                e.Message,
                             Localization.Ok);
                         }
                     })
@@ -590,7 +590,7 @@ namespace GitHub.Unity
                     else
                     {
                         EditorUtility.DisplayDialog(Localization.PushActionTitle,
-                            Localization.PushFailureDescription,
+                            e.Message,
                         Localization.Ok);
                     }
                 })
@@ -606,7 +606,7 @@ namespace GitHub.Unity
                     {
                         TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementHistoryViewToolbarFetch);
 
-                        EditorUtility.DisplayDialog(Localization.FetchActionTitle, Localization.FetchFailureDescription,
+                        EditorUtility.DisplayDialog(Localization.FetchActionTitle, e.Message,
                             Localization.Ok);
                     }
                 })

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -602,12 +602,13 @@ namespace GitHub.Unity
             Repository
                 .Fetch()
                 .FinallyInUI((success, e) => {
-                    if (!success)
+                    if (success)
                     {
                         TaskManager.Run(EntryPoint.ApplicationManager.UsageTracker.IncrementHistoryViewToolbarFetch);
-
-                        EditorUtility.DisplayDialog(Localization.FetchActionTitle, e.Message,
-                            Localization.Ok);
+                    }
+                    else
+                    {
+                        EditorUtility.DisplayDialog(Localization.FetchActionTitle, e.Message, Localization.Ok);
                     }
                 })
                 .Start();


### PR DESCRIPTION
- Using the error messages thrown from exceptions in fetch/push/pull.
- Adding a popup for errors messages for lfs lock request/release
- Fixed a metrics reporting bug

**Examples**:

![](https://i.imgur.com/5vjycgJ.png)

![](https://i.imgur.com/UDxfLxt.png)