### PR TITLE
Don't trample an existing SynchronizationContext

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using GitHub.Logging;
 using System.Runtime.Serialization;
 using System.Text;
@@ -45,115 +44,17 @@ namespace GitHub.Unity
             return loginManager.Logout(host);
         }
 
-        public async Task CreateRepository(string name, string description, bool isPrivate, Action<GitHubRepository, Exception> callback, string organization = null)
+        public void CreateRepository(string name, string description, bool isPrivate, Action<GitHubRepository, Exception> callback, string organization = null)
         {
             Guard.ArgumentNotNull(callback, "callback");
-            try
-            {
-                var repository = await CreateRepositoryInternal(name, organization, description, isPrivate);
-                callback(repository, null);
-            }
-            catch (Exception e)
-            {
-                callback(null, e);
-            }
-        }
 
-        public async Task GetOrganizations(Action<Organization[]> onSuccess, Action<Exception> onError = null)
-        {
-            Guard.ArgumentNotNull(onSuccess, nameof(onSuccess));
-            await GetOrganizationInternal(onSuccess, onError);
-        }
-
-        public async Task GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null)
-        {
-            Guard.ArgumentNotNull(onSuccess, nameof(onSuccess));
-            try
+            new FuncTask<GitHubRepository>(taskManager.Token, () =>
             {
-                var user = await GetCurrentUser();
-                onSuccess(user);
-            }
-            catch (Exception e)
-            {
-                onError?.Invoke(e);
-            }
-        }
-
-        public async Task Login(string username, string password, Action<LoginResult> need2faCode, Action<bool, string> result)
-        {
-            Guard.ArgumentNotNull(need2faCode, "need2faCode");
-            Guard.ArgumentNotNull(result, "result");
-
-            LoginResultData res = null;
-            try
-            {
-                res = await loginManager.Login(OriginalUrl, username, password);
-            }
-            catch (Exception ex)
-            {
-                logger.Warning(ex);
-                result(false, ex.Message);
-                return;
-            }
-
-            if (res.Code == LoginResultCodes.CodeRequired)
-            {
-                var resultCache = new LoginResult(res, result, need2faCode);
-                need2faCode(resultCache);
-            }
-            else
-            {
-                result(res.Code == LoginResultCodes.Success, res.Message);
-            }
-        }
-
-        public async Task ContinueLogin(LoginResult loginResult, string code)
-        {
-            LoginResultData result = null;
-            try
-            {
-                result = await loginManager.ContinueLogin(loginResult.Data, code);
-            }
-            catch (Exception ex)
-            {
-                loginResult.Callback(false, ex.Message);
-                return;
-            }
-            if (result.Code == LoginResultCodes.CodeFailed)
-            {
-                loginResult.TwoFACallback(new LoginResult(result, loginResult.Callback, loginResult.TwoFACallback));
-            }
-            loginResult.Callback(result.Code == LoginResultCodes.Success, result.Message);
-        }
-
-        private async Task<GitHubUser> GetCurrentUser()
-        {
-            //TODO: ONE_USER_LOGIN This assumes we only support one login
-            var keychainConnection = keychain.Connections.FirstOrDefault();
-            if (keychainConnection == null)
-                throw new KeychainEmptyException();
-
-            var keychainAdapter = await GetValidatedKeychainAdapter(keychainConnection);
-
-            // we can't trust that the system keychain has the username filled out correctly.
-            // if it doesn't, we need to grab the username from the server and check it
-            // unfortunately this means that things will be slower when the keychain doesn't have all the info
-            if (keychainConnection.User == null || keychainAdapter.Credential.Username != keychainConnection.Username)
-            {
-                keychainConnection.User = await GetValidatedGitHubUser(keychainConnection, keychainAdapter);
-            }
-            return keychainConnection.User;
-        }
-
-        private async Task<GitHubRepository> CreateRepositoryInternal(string repositoryName, string organization, string description, bool isPrivate)
-        {
-            try
-            {
-                var user = await GetCurrentUser();
+                var user = GetCurrentUser();
                 var keychainAdapter = keychain.Connect(OriginalUrl);
 
                 var command = new StringBuilder("publish -r \"");
-                command.Append(repositoryName);
+                command.Append(name);
                 command.Append("\"");
 
                 if (!string.IsNullOrEmpty(description))
@@ -176,10 +77,10 @@ namespace GitHub.Unity
                 }
 
                 var octorunTask = new OctorunTask(taskManager.Token, nodeJsExecutablePath, octorunScriptPath, command.ToString(),
-                    user: user.Login, userToken: keychainAdapter.Credential.Token)
+                        user: user.Login, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
-                var ret = await octorunTask.StartAwait();
+                var ret = octorunTask.RunSynchronously();
                 if (ret.IsSuccess && ret.Output.Length == 2)
                 {
                     return new GitHubRepository
@@ -190,26 +91,33 @@ namespace GitHub.Unity
                 }
 
                 throw new ApiClientException(ret.GetApiErrorMessage() ?? "Publish failed");
-            }
-            catch (Exception ex)
+            })
+            .FinallyInUI((success, ex, repository) =>
             {
-                logger.Error(ex, "Error Creating Repository");
-                throw;
-            }
+                if (success)
+                    callback(repository, null);
+                else
+                {
+                    logger.Error(ex, "Error creating repository");
+                    callback(null, ex);
+                }
+            })
+            .Start();
         }
 
