### PR TITLE
isBusy should not be serialized

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -23,6 +23,7 @@ namespace GitHub.Unity
         [SerializeField] private bool currentLocksHasUpdate;
 
         [NonSerialized] private GUIContent discardGuiContent;
+        [NonSerialized] private bool isBusy;
 
         [SerializeField] private string commitBody = "";
         [SerializeField] private string commitMessage = "";
@@ -39,7 +40,6 @@ namespace GitHub.Unity
         [SerializeField] private CacheUpdateEvent lastCurrentBranchChangedEvent;
         [SerializeField] private CacheUpdateEvent lastStatusEntriesChangedEvent;
         [SerializeField] private CacheUpdateEvent lastLocksChangedEvent;
-        [SerializeField] private bool isBusy;
 
         public override void OnEnable()
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
@@ -372,6 +372,8 @@ namespace GitHub.Unity
     [Serializable]
     class LocksView : Subview
     {
+        [NonSerialized] private bool isBusy;
+
         [SerializeField] private bool currentStatusEntriesHasUpdate;
         [SerializeField] private bool currentLocksHasUpdate;
         [SerializeField] private bool currentUserHasUpdate;
@@ -382,7 +384,6 @@ namespace GitHub.Unity
         [SerializeField] private List<GitLock> lockedFiles = new List<GitLock>();
         [SerializeField] private List<GitStatusEntry> gitStatusEntries = new List<GitStatusEntry>();
         [SerializeField] private string currentUsername;
-        [SerializeField] private bool isBusy;
         [SerializeField] private GUIContent unlockFileMenuContent = new GUIContent(Localization.UnlockFileMenuItem);
         [SerializeField] private GUIContent forceUnlockFileMenuContent = new GUIContent(Localization.ForceUnlockFileMenuItem);
 


### PR DESCRIPTION
Otherwise the UI might get locked out if Unity reloads in the middle of an operation