### PR TITLE
Validating the GitLock cache whenever any cache object is refreshed

### DIFF
--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -188,6 +188,9 @@ namespace GitHub.Unity
         {
             var cache = cacheContainer.GetCache(cacheType);
             cache.InvalidateData();
+
+            // Ensuring that the GitLock cache is kept up to date
+            cacheContainer.GetCache(CacheType.GitLocks).ValidateData();
         }
 
         private void CacheHasBeenInvalidated(CacheType cacheType)


### PR DESCRIPTION
Since the git locks have so client side data for us to determine we should explicitly invalidate the data.
We are going to verify that the cache data is valid whenever any other cache object is being invalidated.
This should cover the issue without creating an explicit timer.

Fixes #785