-        private async Task GetOrganizationInternal(Action<Organization[]> onSuccess, Action<Exception> onError = null)
+        public void GetOrganizations(Action<Organization[]> onSuccess, Action<Exception> onError = null)
         {
-            try
+            Guard.ArgumentNotNull(onSuccess, nameof(onSuccess));
+            new FuncTask<Organization[]>(taskManager.Token, () =>
             {
-                var user = await GetCurrentUser();
+                var user = GetCurrentUser();
                 var keychainAdapter = keychain.Connect(OriginalUrl);
 
                 var octorunTask = new OctorunTask(taskManager.Token, nodeJsExecutablePath, octorunScriptPath, "organizations",
                         user: user.Login, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
-                var ret = await octorunTask.StartAsAsync();
+                var ret = octorunTask.RunSynchronously();
                 if (ret.IsSuccess)
                 {
                     var organizations = new List<Organization>();
@@ -221,23 +129,109 @@ namespace GitHub.Unity
                             Login = ret.Output[i + 1]
                         });
                     }
-
-                    onSuccess(organizations.ToArray());
-                    return;
+                    return organizations.ToArray();
                 }
 
                 throw new ApiClientException(ret.GetApiErrorMessage() ?? "Error getting organizations");
-            }
-            catch (Exception ex)
+            })
+            .FinallyInUI((success, ex, orgs) =>
             {
-                logger.Error(ex, "Error Getting Organizations");
-                onError?.Invoke(ex);
-            }
+                if (success)
+                    onSuccess(orgs);
+                else
+                {
+                    logger.Error(ex, "Error Getting Organizations");
+                    onError?.Invoke(ex);
+                }
+            })
+            .Start();
         }
 
