### PR TITLE
Ensure environment is never initialized off the main thread

### DIFF
--- a/src/GitHub.Api/Application/IApplicationManager.cs
+++ b/src/GitHub.Api/Application/IApplicationManager.cs
@@ -6,7 +6,6 @@ namespace GitHub.Unity
 {
     public interface IApplicationManager : IDisposable
     {
-        CancellationToken CancellationToken { get; }
         IEnvironment Environment { get; }
         IPlatform Platform { get; }
         IProcessEnvironment GitEnvironment { get; }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationManager.cs
@@ -14,8 +14,9 @@ namespace GitHub.Unity
 
         private FieldInfo quitActionField;
 
-        public ApplicationManager(IMainThreadSynchronizationContext synchronizationContext)
-            : base(synchronizationContext as SynchronizationContext)
+        public ApplicationManager(IMainThreadSynchronizationContext synchronizationContext,
+            IEnvironment environment)
+            : base(synchronizationContext as SynchronizationContext, environment)
         {
             FirstRun = ApplicationCache.Instance.FirstRun;
             InstanceId = ApplicationCache.Instance.InstanceId;
@@ -31,7 +32,7 @@ namespace GitHub.Unity
 
             isBusy = false;
             LfsLocksModificationProcessor.Initialize(Environment, Platform);
-            ProjectWindowInterface.Initialize(Environment.Repository);
+            ProjectWindowInterface.Initialize(this);
             var window = Window.GetWindow();
             if (window != null)
                 window.InitializeWindow(this);
@@ -100,6 +101,5 @@ namespace GitHub.Unity
         }
 
         public override IProcessEnvironment GitEnvironment { get { return Platform.GitEnvironment; } }
-        public override IEnvironment Environment { get { return EnvironmentCache.Instance.Environment; } }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/EntryPoint.cs
@@ -33,7 +33,7 @@ namespace GitHub.Unity
             EditorApplication.update -= Initialize;
 
             // this will initialize ApplicationManager and Environment if they haven't yet
-            var logPath = Environment.LogPath;
+            var logPath = ApplicationManager.Environment.LogPath;
 
             if (ApplicationCache.Instance.FirstRun)
             {
@@ -58,7 +58,7 @@ namespace GitHub.Unity
                     LogHelper.Error(ex, "Error rotating log files");
                 }
 
-                Debug.LogFormat("Initialized GitHub for Unity version {0}{1}Log file: {2}", ApplicationInfo.Version, Environment.NewLine, logPath);
+                Debug.LogFormat("Initialized GitHub for Unity version {0}{1}Log file: {2}", ApplicationInfo.Version, ApplicationManager.Environment.NewLine, logPath);
             }
 
             LogHelper.LogAdapter = new MultipleLogAdapter(new FileLogAdapter(logPath)
@@ -66,12 +66,12 @@ namespace GitHub.Unity
                 , new UnityLogAdapter()
 #endif
                 );
-            LogHelper.Info("Initializing GitHubForUnity:'v{0}' Unity:'v{1}'", ApplicationInfo.Version, Environment.UnityVersion);
+            LogHelper.Info("Initializing GitHubForUnity:'v{0}' Unity:'v{1}'", ApplicationInfo.Version, ApplicationManager.Environment.UnityVersion);
 
             ApplicationManager.Run();
 
             if (ApplicationCache.Instance.FirstRun)
-                UpdateCheckWindow.CheckForUpdates();
+                UpdateCheckWindow.CheckForUpdates(ApplicationManager);
         }
 
         internal static void Restart()
@@ -92,14 +92,10 @@ namespace GitHub.Unity
             {
                 if (appManager == null)
                 {
-                    appManager = new ApplicationManager(new MainThreadSynchronizationContext());
+                    appManager = new ApplicationManager(new MainThreadSynchronizationContext(), EnvironmentCache.Instance.Environment);
                 }
                 return appManager;
             }
         }
-
-        public static IEnvironment Environment { get { return ApplicationManager.Environment; } }
-
-        public static IUsageTracker UsageTracker { get { return ApplicationManager.UsageTracker; } }
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
@@ -21,9 +21,9 @@ namespace GitHub.Unity
             if (location == Location.PreferencesFolder)
                 filepath = InternalEditorUtility.unityPreferencesFolder + "/" + relativePath;
             else if (location == Location.UserFolder)
