### PR TITLE
Fix sign in and out

### DIFF
--- a/src/GitHub.Api/Primitives/UriString.cs
+++ b/src/GitHub.Api/Primitives/UriString.cs
@@ -267,7 +267,7 @@ namespace GitHub.Unity
 
         static string NormalizePath(string path)
         {
-            return path?.Replace('\\', '/');
+            return path?.Replace('\\', '/').TrimEnd('/');
         }
 
         static string GetRepositoryName(string repositoryNameSegment)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -212,6 +212,7 @@ namespace GitHub.Unity
         private void MaybeUpdateData()
         {
             connection = Platform.Keychain.Connections.FirstOrDefault();
+
             if (repositoryProgressHasUpdate)
             {
                 if (repositoryProgress != null)
@@ -425,8 +426,10 @@ namespace GitHub.Unity
 
         private void ConnectionsChanged()
         {
-            connection = Platform.Keychain.Connections.FirstOrDefault();
-            Redraw();
+            if (!ThreadingHelper.InUIThread)
+                TaskManager.RunInUI(Redraw);
+            else
+                Redraw();
         }
 
         public override void OnUI()

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -551,18 +551,6 @@ namespace GitHub.Unity
                 }
 
                 GUILayout.FlexibleSpace();
-
-                if (connection == null)
-                {
-                    if (GUILayout.Button("Sign in", Styles.HistoryToolbarButtonStyle))
-                        SignIn(null);
-                }
-                else
-                {
-                    if (GUILayout.Button(connection.Username, EditorStyles.toolbarDropDown))
-                    {
-                        DoAccountDropdown();
-                    }
             }
             EditorGUILayout.EndHorizontal();
         }
@@ -632,8 +620,18 @@ namespace GitHub.Unity
 
                 GUILayout.FlexibleSpace();
 
-                if (GUILayout.Button(Localization.AccountButton, EditorStyles.toolbarDropDown))
-                    DoAccountDropdown();
+                if (connection == null)
+                {
+                    if (GUILayout.Button("Sign in", EditorStyles.toolbarButton))
+                        SignIn(null);
+                }
+                else
+                {
+                    if (GUILayout.Button(connection.Username, EditorStyles.toolbarDropDown))
+                    {
+                        DoAccountDropdown();
+                    }
+                }
             }
             EditorGUILayout.EndHorizontal();
         }
@@ -823,7 +821,7 @@ namespace GitHub.Unity
             if (Repository != null && Repository.CloneUrl != null && Repository.CloneUrl.IsValidUri)
             {
                 host = new UriString(Repository.CloneUrl.ToRepositoryUri()
-                                               .GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
+                    .GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
             }
             else
             {
@@ -831,7 +829,7 @@ namespace GitHub.Unity
             }
 
             var apiClient = new ApiClient(host, Platform.Keychain, null, null, NPath.Default, NPath.Default);
-            apiClient.Logout(host);
+            apiClient.Logout(host).FinallyInUI((s, e) => Redraw());
         }
 
         public new void ShowNotification(GUIContent content)

--- a/src/tests/UnitTests/Authentication/KeychainTests.cs
+++ b/src/tests/UnitTests/Authentication/KeychainTests.cs
@@ -305,7 +305,7 @@ namespace UnitTests
             fileSystem.DidNotReceive().FileDelete(Args.String);
             fileSystem.DidNotReceive().ReadAllText(Args.String);
             fileSystem.DidNotReceive().ReadAllLines(Args.String);
-            fileSystem.Received(1).WriteAllText(connectionsCacheFile, @"[{""Host"":""https://github.com/"",""Username"":""SomeUser""}]");
+            fileSystem.Received(1).WriteAllText(connectionsCacheFile, @"[{""Host"":""https://github.com"",""Username"":""SomeUser""}]");
 
             credentialManager.DidNotReceive().Load(Args.UriString);
             credentialManager.DidNotReceive().HasCredentials();


### PR DESCRIPTION
Fixes #687 

The connections json had a host with a trailing slash but logout would try to logout a host without a trailing slash. I have no clue how the slash gets randomly inserted at the end, but it's all UriStrings being passed around and UriString should normalize uris to never have trailing slashes anyway, so that fixes that.

This also tweaks the account dropdown UI so that it shows the username if you're logged in and "Sign in" if you're not logged in (because gah I never know if I am or not)