-        private async Task<IKeychainAdapter> GetValidatedKeychainAdapter(Connection keychainConnection)
+        public void GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null)
         {
-            var keychainAdapter = await keychain.Load(keychainConnection.Host);
+            Guard.ArgumentNotNull(onSuccess, nameof(onSuccess));
+            new FuncTask<GitHubUser>(taskManager.Token, GetCurrentUser)
+                .FinallyInUI((success, ex, user) =>
+                {
+                    if (success)
+                        onSuccess(user);
+                    else
+                        onError?.Invoke(ex);
+                })
+                .Start();
+        }
+
+        public void Login(string username, string password, Action<LoginResult> need2faCode, Action<bool, string> result)
+        {
+            Guard.ArgumentNotNull(need2faCode, "need2faCode");
+            Guard.ArgumentNotNull(result, "result");
+
+            new FuncTask<LoginResultData>(taskManager.Token,
+                () => loginManager.Login(OriginalUrl, username, password))
+                .FinallyInUI((success, ex, res) =>
+                {
+                    if (!success)
+                    {
+                        logger.Warning(ex);
+                        result(false, ex.Message);
+                        return;
+                    }
+
+                    if (res.Code == LoginResultCodes.CodeRequired)
+                    {
+                        var resultCache = new LoginResult(res, result, need2faCode);
+                        need2faCode(resultCache);
+                    }
+                    else
+                    {
+                        result(res.Code == LoginResultCodes.Success, res.Message);
+                    }
+                })
+                .Start();
+        }
+
+        public void ContinueLogin(LoginResult loginResult, string code)
+        {
+            new FuncTask<LoginResultData>(taskManager.Token,
+                () => loginManager.ContinueLogin(loginResult.Data, code))
+                .FinallyInUI((success, ex, result) =>
+                {
+                    if (!success)
+                    {
+                        loginResult.Callback(false, ex.Message);
+                        return;
+                    }
+                    if (result.Code == LoginResultCodes.CodeFailed)
+                    {
+                        loginResult.TwoFACallback(new LoginResult(result, loginResult.Callback, loginResult.TwoFACallback));
+                    }
+                    loginResult.Callback(result.Code == LoginResultCodes.Success, result.Message);
+                })
+                .Start();
+        }
+
+        private GitHubUser GetCurrentUser()
+        {
+            //TODO: ONE_USER_LOGIN This assumes we only support one login
+            var keychainConnection = keychain.Connections.FirstOrDefault();
+            if (keychainConnection == null)
+                throw new KeychainEmptyException();
+
+            var keychainAdapter = GetValidatedKeychainAdapter(keychainConnection);
+
+            // we can't trust that the system keychain has the username filled out correctly.
+            // if it doesn't, we need to grab the username from the server and check it
+            // unfortunately this means that things will be slower when the keychain doesn't have all the info
+            if (keychainConnection.User == null || keychainAdapter.Credential.Username != keychainConnection.Username)
+            {
+                keychainConnection.User = GetValidatedGitHubUser(keychainConnection, keychainAdapter);
+            }
+            return keychainConnection.User;
+        }
+
+        private IKeychainAdapter GetValidatedKeychainAdapter(Connection keychainConnection)
+        {
+            var keychainAdapter = keychain.Load(keychainConnection.Host);
             if (keychainAdapter == null)
                 throw new KeychainEmptyException();
 
@@ -255,7 +249,7 @@ namespace GitHub.Unity
             return keychainAdapter;
         }
 
