### PR TITLE
Refactor how we run tasks synchronously so that TPL tasks aren't broken

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -16,7 +16,7 @@ namespace GitHub.Unity
         private Progress progress = new Progress(TaskBase.Default);
         protected bool isBusy;
         private bool firstRun;
-        protected bool FirstRun { get { return firstRun; } set { firstRun = value; } }        
+        protected bool FirstRun { get { return firstRun; } set { firstRun = value; } }
         private Guid instanceId;
         protected Guid InstanceId { get { return instanceId; } set { instanceId = value; } }
 
@@ -75,7 +75,7 @@ namespace GitHub.Unity
                         var getEnvPath = new SimpleProcessTask(TaskManager.Token, "bash".ToNPath(), "-c \"/usr/libexec/path_helper\"")
                                    .Configure(ProcessManager, dontSetupGit: true)
                                    .Catch(e => true); // make sure this doesn't throw if the task fails
-                        var path = getEnvPath.RunWithReturn(true);
+                        var path = getEnvPath.RunSynchronously();
                         if (getEnvPath.Successful)
                         {
                             Logger.Trace("Existing Environment Path Original:{0} Updated:{1}", Environment.Path, path);
@@ -194,7 +194,7 @@ namespace GitHub.Unity
                             Logger.Error(e, "Error running lfs install");
                             return true;
                         })
-                        .RunWithReturn(true);
+                        .RunSynchronously();
                 }
 
                 if (Environment.IsWindows)
@@ -204,7 +204,7 @@ namespace GitHub.Unity
                         {
                             Logger.Error(e, "Error getting the credential helper");
                             return true;
-                        }).RunWithReturn(true);
+                        }).RunSynchronously();
 
                     if (string.IsNullOrEmpty(credentialHelper))
                     {
@@ -215,7 +215,7 @@ namespace GitHub.Unity
                                 Logger.Error(e, "Error setting the credential helper");
                                 return true;
                             })
-                            .RunWithReturn(true);
+                            .RunSynchronously();
                     }
                 }
             }
@@ -238,21 +238,21 @@ namespace GitHub.Unity
 
                     var filesForInitialCommit = new List<string> { gitignore, gitAttrs, assetsGitignore };
 
-                    GitClient.Init().RunWithReturn(true);
+                    GitClient.Init().RunSynchronously();
                     progress.UpdateProgress(10, 100, "Initializing...");
 
                     ConfigureMergeSettings();
                     progress.UpdateProgress(20, 100, "Initializing...");
 
-                    GitClient.LfsInstall().RunWithReturn(true);
+                    GitClient.LfsInstall().RunSynchronously();
                     progress.UpdateProgress(30, 100, "Initializing...");
 
                     AssemblyResources.ToFile(ResourceType.Generic, ".gitignore", targetPath, Environment);
                     AssemblyResources.ToFile(ResourceType.Generic, ".gitattributes", targetPath, Environment);
                     assetsGitignore.CreateFile();
-                    GitClient.Add(filesForInitialCommit).RunWithReturn(true);
+                    GitClient.Add(filesForInitialCommit).RunSynchronously();
                     progress.UpdateProgress(60, 100, "Initializing...");
-                    GitClient.Commit("Initial commit", null).RunWithReturn(true);
+                    GitClient.Commit("Initial commit", null).RunSynchronously();
                     progress.UpdateProgress(70, 100, "Initializing...");
                     Environment.InitializeRepository();
                     UsageTracker.IncrementProjectsInitialized();
@@ -287,12 +287,12 @@ namespace GitHub.Unity
             GitClient.SetConfig("merge.unityyamlmerge.cmd", yamlMergeCommand, GitConfigSource.Local).Catch(e => {
                 Logger.Error(e, "Error setting merge.unityyamlmerge.cmd");
                 return true;
-            }).RunWithReturn(true);
+            }).RunSynchronously();
 
             GitClient.SetConfig("merge.unityyamlmerge.trustExitCode", "false", GitConfigSource.Local).Catch(e => {
                 Logger.Error(e, "Error setting merge.unityyamlmerge.trustExitCode");
                 return true;
-            }).RunWithReturn(true);
+            }).RunSynchronously();
         }
 
         public void RestartRepository()

