### PR TITLE
Fixing date parsing for VSTS repos

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -13,13 +13,23 @@ namespace GitHub.Unity
         public const string GitTimeoutKey = "GitTimeout";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
-        public const string Iso8601FormatPointZ = @"yyyy-MM-dd\THH\:mm\:ss.ff\Z";
         public static readonly string[] Iso8601Formats = {
+            Iso8601Format,
             Iso8601FormatZ,
             @"yyyy-MM-dd\THH\:mm\:ss.fffffffzzz",
-            Iso8601Format,
-            Iso8601FormatPointZ,
+            @"yyyy-MM-dd\THH\:mm\:ss.ffffffzzz",
+            @"yyyy-MM-dd\THH\:mm\:ss.fffffzzz",
+            @"yyyy-MM-dd\THH\:mm\:ss.ffffzzz",
+            @"yyyy-MM-dd\THH\:mm\:ss.ffzzz",
+            @"yyyy-MM-dd\THH\:mm\:ss.fzzz",
             @"yyyy-MM-dd\THH\:mm\:sszzz",
+            @"yyyy-MM-dd\THH\:mm\:ss.fffffff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.ffffff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.fffff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.ffff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.fff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.ff\Z",
+            @"yyyy-MM-dd\THH\:mm\:ss.f\Z",
         };
         public const DateTimeStyles DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;
         public const string SkipVersionKey = "SkipVersion";

--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -13,10 +13,12 @@ namespace GitHub.Unity
         public const string GitTimeoutKey = "GitTimeout";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
+        public const string Iso8601FormatPointZ = @"yyyy-MM-dd\THH\:mm\:ss.ff\Z";
         public static readonly string[] Iso8601Formats = {
             Iso8601FormatZ,
             @"yyyy-MM-dd\THH\:mm\:ss.fffffffzzz",
             Iso8601Format,
+            Iso8601FormatPointZ,
             @"yyyy-MM-dd\THH\:mm\:sszzz",
         };
         public const DateTimeStyles DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;

--- a/src/GitHub.Api/Helpers/SimpleJson.cs
+++ b/src/GitHub.Api/Helpers/SimpleJson.cs
@@ -1250,7 +1250,7 @@ namespace GitHub.Unity.Json
         internal static readonly Type[] EmptyTypes = new Type[0];
         internal static readonly Type[] ArrayConstructorParameterTypes = new Type[] { typeof(int) };
 
-        private static readonly string[] Iso8601Formats = Constants.Iso8601Formats;
+        private static readonly string[] Iso8601Format = Constants.Iso8601Formats;
 
         public PocoJsonSerializerStrategy()
         {
@@ -1359,9 +1359,9 @@ namespace GitHub.Unity.Json
                     if (type == typeof(NPath) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(NPath)))
                         return new NPath(str);
                     if (type == typeof(DateTime) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTime)))
-                        return DateTime.ParseExact(str, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                        return DateTime.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     if (type == typeof(DateTimeOffset) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTimeOffset)))
-                        return DateTimeOffset.ParseExact(str, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                        return DateTimeOffset.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     if (type == typeof(Guid) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(Guid)))
                         return new Guid(str);
                     if (type == typeof(UriString) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(UriString)))
@@ -1494,9 +1494,9 @@ namespace GitHub.Unity.Json
             if (input is NPath || input is UriString)
                 output = input.ToString();
             else if (input is DateTime)
-                output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Formats[0], CultureInfo.InvariantCulture);
+                output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
             else if (input is DateTimeOffset)
-                output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Formats[0], CultureInfo.InvariantCulture);
+                output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
             else if (input is Guid)
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)

--- a/src/GitHub.Api/Helpers/SimpleJson.cs
+++ b/src/GitHub.Api/Helpers/SimpleJson.cs
@@ -1250,17 +1250,7 @@ namespace GitHub.Unity.Json
         internal static readonly Type[] EmptyTypes = new Type[0];
         internal static readonly Type[] ArrayConstructorParameterTypes = new Type[] { typeof(int) };
 
-        private static readonly string[] Iso8601Format = new string[]
-                                                             {
-                                                                @"yyyy-MM-dd\THH\:mm\:sszzz",
-                                                                @"yyyy-MM-dd\THH\:mm\:ss.fffffffzzz",
-                                                                @"yyyy-MM-dd\THH\:mm\:ss.fffzzz",
-                                                                @"yyyy-MM-dd\THH\:mm\:ss\Z",
-                                                                @"yyyy-MM-dd\THH:mm:ss.fffffffzzz",
-                                                                @"yyyy-MM-dd\THH:mm:ss.fffzzz",
-                                                                @"yyyy-MM-dd\THH:mm:sszzz",
-                                                                @"yyyy-MM-dd\THH:mm:ss\Z",
-                                                             };
+        private static readonly string[] Iso8601Formats = Constants.Iso8601Formats;
 
         public PocoJsonSerializerStrategy()
         {
@@ -1504,9 +1494,9 @@ namespace GitHub.Unity.Json
             if (input is NPath || input is UriString)
                 output = input.ToString();
             else if (input is DateTime)
-                output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
+                output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Formats[0], CultureInfo.InvariantCulture);
             else if (input is DateTimeOffset)