-        private async Task<GitHubUser> GetValidatedGitHubUser(Connection keychainConnection, IKeychainAdapter keychainAdapter)
+        private GitHubUser GetValidatedGitHubUser(Connection keychainConnection, IKeychainAdapter keychainAdapter)
         {
             try
             {
@@ -263,7 +257,7 @@ namespace GitHub.Unity
                         user: keychainConnection.Username, userToken: keychainAdapter.Credential.Token)
                     .Configure(processManager);
 
-                var ret = await octorunTask.StartAsAsync();
+                var ret = octorunTask.RunSynchronously();
                 if (ret.IsSuccess)
                 {
                     var login = ret.Output[1];

--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -32,11 +32,7 @@ namespace GitHub.Unity
             this.taskManager = taskManager;
             this.nodeJsExecutablePath = nodeJsExecutablePath;
             this.octorunScriptPath = octorunScriptPath;
-            loginManager = new LoginManager(keychain,
-                processManager: processManager,
-                taskManager: taskManager,
-                nodeJsExecutablePath: nodeJsExecutablePath,
-                octorunScript: octorunScriptPath);
+            loginManager = new LoginManager(keychain, processManager, taskManager, nodeJsExecutablePath, octorunScriptPath);
         }
 
         public ITask Logout(UriString host)

--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -28,10 +28,10 @@ namespace GitHub.Unity
 
         public ApplicationManagerBase(SynchronizationContext synchronizationContext, IEnvironment environment)
         {
+            UIScheduler = ThreadingHelper.GetUIScheduler(synchronizationContext);
+
             SynchronizationContext = synchronizationContext;
-            SynchronizationContext.SetSynchronizationContext(SynchronizationContext);
             ThreadingHelper.SetUIThread();
-            UIScheduler = TaskScheduler.FromCurrentSynchronizationContext();
             ThreadingHelper.MainThreadScheduler = UIScheduler;
 
             Environment = environment;

--- a/src/GitHub.Api/Application/IApiClient.cs
+++ b/src/GitHub.Api/Application/IApiClient.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using System;
+﻿using System;
 
 namespace GitHub.Unity
 {
@@ -7,12 +6,12 @@ namespace GitHub.Unity
     {
         HostAddress HostAddress { get; }
         UriString OriginalUrl { get; }
-        Task CreateRepository(string name, string description, bool isPrivate,
+        void CreateRepository(string name, string description, bool isPrivate,
             Action<GitHubRepository, Exception> callback, string organization = null);
-        Task GetOrganizations(Action<Organization[]> onSuccess, Action<Exception> onError = null);
-        Task Login(string username, string password, Action<LoginResult> need2faCode, Action<bool, string> result);
-        Task ContinueLogin(LoginResult loginResult, string code);
+        void GetOrganizations(Action<Organization[]> onSuccess, Action<Exception> onError = null);
+        void Login(string username, string password, Action<LoginResult> need2faCode, Action<bool, string> result);
+        void ContinueLogin(LoginResult loginResult, string code);
         ITask Logout(UriString host);
-        Task GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null);
+        void GetCurrentUser(Action<GitHubUser> onSuccess, Action<Exception> onError = null);
     }
 }

--- a/src/GitHub.Api/Authentication/ICredentialManager.cs
+++ b/src/GitHub.Api/Authentication/ICredentialManager.cs
@@ -13,9 +13,9 @@ namespace GitHub.Unity
 
     public interface ICredentialManager
     {
-        Task<ICredential> Load(UriString host);
-        Task Save(ICredential cred);
-        Task Delete(UriString host);
+        ICredential Load(UriString host);
+        void Save(ICredential cred);
+        void Delete(UriString host);
         bool HasCredentials();
         ICredential CachedCredentials { get; }
     }

--- a/src/GitHub.Api/Authentication/IKeychain.cs
+++ b/src/GitHub.Api/Authentication/IKeychain.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
     public interface IKeychain
     {
         IKeychainAdapter Connect(UriString host);
-        Task<IKeychainAdapter> Load(UriString host);
-        Task Clear(UriString host, bool deleteFromCredentialManager);
-        Task Save(UriString host);
+        IKeychainAdapter Load(UriString host);
+        void Clear(UriString host, bool deleteFromCredentialManager);
+        void Save(UriString host);
         void SetCredentials(ICredential credential);
         void Initialize();
         Connection[] Connections { get; }

--- a/src/GitHub.Api/Authentication/ILoginManager.cs
+++ b/src/GitHub.Api/Authentication/ILoginManager.cs
@@ -17,8 +17,8 @@ namespace GitHub.Unity
         /// <exception cref="AuthorizationException">
         /// The login authorization failed.
         /// </exception>
-        Task<LoginResultData> Login(UriString host, string username, string password);
-        Task<LoginResultData> ContinueLogin(LoginResultData loginResultData, string twofacode);
+        LoginResultData Login(UriString host, string username, string password);
+        LoginResultData ContinueLogin(LoginResultData loginResultData, string twofacode);
 
         /// <summary>
         /// Logs out of GitHub server.

--- a/src/GitHub.Api/Authentication/Keychain.cs
+++ b/src/GitHub.Api/Authentication/Keychain.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using GitHub.Logging;
 
 namespace GitHub.Unity
@@ -100,18 +99,18 @@ namespace GitHub.Unity
             return FindOrCreateAdapter(host);
         }
 
-        public async Task<IKeychainAdapter> Load(UriString host)
+        public IKeychainAdapter Load(UriString host)
         {
             Guard.ArgumentNotNull(host, nameof(host));
 
             var keychainAdapter = FindOrCreateAdapter(host);
             var connection = GetConnection(host);
 
-            var keychainItem = await credentialManager.Load(host);
+            var keychainItem = credentialManager.Load(host);
             if (keychainItem == null)
             {
                 logger.Warning("Cannot load host from Credential Manager; removing from cache");
-                await Clear(host, false);
+                Clear(host, false);
                 keychainAdapter = null;
             }
             else
@@ -142,21 +141,21 @@ namespace GitHub.Unity
             LoadConnectionsFromDisk();
         }
 
-        public async Task Clear(UriString host, bool deleteFromCredentialManager)
+        public void Clear(UriString host, bool deleteFromCredentialManager)
         {
             Guard.ArgumentNotNull(host, nameof(host));
 
             RemoveConnection(host);
 
             //clear octokit credentials
-            await RemoveCredential(host, deleteFromCredentialManager);
+            RemoveCredential(host, deleteFromCredentialManager);
         }
 
-        public async Task Save(UriString host)
+        public void Save(UriString host)
         {
             Guard.ArgumentNotNull(host, nameof(host));
 
-            var keychainAdapter = await AddCredential(host);
+            var keychainAdapter = AddCredential(host);
             AddConnection(new Connection(host, keychainAdapter.Credential.Username));
         }
 
@@ -231,7 +230,7 @@ namespace GitHub.Unity
             return credentialAdapter;
         }
 
-        private async Task<KeychainAdapter> AddCredential(UriString host)
+        private KeychainAdapter AddCredential(UriString host)
         {
             var keychainAdapter = GetKeychainAdapter(host);
             if (string.IsNullOrEmpty(keychainAdapter.Credential.Token))
@@ -240,12 +239,12 @@ namespace GitHub.Unity
             }
 
             // saves credential in git credential manager (host, username, token)
-            await credentialManager.Delete(host);
-            await credentialManager.Save(keychainAdapter.Credential);
+            credentialManager.Delete(host);
+            credentialManager.Save(keychainAdapter.Credential);
             return keychainAdapter;
         }
 