--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -138,7 +138,7 @@ namespace GitHub.Unity
         {
             Guard.ArgumentNotNull(hostAddress, nameof(hostAddress));
 
-            return new ActionTask(keychain.Clear(hostAddress, true)) { Message = "Signing out" }.Start();
+            return new TPLTask(keychain.Clear(hostAddress, true)) { Message = "Signing out" }.Start();
         }
 
         private async Task<LoginResultData> TryLogin(

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -106,7 +106,7 @@ namespace GitHub.Unity
                 var gitPath = new FindExecTask("git", cancellationToken)
                     .Configure(processManager, dontSetupGit: true)
                     .Catch(e => true)
-                    .RunWithReturn(true);
+                    .RunSynchronously();
                 state.GitExecutablePath = gitPath;
                 state = ValidateGitVersion(state);
                 if (state.GitIsValid)
@@ -122,7 +122,7 @@ namespace GitHub.Unity
                 var gitLfsPath = new FindExecTask("git-lfs", cancellationToken)
                     .Configure(processManager, dontSetupGit: true)
                     .Catch(e => true)
-                    .RunWithReturn(true);
+                    .RunSynchronously();
                 state.GitLfsExecutablePath = gitLfsPath;
                 state = ValidateGitLfsVersion(state);
                 if (state.GitLfsIsValid)
@@ -159,7 +159,7 @@ namespace GitHub.Unity
             var version = new GitVersionTask(cancellationToken)
                 .Configure(processManager, state.GitExecutablePath, dontSetupGit: true)
                 .Catch(e => true)
-                .RunWithReturn(true);
+                .RunSynchronously();
             state.GitIsValid = version >= Constants.MinimumGitVersion;
             state.GitVersion = version;
             return state;
@@ -175,7 +175,7 @@ namespace GitHub.Unity
             var version = new ProcessTask<TheVersion>(cancellationToken, "version", new LfsVersionOutputProcessor())
                     .Configure(processManager, state.GitLfsExecutablePath, dontSetupGit: true)
                     .Catch(e => true)
-                    .RunWithReturn(true);
+                    .RunSynchronously();
             state.GitLfsIsValid = version >= Constants.MinimumGitLfsVersion;
             state.GitLfsVersion = version;
             return state;
@@ -244,7 +244,7 @@ namespace GitHub.Unity
             if (state.GitZipExists && state.GitLfsZipExists)
                 return state;
 
-            var downloader = new Downloader();
+            var downloader = new Downloader(environment.FileSystem);
             downloader.Catch(e =>
                 {
                     LogHelper.Trace(e, "Failed to download");
@@ -255,7 +255,7 @@ namespace GitHub.Unity
                 downloader.QueueDownload(state.GitPackage.Uri, installDetails.ZipPath);
             if (!state.GitLfsZipExists && !state.GitLfsIsValid && state.GitLfsPackage != null)
                 downloader.QueueDownload(state.GitLfsPackage.Uri, installDetails.ZipPath);
-            downloader.RunWithReturn(true);
+            downloader.RunSynchronously();
 
             state.GitZipExists = installDetails.GitZipPath.FileExists();
             state.GitLfsZipExists = installDetails.GitLfsZipPath.FileExists();
@@ -295,7 +295,7 @@ namespace GitHub.Unity
                         return true;
                     });
                 unzipTask.Progress(p => Progress.UpdateProgress(40 + (long)(20 * p.Percentage), 100, unzipTask.Message));
-                var path = unzipTask.RunWithReturn(true);
+                var path = unzipTask.RunSynchronously();
                 var target = state.GitInstallationPath;
                 if (unzipTask.Successful)
                 {
@@ -320,7 +320,7 @@ namespace GitHub.Unity
                         return true;
                     });
                 unzipTask.Progress(p => Progress.UpdateProgress(60 + (long)(20 * p.Percentage), 100, unzipTask.Message));