-                filepath = EntryPoint.Environment.UserCachePath.Combine(relativePath).ToString(SlashMode.Forward);
+                filepath = EntryPoint.ApplicationManager.Environment.UserCachePath.Combine(relativePath).ToString(SlashMode.Forward);
             else if (location == Location.LibraryFolder)
-                filepath = EntryPoint.Environment.UnityProjectPath.Combine("Library", "gfu", relativePath);
+                filepath = EntryPoint.ApplicationManager.Environment.UnityProjectPath.Combine("Library", "gfu", relativePath);
         }
     }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/GitPathView.cs
@@ -173,9 +173,9 @@ namespace GitHub.Unity
                     {
                         GUI.FocusControl(null);
                         isBusy = true;
-                        new FuncTask<GitInstaller.GitInstallationState>(Manager.CancellationToken, () =>
+                        new FuncTask<GitInstaller.GitInstallationState>(TaskManager.Token, () =>
                             {
-                                var gitInstaller = new GitInstaller(Environment, Manager.ProcessManager, Manager.CancellationToken);
+                                var gitInstaller = new GitInstaller(Environment, Manager.ProcessManager, TaskManager.Token);
                                 return gitInstaller.FindSystemGit(new GitInstaller.GitInstallationState());
                             })
                             { Message = "Locating git..." }
@@ -226,7 +226,7 @@ namespace GitHub.Unity
             {
                 new FuncTask<GitInstaller.GitInstallationState>(TaskManager.Token, () =>
                     {
-                        var gitInstaller = new GitInstaller(Environment, Manager.ProcessManager, Manager.CancellationToken);
+                        var gitInstaller = new GitInstaller(Environment, Manager.ProcessManager, TaskManager.Token);
                         var state = new GitInstaller.GitInstallationState();
                         state = gitInstaller.SetDefaultPaths(state);
                         // on non-windows we only bundle git-lfs

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
@@ -57,6 +57,8 @@ namespace GitHub.Unity
         [SerializeField] public GitLockEntryDictionary assets = new GitLockEntryDictionary();
         [SerializeField] public GitStatusDictionary gitStatusDictionary = new GitStatusDictionary();
         [SerializeField] private GitLockEntry selectedEntry;
+        [SerializeField] public NPath projectPath;
+
         public bool IsEmpty { get { return gitLockEntries.Count == 0; } }
 
         public GitLockEntry SelectedEntry
@@ -69,8 +71,8 @@ namespace GitHub.Unity
             {
                 selectedEntry = value;
 
-                var activeObject = selectedEntry != null && selectedEntry.GitLock != GitLock.Default
-                    ? AssetDatabase.LoadMainAssetAtPath(selectedEntry.GitLock.Path.MakeAbsolute().RelativeTo(EntryPoint.Environment.UnityProjectPath))
+                var activeObject = selectedEntry != null && selectedEntry.GitLock != GitLock.Default && projectPath.IsInitialized
+                    ? AssetDatabase.LoadMainAssetAtPath(selectedEntry.GitLock.Path.MakeAbsolute().RelativeTo(projectPath))
                     : null;
 
                 lastActivatedObject = activeObject;
@@ -235,7 +237,7 @@ namespace GitHub.Unity
 
                 var gitLockEntry = new GitLockEntry(gitLock, gitFileStatus);
                 LoadIcon(gitLockEntry, true);
-                var path = gitLock.Path.MakeAbsolute().RelativeTo(EntryPoint.Environment.UnityProjectPath);
+                var path = gitLock.Path.MakeAbsolute().RelativeTo(projectPath);
                 var assetGuid = AssetDatabase.AssetPathToGUID(path);
                 if (!string.IsNullOrEmpty(assetGuid))
                 {
@@ -610,6 +612,7 @@ namespace GitHub.Unity
                 locksControl = new LocksControl();
             }
 
+            locksControl.projectPath = Environment.UnityProjectPath;
             locksControl.Load(lockedFiles, gitStatusEntries);
         }
         public override void OnSelectionChange()


### PR DESCRIPTION
There's a potential for Environment to be initialized off the main thread in some cases (not sure exactly how, but #783 has an exception about it so it can definitely happen), so make sure everything depends
on it being instantiated first.

Also clean up some confusing properties.

This needs testing to ensure it hasn't broken anything.