-        private async Task RemoveCredential(UriString host, bool deleteFromCredentialManager)
+        private void RemoveCredential(UriString host, bool deleteFromCredentialManager)
         {
             KeychainAdapter k;
             if (keychainAdapters.TryGetValue(host, out k))
@@ -256,7 +255,7 @@ namespace GitHub.Unity
 
             if (deleteFromCredentialManager)
             {
-                await credentialManager.Delete(host);
+                credentialManager.Delete(host);
             }
         }
 

--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -34,7 +34,7 @@ namespace GitHub.Unity
         /// <param name="nodeJsExecutablePath"></param>
         /// <param name="octorunScript"></param>
         public LoginManager(
-            IKeychain keychain, IProcessManager processManager = null, ITaskManager taskManager = null,
+            IKeychain keychain, IProcessManager processManager, ITaskManager taskManager,
             NPath? nodeJsExecutablePath = null, NPath? octorunScript = null)
         {
             Guard.ArgumentNotNull(keychain, nameof(keychain));

--- a/src/GitHub.Api/Git/GitCredentialManager.cs
+++ b/src/GitHub.Api/Git/GitCredentialManager.cs
@@ -1,7 +1,6 @@
 using GitHub.Logging;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
@@ -29,35 +28,35 @@ namespace GitHub.Unity
 
         public ICredential CachedCredentials { get { return credential; } }
 
-        public async Task Delete(UriString host)
+        public void Delete(UriString host)
         {
-            if (!await LoadCredentialHelper())
+            if (!LoadCredentialHelper())
                 return;
 
-            await RunCredentialHelper(
+            RunCredentialHelper(
                 "erase",
                 new string[] {
                         String.Format("protocol={0}", host.Protocol),
                         String.Format("host={0}", host.Host)
-                }).StartAwait();
+                }).RunSynchronously();
             credential = null;
         }
 