-                var path = unzipTask.RunWithReturn(true);
+                var path = unzipTask.RunSynchronously();
                 var target = state.GitLfsInstallationPath;
                 if (unzipTask.Successful)
                 {

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -38,7 +38,7 @@ namespace GitHub.Unity
                     tempZipExtractPath, sharpZipLibHelper,
                     fileSystem)
                     .Catch(e => { Logger.Error(e, "Error extracting octorun"); return true; });
-            var extractPath = unzipTask.RunWithReturn(true);
+            var extractPath = unzipTask.RunSynchronously();
             if (unzipTask.Successful)
                 path = MoveOctorun(extractPath.Combine("octorun"));
             return path;

--- a/src/GitHub.Api/Installer/UnzipTask.cs
+++ b/src/GitHub.Api/Installer/UnzipTask.cs
@@ -26,12 +26,9 @@ namespace GitHub.Unity
             return base.RunWithReturn(success);
         }
 
-        public override NPath RunWithReturn(bool success)
+        protected override NPath RunWithReturn(bool success)
         {
             var ret = BaseRun(success);
-
-            RaiseOnStart();
-
             try
             {
                 ret = RunUnzip(success);
@@ -39,11 +36,7 @@ namespace GitHub.Unity
             catch (Exception ex)
             {
                 if (!RaiseFaultHandlers(ex))
-                    throw;
-            }
-            finally
-            {
-                RaiseOnEnd(ret);
+                    throw exception;
             }
             return ret;
         }

--- a/src/GitHub.Api/Primitives/Package.cs
+++ b/src/GitHub.Api/Primitives/Package.cs
@@ -41,7 +41,7 @@ namespace GitHub.Unity
                         LogHelper.Warning(@"Error downloading package feed:{0} ""{1}"" Message:""{2}""", packageFeed, ex.GetType().ToString(), ex.GetExceptionMessageShort());
                         return true;
                     })
-                    .RunWithReturn(true);
+                    .RunSynchronously();
 
                 if (feed.IsInitialized)
                     environment.UserSettings.Set<DateTimeOffset>(key, now);

--- a/src/GitHub.Api/Tasks/DownloadTask.cs
+++ b/src/GitHub.Api/Tasks/DownloadTask.cs
@@ -49,12 +49,9 @@ namespace GitHub.Unity
             return base.RunWithReturn(success);
         }
 
-        public override NPath RunWithReturn(bool success)
+        protected override NPath RunWithReturn(bool success)
         {
             var result = base.RunWithReturn(success);
-
-            RaiseOnStart();
-
             try
             {
                 result = RunDownload(success);
@@ -62,13 +59,8 @@ namespace GitHub.Unity
             catch (Exception ex)
             {
                 if (!RaiseFaultHandlers(ex))
-                    throw;
+                    throw exception;
             }
-            finally
-            {
-                RaiseOnEnd(result);
-            }
-
             return result;
         }
 
@@ -76,7 +68,6 @@ namespace GitHub.Unity
         /// The actual functionality to download with optional hash verification
         /// subclasses that wish to return the contents of the downloaded file
         /// or do something else with it can override this instead of RunWithReturn.
-        /// If you do, you must call RaiseOnStart()/RaiseOnEnd()
         /// </summary>
         /// <param name="success"></param>
         /// <returns></returns>

--- a/src/GitHub.Api/Tasks/ProcessTask.cs
+++ b/src/GitHub.Api/Tasks/ProcessTask.cs
@@ -279,12 +279,6 @@ namespace GitHub.Unity
             Name = ProcessArguments;
         }
 
