### PR TITLE
Unity 2018 .NET 4.5+ Support

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,6 +11,11 @@ if not %2.==. (
 	set Target=%2
 )
 
+set FrameworkVersion=v3.5
+if not %3.==. (
+	set FrameworkVersion=%3
+)
+
 if %Target%==Rebuild (
 	del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\*.dll
 	del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\*.mdb
@@ -25,8 +30,8 @@ if %Target%==Rebuild (
 
 call common\nuget.exe restore GitHub.Unity.sln
 
-echo xbuild GitHub.Unity.sln /verbosity:normal /property:Configuration=%Configuration% /target:%Target%
-call xbuild GitHub.Unity.sln /verbosity:normal /property:Configuration=%Configuration% /target:%Target%
+echo xbuild GitHub.Unity.sln /verbosity:normal /property:Configuration=%Configuration% /property:TargetFrameworkVersion=%FrameworkVersion% /target:%Target%
+call xbuild GitHub.Unity.sln /verbosity:normal /property:Configuration=%Configuration% /property:TargetFrameworkVersion=%FrameworkVersion% /target:%Target%
 
 del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\deleteme*
 del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\deleteme*

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,11 @@ if [ $# -gt 1 ]; then
 	Target=$2
 fi
 
+FrameworkVersion="v3.5"
+if [ $# -gt 2 ]; then
+	FrameworkVersion=$3
+fi
+
 if [ x"$Target" == x"Rebuild" ]; then
 	rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/*.dll
 	rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/*.mdb
@@ -32,7 +37,7 @@ else
 	mono common/nuget.exe restore GitHub.Unity.sln
 fi
 
-xbuild GitHub.Unity.sln /verbosity:minimal /property:Configuration=$Configuration /target:$Target || true
+xbuild GitHub.Unity.sln /verbosity:minimal /property:Configuration=$Configuration /property:TargetFrameworkVersion=$FrameworkVersion /target:$Target || true
 
 rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/deleteme*
 rm -f unity/PackageProject/Assets/Plugins/GitHub/Editor/deleteme*

--- a/common/properties.props
+++ b/common/properties.props
@@ -5,6 +5,7 @@
     <BuildType Condition="Exists('$(SolutionDir)script\src\MetricsService.cs')">Internal</BuildType>
     <BuildDefs Condition="$(Buildtype) == 'Internal'">ENABLE_METRICS</BuildDefs>
     <BuildDefs>$(BuildDefs);ENABLE_MONO</BuildDefs>
+    <BuildDefs Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">NET35</BuildDefs>
 
     <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\script\lib\Managed\UnityEditor.dll')">$(SolutionDir)script\lib\</UnityDir>
     <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\lib\Managed\UnityEditor.dll')">$(SolutionDir)lib\</UnityDir>

--- a/package.cmd
+++ b/package.cmd
@@ -25,6 +25,11 @@ if %ChangeConfigurationToDebug%==1 (
 	set Configuration=Debug
 )
 
+set FrameworkVersion=v3.5
+if not %3.==. (
+	set FrameworkVersion=%3
+)
+
 set Unity=%UnityPath%\Editor\Unity.exe
 if not exist "%Unity%" ( 
 	echo Cannot find Unity at %Unity%
@@ -39,8 +44,8 @@ if not exist "%Unity%" (
 	cd ..
 	
 	call common\nuget.exe restore GitHub.Unity.sln
-	echo xbuild GitHub.Unity.sln /property:Configuration=%Configuration%
-	call xbuild GitHub.Unity.sln /property:Configuration=%Configuration%
+	echo xbuild GitHub.Unity.sln /property:Configuration=%Configuration% property:TargetFrameworkVersion=%FrameworkVersion%
+	call xbuild GitHub.Unity.sln /property:Configuration=%Configuration% property:TargetFrameworkVersion=%FrameworkVersion%
 	
 	del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\deleteme*
 	del /Q unity\PackageProject\Assets\Plugins\GitHub\Editor\*.pdb
@@ -50,6 +55,9 @@ if not exist "%Unity%" (
 	for /f tokens^=^2^ usebackq^ delims^=^" %%G in (`find "const string Version" common\SolutionInfo.cs`) do call :Package %%G
 	
 	goto End
+
+	rem TODO: Put FrameworkVersion into unitypackage name
+	rem TODO: Remove AsyncBridge related metas
 	
 	:Package
 	set Version=%1

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -55,20 +55,26 @@
   <PropertyGroup>
     <BuildConfig Condition=" '$(BuildConfig)' == '' ">Debug</BuildConfig>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="sfw.net">
+      <HintPath>$(SolutionDir)\lib\sfw\sfw.net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir).\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>$(SolutionDir)lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Posix">
       <HintPath>$(SolutionDir)lib\Mono.Posix.dll</HintPath>
-    </Reference>
-    <Reference Include="ReadOnlyCollectionsInterfaces, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)packages\ReadOnlyCollectionInterfaces.1.0.0\lib\NET20\ReadOnlyCollectionsInterfaces.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="sfw.net">
       <HintPath>$(SolutionDir)\lib\sfw\sfw.net.dll</HintPath>
@@ -76,10 +82,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir).\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Application\ApplicationInfo.cs" />
@@ -236,6 +238,7 @@
     <Compile Include="Platform\Platform.cs" />
     <Compile Include="Git\GitCredentialManager.cs" />
     <Compile Include="UI\TreeBase.cs" />
+    <Compile Include="Tasks\TaskEx.cs" />
   </ItemGroup>
   <Choose>
     <When Condition="$(Buildtype) == 'Internal'">

--- a/src/GitHub.Api/Tasks/TaskEx.cs
+++ b/src/GitHub.Api/Tasks/TaskEx.cs
@@ -1,0 +1,57 @@
+﻿#if !NET35
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitHub.Unity
+{
+    public static class TaskEx
+    {
+        public static Task<TResult> FromResult<TResult>(TResult result)
+        {
+            return Task.FromResult(result);
+        }
+
+        public static Task<Task> WhenAny(System.Collections.Generic.IEnumerable<Task> tasks)
+        {
+            return Task.WhenAny(tasks);
+        }
+
+        public static Task<Task> WhenAny(params Task[] tasks)
+        {
+            return Task.WhenAny(tasks);
+        }
+
+        public static Task<Task<TResult>> WhenAny<TResult>(IEnumerable<Task<TResult>> tasks)
+        {
+            return Task.WhenAny(tasks);
+        }
+
+        public static Task<Task<TResult>> WhenAny<TResult>(params Task<TResult>[] tasks)        
+        {
+            return Task.WhenAny(tasks);
+        }
+
+        public static Task Delay(int millisecondsDelay)
+        {
+            return Task.Delay(millisecondsDelay);
+        }
+
+        public static Task Delay(int millisecondsDelay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(millisecondsDelay, cancellationToken);
+        }
+
+        public static Task Delay(TimeSpan delay)
+        {
+            return Task.Delay(delay);
+        }
+
+        public static Task Delay(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+}
+#endif

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/GitHub.Unity.csproj
@@ -51,13 +51,15 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="UnityEditor">
       <HintPath>$(UnityDir)Managed\UnityEditor.dll</HintPath>
       <Private>False</Private>

--- a/src/packaging/CopyLibrariesToPackageProject/CopyLibrariesToPackageProject.csproj
+++ b/src/packaging/CopyLibrariesToPackageProject/CopyLibrariesToPackageProject.csproj
@@ -29,6 +29,20 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
+    <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReadOnlyCollectionsInterfaces, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\ReadOnlyCollectionInterfaces.1.0.0\lib\NET20\ReadOnlyCollectionsInterfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GitHub.Api\GitHub.Api.csproj">
       <Project>{b389adaf-62cc-486e-85b4-2d8b078df763}</Project>
@@ -43,21 +57,9 @@
       <Name>GitHub.Unity</Name>
       <Private>True</Private>
     </ProjectReference>
-    <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ReadOnlyCollectionsInterfaces, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\ReadOnlyCollectionInterfaces.1.0.0\lib\NET20\ReadOnlyCollectionsInterfaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="sfw.net">
       <HintPath>$(SolutionDir)\lib\sfw\sfw.net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/IntegrationTests.csproj
@@ -31,11 +31,17 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -58,10 +64,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/tests/IntegrationTests/Metrics/MetricsTests.cs
+++ b/src/tests/IntegrationTests/Metrics/MetricsTests.cs
@@ -1,4 +1,6 @@
-﻿using GitHub.Unity;
+﻿#if ENABLE_METRICS
+
+using GitHub.Unity;
 using NSubstitute;
 using NUnit.Framework;
 using System;
@@ -119,3 +121,5 @@ namespace IntegrationTests
         }
     }
 }
+
+#endif

--- a/src/tests/TaskSystemIntegrationTests/TaskSystem.csproj
+++ b/src/tests/TaskSystemIntegrationTests/TaskSystem.csproj
@@ -33,11 +33,17 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -52,10 +58,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/tests/TestUtils/TestUtils.csproj
+++ b/src/tests/TestUtils/TestUtils.csproj
@@ -29,11 +29,17 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -48,10 +54,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/tests/UnitTests/UnitTests.csproj
+++ b/src/tests/UnitTests/UnitTests.csproj
@@ -37,11 +37,17 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v3.5' ">
     <Reference Include="AsyncBridge.Net35, Version=0.2.3333.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AsyncBridge.Net35.0.2.3333.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -60,10 +66,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.3333.0, Culture=neutral, PublicKeyToken=402899b480e6f383, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\TaskParallelLibrary.1.0.3333.0\lib\Net35\System.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Allows to compile a Unity 2018 .NET 4.5+ compatible package, as described in #824

### Description of the Change
- Command line builds support an optional extra parameter with the desired framework version (v3.5 or v4.5), ex: `./package.sh /Applications/Unity Release v4.5`
- Package command line build also adds a `.netXX` to the `.unitypackage` file name
- On the IDE you have to manually select the target framework in all the projects
- Asyncbridge related:
    - The dll and dependencies are taken out of the compilation by MSBuild conditionals inside the project files (`AsyncBridge.Net35.dll, ReadOnlyCollectionsInterfaces.dll, System.Threading.dll`)
    - Added a wrapper `TaskEx.cs` files to directly call the system functions
    - Workaround in the `package.sh` to clean up the .meta out out the `.unitypackage`

### Possible Drawbacks
- My bootcamp windows is messed up, so:
    - Was tested only on a Mac, Unity 2018.2.0 and 2017.4.5
    - The `package.cmd` still has two TODO itens to match the functionality with the `.sh`
- As mentioned in the issue, Unity don't have a way to keep both target frameworks in the same package so two simultaneous packages will be needed for each release