-        public async Task<ICredential> Load(UriString host)
+        public ICredential Load(UriString host)
         {
             if (credential == null)
             {
-                if (!await LoadCredentialHelper())
+                if (!LoadCredentialHelper())
                     return null;
 
                 string kvpCreds = null;
 
-                kvpCreds = await RunCredentialHelper(
+                kvpCreds = RunCredentialHelper(
                     "get",
                     new string[] {
                         String.Format("protocol={0}", host.Protocol),
                         String.Format("host={0}", host.Host)
-                    }).StartAwait();
+                    }).RunSynchronously();
 
                 if (String.IsNullOrEmpty(kvpCreds))
                 {
@@ -92,11 +91,11 @@ namespace GitHub.Unity
             return credential;
         }
 
-        public async Task Save(ICredential cred)
+        public void Save(ICredential cred)
         {
             this.credential = cred;
 
-            if (!await LoadCredentialHelper())
+            if (!LoadCredentialHelper())
                 return;
 
             var data = new List<string>
@@ -108,21 +107,21 @@ namespace GitHub.Unity
             };
 
             var task = RunCredentialHelper("store", data.ToArray());
-            await task.StartAwait();
+            task.RunSynchronously();
             if (!task.Successful)
             {
                 Logger.Error("Failed to save credentials");
             }
         }
 