-        protected override void RaiseOnStart()
-        {
-            base.RaiseOnStart();
-            OnStartProcess?.Invoke(this);
-        }
-
         protected override void RaiseOnEnd()
         {
             base.RaiseOnEnd();
@@ -295,12 +289,12 @@ namespace GitHub.Unity
         {
         }
 
-        public override T RunWithReturn(bool success)
+        protected override T RunWithReturn(bool success)
         {
             var result = base.RunWithReturn(success);
 
             wrapper = new ProcessWrapper(Name, Process, outputProcessor,
-                RaiseOnStart,
+                () => OnStartProcess?.Invoke(this),
                 () =>
                 {
                     try
@@ -322,15 +316,8 @@ namespace GitHub.Unity
                             thrownException = new ProcessException(thrownException.GetExceptionMessage(), ex);
                     }
 
-                    try
-                    {
-                        if (thrownException != null && !RaiseFaultHandlers(thrownException))
-                            throw thrownException;
-                    }
-                    finally
-                    {
-                        RaiseOnEnd(result);
-                    }
+                    if (thrownException != null && !RaiseFaultHandlers(thrownException))
+                        throw thrownException;
                 },
                 (ex, error) =>
                 {
@@ -410,12 +397,6 @@ namespace GitHub.Unity
             ProcessName = psi.FileName;
         }
 
-        protected override void RaiseOnStart()
-        {
-            base.RaiseOnStart();
-            OnStartProcess?.Invoke(this);
-        }
-
         protected override void RaiseOnEnd()
         {
             base.RaiseOnEnd();
@@ -431,12 +412,12 @@ namespace GitHub.Unity
             outputProcessor.OnEntry += x => RaiseOnData(x);
         }
 
-        public override List<T> RunWithReturn(bool success)
+        protected override List<T> RunWithReturn(bool success)
         {
             var result = base.RunWithReturn(success);
 
             wrapper = new ProcessWrapper(Name, Process, outputProcessor,
-                RaiseOnStart,
+                () => OnStartProcess?.Invoke(this),
                 () =>
                 {
                     try
@@ -457,15 +438,8 @@ namespace GitHub.Unity
                             thrownException = new ProcessException(thrownException.GetExceptionMessage(), ex);
                     }
 
-                    try
-                    {
-                        if (thrownException != null && !RaiseFaultHandlers(thrownException))
-                            throw thrownException;
-                    }
-                    finally
-                    {
-                        RaiseOnEnd(result);
-                    }
+                    if (thrownException != null && !RaiseFaultHandlers(thrownException))
+                        throw thrownException;
                 },
                 (ex, error) =>
                 {

--- a/src/GitHub.Api/Tasks/TaskExtensions.cs
+++ b/src/GitHub.Api/Tasks/TaskExtensions.cs
@@ -68,7 +68,7 @@ namespace GitHub.Unity
 
         public static ITask<T> Then<T>(this ITask task, Task<T> continuation, TaskAffinity affinity = TaskAffinity.Concurrent, TaskRunOptions runOptions = TaskRunOptions.OnSuccess)
         {
-            var cont = new FuncTask<T>(continuation) { Affinity = affinity, Name = $"ThenAsync<{typeof(T)}>" };
+            var cont = new TPLTask<T>(continuation) { Affinity = affinity, Name = $"ThenAsync<{typeof(T)}>" };
             return task.Then(cont, runOptions);
         }
 

--- a/src/tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/tests/IntegrationTests/BaseIntegrationTest.cs
@@ -147,7 +147,7 @@ namespace IntegrationTests
             var extractPath = tempZipExtractPath.Combine("git").CreateDirectory();
             var path = new UnzipTask(TaskManager.Token, installDetails.GitZipPath, extractPath, null, Environment.FileSystem)
                 .Catch(e => true)
-                .RunWithReturn(true);
+                .RunSynchronously();
             var source = path;
             installDetails.GitInstallationPath.EnsureParentDirectoryExists();
             source.Move(installDetails.GitInstallationPath);
@@ -155,7 +155,7 @@ namespace IntegrationTests
             extractPath = tempZipExtractPath.Combine("git-lfs").CreateDirectory();
             path = new UnzipTask(TaskManager.Token, installDetails.GitLfsZipPath, extractPath, null, Environment.FileSystem)
                 .Catch(e => true)
-                .RunWithReturn(true);
+                .RunSynchronously();
             installDetails.GitLfsInstallationPath.EnsureParentDirectoryExists();
             path.Move(installDetails.GitLfsInstallationPath);
         }

--- a/src/tests/IntegrationTests/Git/GitClientTests.cs
+++ b/src/tests/IntegrationTests/Git/GitClientTests.cs
@@ -25,7 +25,7 @@ namespace IntegrationTests
 
             InitializePlatformAndEnvironment(TestRepoMasterCleanSynchronized);
 
-            var result = GitClient.Version().RunWithReturn(true);
+            var result = GitClient.Version().RunSynchronously();
             var expected = TheVersion.Parse("2.17.0");
             result.Major.Should().Be(expected.Major);
             result.Minor.Should().Be(expected.Minor);
@@ -40,7 +40,7 @@ namespace IntegrationTests
 
             InitializePlatformAndEnvironment(TestRepoMasterCleanSynchronized);
 
-            var result = GitClient.LfsVersion().RunWithReturn(true);
+            var result = GitClient.LfsVersion().RunSynchronously();
             var expected = TheVersion.Parse("2.4.0");
             result.Should().Be(expected);
         }

--- a/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
+++ b/src/tests/IntegrationTests/Installer/GitInstallerTests.cs
@@ -25,7 +25,7 @@ namespace IntegrationTests
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            server = new TestWebServer.HttpServer(SolutionDirectory.Combine("files"));
+            server = new TestWebServer.HttpServer(SolutionDirectory.Combine("files"), 50000);
             Task.Factory.StartNew(server.Start);
             ApplicationConfiguration.WebTimeout = 10000;
         }
@@ -174,9 +174,9 @@ namespace IntegrationTests
             var gitLfsInstallationPath = TestBasePath.Combine("GitInstall").Combine(GitInstaller.GitInstallDetails.GitLfsDirectory);
 
             var gitZipUri = new UriString($"http://localhost:{server.Port}/unity/git/windows/git-slim.zip");
-            var downloader = new Downloader();
+            var downloader = new Downloader(Environment.FileSystem);
             downloader.QueueDownload(gitZipUri, tempZipExtractPath);
-            downloader.RunWithReturn(true);
+            downloader.RunSynchronously();
 
             var gitExtractPath = tempZipExtractPath.Combine("git").CreateDirectory();
             ZipHelper.Instance.Extract(tempZipExtractPath.Combine(gitZipUri.Filename), gitExtractPath, TaskManager.Token, null);
@@ -209,9 +209,9 @@ namespace IntegrationTests
             var customGitInstall = TestBasePath.Combine("CustomGitInstall").Combine(GitInstaller.GitInstallDetails.GitDirectory);
 
             var gitZipUri = new UriString($"http://localhost:{server.Port}/unity/git/windows/git-slim.zip");
-            var downloader = new Downloader();
+            var downloader = new Downloader(Environment.FileSystem);
             downloader.QueueDownload(gitZipUri, tempZipExtractPath);
-            downloader.RunWithReturn(true);
+            downloader.RunSynchronously();
 
             var gitExtractPath = tempZipExtractPath.Combine("git").CreateDirectory();
             ZipHelper.Instance.Extract(tempZipExtractPath.Combine(gitZipUri.Filename), gitExtractPath, TaskManager.Token, null);

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -1011,7 +1011,7 @@ namespace IntegrationTests
         public void FailingTasksThrowCorrectlyEvenIfFinallyIsPresent()
         {
             var queue = new TaskQueue();
-            var task = new ActionTask(Token, () => throw new Exception())
+            var task = new ActionTask(Token, () => { throw new Exception(); })
                 .Finally((s, e) => { });
             queue.Queue(task);
             Assert.Throws<Exception>(() => queue.RunSynchronously());

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -770,7 +770,7 @@ namespace IntegrationTests
         {
             var runOrder = new List<string>();
             var task = new Task(() => runOrder.Add($"ran"));
-            var act = new ActionTask(task) { Affinity = TaskAffinity.Exclusive };
+            var act = new TPLTask(task) { Affinity = TaskAffinity.Exclusive };
             await act.Start().Task;
             CollectionAssert.AreEqual(new string[] { $"ran" }, runOrder);
         }
@@ -816,19 +816,14 @@ namespace IntegrationTests
                 : base(token, action)
             {}
 
-            public TaskBase Test_GetTopMostTask()
+            public TaskBase Test_GetFirstStartableTask()
             {
-                return base.GetTopMostTask();
-            }
-
-            public TaskBase Test_GetTopMostTaskInCreatedState()
-            {
-                return base.GetTopMostTaskInCreatedState();
+                return base.GetTopMostStartableTask();
             }
         }
 
         [Test]
-        public async Task GetTopMostTaskInCreatedState()
+        public async Task GetTopOfChain_ReturnsTopMostInCreatedState()
         {
             var task1 = new ActionTask(Token, () => { });
             await task1.StartAwait();
@@ -837,20 +832,45 @@ namespace IntegrationTests
 
             task1.Then(task2).Then(task3);
 
-            var top = task3.Test_GetTopMostTaskInCreatedState();
+            var top = task3.GetTopOfChain();
             Assert.AreSame(task2, top);
         }
 
         [Test]
-        public void GetTopMostTask()
+        public void GetTopOfChain_ReturnsTopTaskWhenNotStarted()
         {
-            var task1 = new ActionTask(TaskEx.FromResult(true));
+            var task1 = new TPLTask(TaskEx.FromResult(true));
             var task2 = new TestActionTask(Token, _ => { });
             var task3 = new TestActionTask(Token, _ => { });
 
             task1.Then(task2).Then(task3);
 
-            var top = task3.Test_GetTopMostTask();
+            var top = task3.GetTopOfChain();
+            Assert.AreSame(task1, top);
+        }
+
+        public async Task GetFirstStartableTask_ReturnsNullWhenItsAlreadyStarted()
+        {
+            var task1 = new ActionTask(Token, () => { });
+            await task1.StartAwait();
+            var task2 = new TestActionTask(Token, _ => { });
+            var task3 = new TestActionTask(Token, _ => { });
+
+            task1.Then(task2).Then(task3);
+
+            var top = task3.Test_GetFirstStartableTask();
+            Assert.AreSame(task2, top);
+        }
+
+        public void GetFirstStartableTask_ReturnsTopTaskWhenNotStarted()
+        {
+            var task1 = new ActionTask(Token, () => { });
+            var task2 = new TestActionTask(Token, _ => { });
+            var task3 = new TestActionTask(Token, _ => { });
+
+            task1.Then(task2).Then(task3);
+
+            var top = task3.Test_GetFirstStartableTask();
             Assert.AreSame(task1, top);
         }
 
@@ -860,7 +880,7 @@ namespace IntegrationTests
             var callOrder = new List<string>();
             var dependsOrder = new List<ITask>();
 
-            var innerChainTask1 = new ActionTask(TaskEx.FromResult(LogAndReturnResult(callOrder, "chain2 completed1", true)));
+            var innerChainTask1 = new TPLTask(TaskEx.FromResult(LogAndReturnResult(callOrder, "chain2 completed1", true)));
             var innerChainTask2 = innerChainTask1.Then(_ =>
                 {
                     callOrder.Add("chain2 FuncTask<string>");
@@ -955,6 +975,83 @@ namespace IntegrationTests
         {
             callOrder.Add(msg);
             return result;
+        }
+    }
+
+    [TestFixture]
+    class TaskQueueTests : BaseTest
+    {
+        [Test]
+        public void ConvertsTaskResultsCorrectly()
+        {
+            var vals = new string[] { "2.1", Math.PI.ToString(), "1" };
+            var expected = new double[] { 2.1, Math.PI, 1.0 };
+            var queue = new TaskQueue<string, double>(task => Double.Parse(task.Result));
+            vals.All(s => { queue.Queue(new TPLTask<string>(TaskEx.FromResult(s))); return true; });
+            var ret = queue.RunSynchronously();
+            Assert.AreEqual(expected.Join(","), ret.Join(","));
+        }
+
+        [Test]
+        public void ThrowsIfCannotConvert()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TaskQueue<string, double>());
+            // NPath has an implicit operator to string, but we cannot verify this without using
+            // reflection, so a converter is required
+            Assert.Throws<ArgumentNullException>(() => new TaskQueue<NPath, string>());
+        }
+
+        [Test]
+        public void DoesNotThrowIfItCanConvert()
+        {
+            Assert.DoesNotThrow(() => new TaskQueue<DownloadTask, ITask>());
+        }
+
+        [Test]
+        public void FailingTasksThrowCorrectlyEvenIfFinallyIsPresent()
+        {
+            var queue = new TaskQueue();
+            var task = new ActionTask(Token, () => throw new Exception())
+                .Finally((s, e) => { });
+            queue.Queue(task);
+            Assert.Throws<Exception>(() => queue.RunSynchronously());
+        }
+
+        [Test]
+        public async Task DoubleSchedulingStartsOnlyOnce()
+        {
+            var runOrder = new List<string>();
+            var queue = new TaskQueue();
+            var task1 = new FuncTask<string>(Token, () =>
+                {
+                    runOrder.Add("1");
+                    return "2";
+                });
+            task1.OnStart += _ => runOrder.Add("start 1");
+            task1.OnEnd += (a, b, c, d) => runOrder.Add("end 1");
+            var task2 = new FuncTask<string, string>(Token, (_, str) =>
+                {
+                    runOrder.Add(str);
+                    return "3";
+                });
+            task2.OnStart += _ => runOrder.Add("start 2");
+            task2.OnEnd += (a, b, c, d) => runOrder.Add("end 2");
+            var task3 = new FuncTask<string, string>(Token, (_, str) =>
+            {
+                runOrder.Add(str);
+                return "4";
+            });
+            task3.OnStart += _ => runOrder.Add("start 3");
+            task3.OnEnd += (a, b, c, d) => runOrder.Add("end 3");
+
+            queue.Queue(task1.Then(task2).Then(task3));
+            await queue.StartAwait();
+            var expected = new string[] {
+                "start 1", "1", "end 1",
+                "start 2", "2", "end 2",
+                "start 3", "3", "end 3",
+            };
+            Assert.AreEqual(expected.Join(","), runOrder.Join(","));
         }
     }
 


### PR DESCRIPTION
Our task system uses TPL tasks (System.Threading.Tasks.Task) under the hood (every ITask really is a TPL task whose body is the callback or Run/RunWithReturn/RunWithData method override), so when we run one of our ITask, what we're really doing is scheduling the underlying TPL task to be executed. If we want to run the ITask synchronously, it's straightforward to just execute the Run/RunWithReturn/RunWithData method that does the actual work.

Because of this, we also have an overload to pass in an existing TPL task into an ITask, so that we can also run async/await task types in our threading system (so that we can control the thread these tasks are going to be run in, given that async/await has no threading control model).

The problem with allowing a TPL task to be set directly into an ITask is that the TPL task wasn't set up in a way that exposed a Run/RunWithReturn/RunWithData method that could be called synchronously.This PR moves things around so that instead of calling directly the Run/RunWithReturn/RunWithData methods, there is one RunSynchronously method that does the right thing for all task types, regardless of how they're initialized. This has the added benefit that the exact same method (`RunSynchronously`) is executed independent of who's calling it - if the ITask is running on the scheduler, `RunSynchronously` is the task body that the scheduler will execute, and if the user wants to run it in thread, they can call it directly.