-                output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
+                output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Formats[0], CultureInfo.InvariantCulture);
             else if (input is Guid)
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)

--- a/src/GitHub.Api/Helpers/SimpleJson.cs
+++ b/src/GitHub.Api/Helpers/SimpleJson.cs
@@ -1369,9 +1369,9 @@ namespace GitHub.Unity.Json
                     if (type == typeof(NPath) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(NPath)))
                         return new NPath(str);
                     if (type == typeof(DateTime) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTime)))
-                        return DateTime.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                        return DateTime.ParseExact(str, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     if (type == typeof(DateTimeOffset) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTimeOffset)))
-                        return DateTimeOffset.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                        return DateTimeOffset.ParseExact(str, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     if (type == typeof(Guid) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(Guid)))
                         return new Guid(str);
                     if (type == typeof(UriString) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(UriString)))

--- a/src/tests/UnitTests/IO/LockOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/LockOutputProcessorTests.cs
@@ -68,6 +68,25 @@ namespace UnitTests
                 new GitLock("2f9cfde9c159d50e235cc1402c3e534b0bf2198afb20760697a5f9b07bf04fb3", "somezip.zip".ToNPath(), new GitUser("GitHub User", ""), now)
             };
 
+            AssertProcessOutput(output, expected);
+        }
+
+        [Test]
+        public void ShouldParseVSTSLocksFormat()
+        {
+            var nowString = DateTimeOffset.UtcNow.ToString(Constants.Iso8601FormatPointZ);
+            var now = DateTimeOffset.ParseExact(nowString, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+            var output = new[]
+            {
+                $@"[{{""id"":""7""   ,""path"":""Assets/Main.unity"",""owner"":{{""name"":""GitHub User""}},""locked_at"":""{nowString}""}}]",
+                string.Empty,
+                "1 lock(s) matched query.",
+                null
+            };
+
+            var expected = new[] {
+                new GitLock("7", "Assets/Main.unity".ToNPath(), new GitUser("GitHub User", ""), now),
+            };
 
             AssertProcessOutput(output, expected);
         }

--- a/src/tests/UnitTests/IO/LockOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/LockOutputProcessorTests.cs
@@ -74,7 +74,7 @@ namespace UnitTests
         [Test]
         public void ShouldParseVSTSLocksFormat()
         {
-            var nowString = DateTimeOffset.UtcNow.ToString(Constants.Iso8601FormatPointZ);
+            var nowString = DateTimeOffset.UtcNow.ToString(@"yyyy-MM-dd\THH\:mm\:ss.ff\Z");
             var now = DateTimeOffset.ParseExact(nowString, Constants.Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
             var output = new[]
             {

--- a/src/tests/UnitTests/Primitives/SerializationTests.cs
+++ b/src/tests/UnitTests/Primitives/SerializationTests.cs
@@ -37,6 +37,25 @@ namespace UnitTests.Primitives
             Assert.AreEqual(dt3, dt4);
         }
 
+        [Test]
+        public void DateTimeSerializationRoundTripFormatPointZ()
+        {
+            var dt1 = DateTimeOffset.ParseExact("2018-05-01T15:04:29.00Z", new []{ Constants.Iso8601FormatPointZ }, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            DateTimeOffset.ParseExact("2018-05-01T15:04:29.00Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            var str1 = dt1.ToJson();
+            var ret1 = str1.FromJson<DateTimeOffset>();
+            Assert.AreEqual(dt1, ret1);
+        }
+
+        [Test]
+        public void DateTimeSerializationRoundTripFormatZ()
+        {
+            var dt1 = DateTimeOffset.ParseExact("2018-05-01T15:04:29Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            var str1 = dt1.ToJson();
+            var ret1 = str1.FromJson<DateTimeOffset>();
+            Assert.AreEqual(dt1, ret1);
+        }
+
         class TestData
         {
             public List<string> Things { get; set; } = new List<string>();

--- a/src/tests/UnitTests/Primitives/SerializationTests.cs
+++ b/src/tests/UnitTests/Primitives/SerializationTests.cs
@@ -11,6 +11,41 @@ namespace UnitTests.Primitives
     [TestFixture]
     class SerializationTests
     {
+        [TestCase("2018-05-01T12:04:29.1234567-02:00", "2018-05-01T14:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.123456-02:00", "2018-05-01T14:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.12345-02:00", "2018-05-01T14:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.1234-02:00", "2018-05-01T14:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.123-02:00", "2018-05-01T14:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.12-02:00", "2018-05-01T14:04:29.120+00:00")]
+        [TestCase("2018-05-01T12:04:29.1-02:00", "2018-05-01T14:04:29.100+00:00")]
+        [TestCase("2018-05-01T12:04:29-02:00", "2018-05-01T14:04:29.000+00:00")]
+        [TestCase("2018-05-01T12:04:29.1234567Z", "2018-05-01T12:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.123456Z", "2018-05-01T12:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.12345Z", "2018-05-01T12:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.1234Z", "2018-05-01T12:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.123Z", "2018-05-01T12:04:29.123+00:00")]
+        [TestCase("2018-05-01T12:04:29.12Z", "2018-05-01T12:04:29.120+00:00")]
+        [TestCase("2018-05-01T12:04:29.1Z", "2018-05-01T12:04:29.100+00:00")]
+        [TestCase("2018-05-01T12:04:29Z", "2018-05-01T12:04:29.000+00:00")]
+        public void FromLocalStringToUniversalDateTimeOffset(string input, string expected)
+        {
+            var dtInput = DateTimeOffset.ParseExact(input, Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            var output = dtInput.ToUniversalTime().ToString(Constants.Iso8601Format);
+            Assert.AreEqual(expected, output);
+
+            var json = $@"{{""date"":""{input}""}}";
+            Assert.DoesNotThrow(() => json.FromJson<ADateTimeOffset>(lowerCase: true));
+        }
+
+        [Test]
+        public void JsonSerializationUsesKnownFormat()
+        {
+            var now = DateTimeOffset.Now;
+            var output = new ADateTimeOffset { Date = now };
+            var json = output.ToJson(lowerCase: true);
+            Assert.AreEqual($@"{{""date"":""{ now.ToUniversalTime().ToString(Constants.Iso8601Format, CultureInfo.InvariantCulture) }""}}", json);
+        }
+
         [Test]
         public void DateTimeSerializationRoundTrip()
         {
@@ -51,6 +86,11 @@ namespace UnitTests.Primitives
             Assert.AreEqual(dt2, ret2);
 
             Assert.AreEqual(dt1, dt2);
+        }
+
+        class ADateTimeOffset
+        {
+            public DateTimeOffset Date;
         }
 
         class TestData

--- a/src/tests/UnitTests/Primitives/SerializationTests.cs
+++ b/src/tests/UnitTests/Primitives/SerializationTests.cs
@@ -40,20 +40,17 @@ namespace UnitTests.Primitives
         [Test]
         public void DateTimeSerializationRoundTripFormatPointZ()
         {
-            var dt1 = DateTimeOffset.ParseExact("2018-05-01T15:04:29.00Z", new []{ Constants.Iso8601FormatPointZ }, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
-            DateTimeOffset.ParseExact("2018-05-01T15:04:29.00Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            var dt1 = DateTimeOffset.ParseExact("2018-05-01T15:04:29.00Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
             var str1 = dt1.ToJson();
             var ret1 = str1.FromJson<DateTimeOffset>();
             Assert.AreEqual(dt1, ret1);
-        }
 
-        [Test]
-        public void DateTimeSerializationRoundTripFormatZ()
-        {
-            var dt1 = DateTimeOffset.ParseExact("2018-05-01T15:04:29Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
-            var str1 = dt1.ToJson();
-            var ret1 = str1.FromJson<DateTimeOffset>();
-            Assert.AreEqual(dt1, ret1);
+            var dt2 = DateTimeOffset.ParseExact("2018-05-01T15:04:29Z", Constants.Iso8601Formats, CultureInfo.InvariantCulture, Constants.DateTimeStyle);
+            var str2 = dt2.ToJson();
+            var ret2 = str2.FromJson<DateTimeOffset>();
+            Assert.AreEqual(dt2, ret2);
+
+            Assert.AreEqual(dt1, dt2);
         }
 
         class TestData


### PR DESCRIPTION
Fixes #835

- Switched to using Constants.Iso8601Formats in SimpleJson.
- Added a test to verify that LocksOutputProcessor is working as expected.

Update by @shana:

This adds more milisecond precision variants to the ISO8601 formats, given that different servers return different variations of the standard. Because standards.

![iso 8601](https://user-images.githubusercontent.com/310137/41778085-d13d2c82-762d-11e8-8867-70bb748cc7a3.png)