-        private async Task<bool> LoadCredentialHelper()
+        private bool LoadCredentialHelper()
         {
             if (credHelper != null)
                 return true;
 
-            credHelper = await new GitConfigGetTask("credential.helper", GitConfigSource.NonSpecified, taskManager.Token)
+            credHelper = new GitConfigGetTask("credential.helper", GitConfigSource.NonSpecified, taskManager.Token)
                 .Configure(processManager)
-                .StartAwait();
+                .RunSynchronously();
 
             //Logger.Trace("Loaded Credential Helper: {0}", credHelper);
 

--- a/src/GitHub.Api/Threading/ThreadingHelper.cs
+++ b/src/GitHub.Api/Threading/ThreadingHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Unity
@@ -19,102 +17,15 @@ namespace GitHub.Unity
 
         public static bool InUIThread => InMainThread || Guard.InUnitTestRunner;
 
-        /// <summary>
-        /// Switch to the UI thread
-        /// Auto-disables switching when running in unit test mode
-        /// </summary>
-        /// <returns></returns>
-        public static IAwaitable SwitchToMainThreadAsync()
+        public static TaskScheduler GetUIScheduler(SynchronizationContext synchronizationContext)
         {
-            return Guard.InUnitTestRunner ?
-                new AwaitableWrapper() :
-                new AwaitableWrapper(MainThreadScheduler);
+            // quickly swap out the sync context so we can leverage FromCurrentSynchronizationContext for our ui scheduler
+            var currentSyncContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            var ret = TaskScheduler.FromCurrentSynchronizationContext();
+            if (currentSyncContext != null)
+                SynchronizationContext.SetSynchronizationContext(currentSyncContext);
+            return ret;
         }
-
-
-        /// <summary>
-        /// Switch to a thread pool background thread if the current thread isn't one, otherwise does nothing
-        /// Auto-disables switching when running in unit test mode
-        /// </summary>
-        /// <param name="scheduler"></param>
-        /// <returns></returns>
-        public static IAwaitable SwitchToThreadAsync(TaskScheduler scheduler = null)
-        {
-            return Guard.InUnitTestRunner ?
-                new AwaitableWrapper() :
-                new AwaitableWrapper(scheduler ?? TaskManager.Instance.ConcurrentScheduler);
-        }
-
-        class AwaitableWrapper : IAwaitable
-        {
-            Func<IAwaiter> getAwaiter;
-
-            public AwaitableWrapper()
-            {
-                getAwaiter = () => new AwaiterWrapper();
-            }
-
-            public AwaitableWrapper(TaskScheduler scheduler)
-            {
-                getAwaiter = () => new AwaiterWrapper(new TaskSchedulerAwaiter(scheduler));
-            }
-
-            public IAwaiter GetAwaiter() => getAwaiter();
-        }
-
-        class AwaiterWrapper : IAwaiter
-        {
-            Func<bool> isCompleted;
-            Action<Action> onCompleted;
-            Action getResult;
-
-            public AwaiterWrapper()
-            {
-                isCompleted = () => true;
-                onCompleted = c => c();
-                getResult = () => { };
-            }
-
-            public AwaiterWrapper(TaskSchedulerAwaiter awaiter)
-            {
-                isCompleted = () => awaiter.IsCompleted;
-                onCompleted = c => awaiter.OnCompleted(c);
-                getResult = () => awaiter.GetResult();
-            }
-
-            public bool IsCompleted => isCompleted();
-
-            public void OnCompleted(Action continuation) => onCompleted(continuation);
-
-            public void GetResult() => getResult();
-        }
-
-        public struct TaskSchedulerAwaiter : INotifyCompletion
-        {
-            private readonly TaskScheduler scheduler;
-
-            public bool IsCompleted
-            {
-                get
-                {
-                    return (this.scheduler == TaskManager.Instance.UIScheduler && InUIThread) || (this.scheduler != TaskManager.Instance.UIScheduler && !InUIThread);
-                }
-            }
-
-            public TaskSchedulerAwaiter(TaskScheduler scheduler)
-            {
-                this.scheduler = scheduler;
-            }
-
-            public void OnCompleted(Action action)
-            {
-                Task.Factory.StartNew(action, TaskManager.Instance.Token, TaskCreationOptions.None, this.scheduler);
-            }
-
-            public void GetResult()
-            {
-            }
-        }
-
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Services/AuthenticationService.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Services/AuthenticationService.cs
@@ -8,9 +8,9 @@ namespace GitHub.Unity
 
         private LoginResult loginResultData;
 
-        public AuthenticationService(UriString host, IKeychain keychain, NPath nodeJsExecutablePath, NPath octorunExecutablePath)
+        public AuthenticationService(IProcessManager processManager, ITaskManager taskManager, UriString host, IKeychain keychain, NPath nodeJsExecutablePath, NPath octorunExecutablePath)
         {
-            client = new ApiClient(host, keychain, EntryPoint.ApplicationManager.ProcessManager, EntryPoint.ApplicationManager.TaskManager, nodeJsExecutablePath, octorunExecutablePath);
+            client = new ApiClient(host, keychain, processManager, taskManager, nodeJsExecutablePath, octorunExecutablePath);
         }
 
         public void Login(string username, string password, Action<string> twofaRequired, Action<bool, string> authResult)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/AuthenticationView.cs
@@ -254,7 +254,7 @@ namespace GitHub.Unity
                         host = UriString.ToUriString(HostAddress.GitHubDotComHostAddress.WebUri);
                     }
 
-                    AuthenticationService = new AuthenticationService(host, Platform.Keychain, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
+                    AuthenticationService = new AuthenticationService(Manager.ProcessManager, Manager.TaskManager, host, Platform.Keychain, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
                 }
                 return authenticationService;
             }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -816,7 +816,7 @@ namespace GitHub.Unity
                 host = UriString.ToUriString(HostAddress.GitHubDotComHostAddress.WebUri);
             }
 
-            var apiClient = new ApiClient(host, Platform.Keychain, null, null, NPath.Default, NPath.Default);
+            var apiClient = new ApiClient(host, Platform.Keychain, Manager.ProcessManager, Manager.TaskManager, Environment.NodeJsExecutablePath, Environment.OctorunScriptPath);
             apiClient.Logout(host);
         }
 

--- a/src/tests/UnitTests/Authentication/KeychainTests.cs
+++ b/src/tests/UnitTests/Authentication/KeychainTests.cs
@@ -162,7 +162,7 @@ namespace UnitTests
                 credential.Username.Returns(username);
                 credential.Token.Returns(token);
                 credential.Host.Returns(hostUri);
-                return TaskEx.FromResult(credential);
+                return credential;
             });
 
             var keychain = new Keychain(environment, credentialManager);
@@ -176,7 +176,7 @@ namespace UnitTests
             fileSystem.DidNotReceive().WriteAllLines(Args.String, Arg.Any<string[]>());
 
             var uriString = keychain.Hosts.FirstOrDefault();
-            var keychainAdapter = keychain.Load(uriString).Result;
+            var keychainAdapter = keychain.Load(uriString);
             keychainAdapter.Credential.Username.Should().Be(username);
             keychainAdapter.Credential.Token.Should().Be(token);
             keychainAdapter.Credential.Host.Should().Be(hostUri);
@@ -209,7 +209,7 @@ namespace UnitTests
             environment.FileSystem.Returns(fileSystem);
 
             var credentialManager = Substitute.For<ICredentialManager>();
-            credentialManager.Load(hostUri).Returns(info => TaskEx.FromResult<ICredential>(null));
+            credentialManager.Load(hostUri).Returns(info => null);
 
             var keychain = new Keychain(environment, credentialManager);
             keychain.Initialize();
@@ -222,7 +222,7 @@ namespace UnitTests
             fileSystem.ClearReceivedCalls();
 
             var uriString = keychain.Hosts.FirstOrDefault();
-            var keychainAdapter = keychain.Load(uriString).Result;
+            var keychainAdapter = keychain.Load(uriString);
             keychainAdapter.Should().BeNull();
 
             fileSystem.DidNotReceive().FileExists(Args.String);
@@ -258,10 +258,6 @@ namespace UnitTests
             environment.FileSystem.Returns(fileSystem);
 
             var credentialManager = Substitute.For<ICredentialManager>();
-
-            credentialManager.Delete(Args.UriString).Returns(info => TaskEx.FromResult(0));
-
-            credentialManager.Save(Arg.Any<ICredential>()).Returns(info => TaskEx.FromResult(0));
 
             var keychain = new Keychain(environment, credentialManager);
             keychain.Initialize();
@@ -299,7 +295,7 @@ namespace UnitTests
             keychainAdapter.Credential.Username.Should().Be(username);
             keychainAdapter.Credential.Token.Should().Be(token);
 
-            keychain.Save(hostUri).Wait();
+            keychain.Save(hostUri);
 
             fileSystem.DidNotReceive().FileExists(Args.String);
             fileSystem.DidNotReceive().FileDelete(Args.String);
@@ -334,10 +330,6 @@ namespace UnitTests
 
             var credentialManager = Substitute.For<ICredentialManager>();
 
-            credentialManager.Delete(Args.UriString).Returns(info => TaskEx.FromResult(0));
-
-            credentialManager.Save(Arg.Any<ICredential>()).Returns(info => TaskEx.FromResult(0));
-
             var keychain = new Keychain(environment, credentialManager);
             keychain.Initialize();
 
@@ -367,7 +359,7 @@ namespace UnitTests
             keychainAdapter.Credential.Username.Should().Be(username);
             keychainAdapter.Credential.Token.Should().Be(password);
 
-            keychain.Clear(hostUri, false).Wait();
+            keychain.Clear(hostUri, false);
 
             keychainAdapter.Credential.Should().BeNull();
 


### PR DESCRIPTION
Unity now ships with a synchronization context, so we shouldn't trample all over it. We don't need a sync context permanently in the main thread anyway, we just need it temporarily there to create a task scheduler.