### PR TITLE
Fix changes tree ordering

### DIFF
--- a/src/GitHub.Api/Git/GitStatusEntry.cs
+++ b/src/GitHub.Api/Git/GitStatusEntry.cs
@@ -14,8 +14,7 @@ namespace GitHub.Unity
         public GitFileStatus status;
         public bool staged;
 
-        public GitStatusEntry(string path, string fullPath, string projectPath,
-            GitFileStatus status,
+        public GitStatusEntry(string path, string fullPath, string projectPath, GitFileStatus status,
             string originalPath = null, bool staged = false)
         {
             Guard.ArgumentNotNullOrWhiteSpace(path, "path");

--- a/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
@@ -224,7 +224,7 @@ namespace GitHub.Unity
                 Guard.ArgumentNotNull(x, nameof(x));
                 Guard.ArgumentNotNull(y, nameof(y));
 
-                const string meta = ".meta";
+                var meta = ".meta";
                 var xHasMeta = x.EndsWith(meta);
                 var yHasMeta = y.EndsWith(meta);
 

--- a/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
@@ -224,30 +224,21 @@ namespace GitHub.Unity
                 Guard.ArgumentNotNull(x, nameof(x));
                 Guard.ArgumentNotNull(y, nameof(y));
 
-                var metaString = ".meta";
-                var xIsMeta = x.EndsWith(metaString);
-                var yIsMeta = y.EndsWith(metaString);
+                const string meta = ".meta";
+                var xHasMeta = x.EndsWith(meta);
+                var yHasMeta = y.EndsWith(meta);
 
-                if (xIsMeta || yIsMeta)
+                if(!xHasMeta && !yHasMeta) return StringComparer.InvariantCulture.Compare(x, y);
+
+                var xPure = xHasMeta ? x.Substring(0, x.Length - meta.Length) : x;
+                var yPure = yHasMeta ? y.Substring(0, y.Length - meta.Length) : y;
+
+                if (xHasMeta)
                 {
-                    var compareX = !xIsMeta ? x : x.Substring(0, x.Length - 5);
-                    var compareY = !yIsMeta ? y : y.Substring(0, y.Length - 5);
-
-                    var comparisonResult = StringComparer.InvariantCultureIgnoreCase.Compare(compareX, compareY);
-                    if (comparisonResult != 0)
-                    {
-                        return comparisonResult;
-                    }
-
-                    if (xIsMeta)
-                    {
-                        return 1;
-                    }
-
-                    return -1;
+                    return xPure.Equals(y) ? 1 : StringComparer.InvariantCulture.Compare(xPure, yPure);
                 }
 
-                return StringComparer.InvariantCultureIgnoreCase.Compare(x, y);
+                return yPure.Equals(x) ? -1 : StringComparer.InvariantCulture.Compare(xPure, yPure);
             }
         }
     }

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -54,7 +54,7 @@ namespace GitHub.Unity
             TNode lastAddedNode = null;
 
             Clear();
-            AddNode(Title, Title, -1 + displayRootLevel, true, false, false, false, isSelected, false, null, false);
+            AddNode(Title, Title, -1 + displayRootLevel, true, false, false, false, isSelected, false, null);
 
             foreach (var treeData in treeDatas)
             {
@@ -123,8 +123,7 @@ namespace GitHub.Unity
 
                         isSelected = selectedNodePath != null && nodePath == selectedNodePath;
 
-                        lastAddedNode = AddNode(nodePath, label, level + displayRootLevel + (parentIsPromoted ? 1 : 0), isFolder, isActive, nodeIsHidden,
-                            nodeIsCollapsed, isSelected, isChecked, treeNodeTreeData, false);
+                        lastAddedNode = AddNode(nodePath, label, level + displayRootLevel + (parentIsPromoted ? 1 : 0), isFolder, isActive, nodeIsHidden, nodeIsCollapsed, isSelected, isChecked, treeNodeTreeData);
                     }
                 }
             }
@@ -204,9 +203,9 @@ namespace GitHub.Unity
             }
         }
 
-        protected TNode AddNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isSelected, bool isChecked, TData? treeData, bool isContainer)
+        protected TNode AddNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isSelected, bool isChecked, TData? treeData)
         {
-            var node = CreateTreeNode(path, label, level, isFolder, isActive, isHidden, isCollapsed, isChecked, treeData, isContainer);
+            var node = CreateTreeNode(path, label, level, isFolder, isActive, isHidden, isCollapsed, isChecked, treeData);
 
             SetNodeIcon(node);
             Nodes.Add(node);
@@ -407,7 +406,8 @@ namespace GitHub.Unity
         protected abstract IEnumerable<string> GetCollapsedFolders();
         protected abstract void RemoveCheckedNode(TNode node);
         protected abstract void AddCheckedNode(TNode node);
-        protected abstract TNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, TData? treeData, bool isContainer);
+        protected abstract TNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, TData? treeData);
+
         protected abstract void SetNodeIcon(TNode node);
 
         public string SelectedNodePath => SelectedNode?.Path;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesTreeControl.cs
@@ -186,7 +186,7 @@ namespace GitHub.Unity
             return Styles.GetFileStatusIcon(gitFileStatus, node.IsLocked);
         }
 
-        protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitStatusEntryTreeData? treeData, bool isContainer)
+        protected override ChangesTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitStatusEntryTreeData? treeData)
         {
             var gitStatusEntry = GitStatusEntry.Default;
             var isLocked = false;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -660,14 +660,13 @@ namespace GitHub.Unity
             return nodeIcon;
         }
 
-        protected override TreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitBranchTreeData? treeData, bool isContainer)
+        protected override TreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, GitBranchTreeData? treeData)
         {
             var node = new TreeNode {
                 Path = path,
                 Label = label,
                 Level = level,
                 IsFolder = isFolder,
-                IsContainer = isContainer,
                 IsActive = isActive,
                 IsHidden = isHidden,
                 IsCollapsed = isCollapsed,

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -303,6 +303,45 @@ namespace UnitTests
             });
         }
 
+        public void ShouldSortOutputCorrectly3()
+        {
+            var output = new[]
+            {
+                "## master",
+                "?? Assets/Assets.Test.dll",
+                "?? Assets/Assets.Test.dll.meta",
+                "?? Plugins/GitHub.Unity.dll",
+                "?? Plugins/GitHub.Unity.dll.mdb",
+                "?? Plugins/GitHub.Unity.dll.mdb.meta",
+                "?? Plugins/GitHub.Unity2.dll",
+                "?? Plugins/GitHub.Unity2.dll.mdb",
+                "?? Plugins/GitHub.Unity2.dll.mdb.meta",
+                "?? Plugins/GitHub.Unity2.dll.meta",
+                "?? Plugins/GitHub.Unity.dll.meta",
+                "?? blah.txt",
+                null
+            };
+
+            AssertProcessOutput(output, new GitStatus
+            {
+                LocalBranch = "master",
+                Entries = new List<GitStatusEntry>
+                {
+                    new GitStatusEntry(@"Assets/Assets.Test.dll", TestRootPath + @"\Assets/Assets.Test.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Assets/Assets.Test.dll.meta", TestRootPath + @"\Assets/Assets.Test.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"blah.txt", TestRootPath + @"\blah.txt", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll", TestRootPath + @"\Plugins/GitHub.Unity.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll", TestRootPath + @"\Plugins/GitHub.Unity2.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity2.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity2.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity2.dll.mdb.meta", null, GitFileStatus.Untracked),
+                }
+            });
+        }
+
         private void AssertProcessOutput(IEnumerable<string> lines, GitStatus expected)
         {
             var gitObjectFactory = SubstituteFactory.CreateGitObjectFactory(TestRootPath);

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -251,8 +251,8 @@ namespace UnitTests
             var output = new[]
             {
                 "## master",
-                "?? Assets/Assets.Test.dll",
                 "?? Assets/Assets.Test.dll.meta",
+                "?? Assets/Assets.Test.dll",
                 "?? Plugins/GitHub.Unity.dll",
                 "?? Plugins/GitHub.Unity.dll.mdb",
                 "?? Plugins/GitHub.Unity.dll.mdb.meta",

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -303,6 +303,7 @@ namespace UnitTests
             });
         }
 
+        [Test]
         public void ShouldSortOutputCorrectly3()
         {
             var output = new[]

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -251,64 +251,6 @@ namespace UnitTests
             var output = new[]
             {
                 "## master",
-                "?? GitHub.Unity.dll",
-                "?? GitHub.Unity.dll.mdb",
-                "?? GitHub.Unity.dll.mdb.meta",
-                "?? GitHub.Unity.dll.meta",
-                null
-            };
-
-            AssertProcessOutput(output, new GitStatus
-            {
-                LocalBranch = "master",
-                Entries = new List<GitStatusEntry>
-                {
-                    new GitStatusEntry(@"GitHub.Unity.dll", TestRootPath + @"\GitHub.Unity.dll", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"GitHub.Unity.dll.meta", TestRootPath + @"\GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"GitHub.Unity.dll.mdb", TestRootPath + @"\GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"GitHub.Unity.dll.mdb.meta", TestRootPath + @"\GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
-                }
-            });
-        }
-
-        [Test]
-        public void ShouldSortOutputCorrectly2()
-        {
-            var output = new[]
-            {
-                "## master",
-                "?? Assets/Assets.Test.dll",
-                "?? Assets/Assets.Test.dll.meta",
-                "?? Plugins/GitHub.Unity.dll",
-                "?? Plugins/GitHub.Unity.dll.mdb",
-                "?? Plugins/GitHub.Unity.dll.mdb.meta",
-                "?? Plugins/GitHub.Unity.dll.meta",
-                "?? blah.txt",
-                null
-            };
-
-            AssertProcessOutput(output, new GitStatus
-            {
-                LocalBranch = "master",
-                Entries = new List<GitStatusEntry>
-                {
-                    new GitStatusEntry(@"Assets/Assets.Test.dll", TestRootPath + @"\Assets/Assets.Test.dll", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"Assets/Assets.Test.dll.meta", TestRootPath + @"\Assets/Assets.Test.dll.meta", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"blah.txt", TestRootPath + @"\blah.txt", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll", TestRootPath + @"\Plugins/GitHub.Unity.dll", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
-                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
-                }
-            });
-        }
-
-        [Test]
-        public void ShouldSortOutputCorrectly3()
-        {
-            var output = new[]
-            {
-                "## master",
                 "?? Assets/Assets.Test.dll",
                 "?? Assets/Assets.Test.dll.meta",
                 "?? Plugins/GitHub.Unity.dll",

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -245,6 +245,64 @@ namespace UnitTests
             });
         }
 
+        [Test]
+        public void ShouldSortOutputCorrectly()
+        {
+            var output = new[]
+            {
+                "## master",
+                "?? GitHub.Unity.dll",
+                "?? GitHub.Unity.dll.mdb",
+                "?? GitHub.Unity.dll.mdb.meta",
+                "?? GitHub.Unity.dll.meta",
+                null
+            };
+
+            AssertProcessOutput(output, new GitStatus
+            {
+                LocalBranch = "master",
+                Entries = new List<GitStatusEntry>
+                {
+                    new GitStatusEntry(@"GitHub.Unity.dll", TestRootPath + @"\GitHub.Unity.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"GitHub.Unity.dll.meta", TestRootPath + @"\GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"GitHub.Unity.dll.mdb", TestRootPath + @"\GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"GitHub.Unity.dll.mdb.meta", TestRootPath + @"\GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
+                }
+            });
+        }
+
+        [Test]
+        public void ShouldSortOutputCorrectly2()
+        {
+            var output = new[]
+            {
+                "## master",
+                "?? Assets/Assets.Test.dll",
+                "?? Assets/Assets.Test.dll.meta",
+                "?? Plugins/GitHub.Unity.dll",
+                "?? Plugins/GitHub.Unity.dll.mdb",
+                "?? Plugins/GitHub.Unity.dll.mdb.meta",
+                "?? Plugins/GitHub.Unity.dll.meta",
+                "?? blah.txt",
+                null
+            };
+
+            AssertProcessOutput(output, new GitStatus
+            {
+                LocalBranch = "master",
+                Entries = new List<GitStatusEntry>
+                {
+                    new GitStatusEntry(@"Assets/Assets.Test.dll", TestRootPath + @"\Assets/Assets.Test.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Assets/Assets.Test.dll.meta", TestRootPath + @"\Assets/Assets.Test.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"blah.txt", TestRootPath + @"\blah.txt", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll", TestRootPath + @"\Plugins/GitHub.Unity.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
+                }
+            });
+        }
+
         private void AssertProcessOutput(IEnumerable<string> lines, GitStatus expected)
         {
             var gitObjectFactory = SubstituteFactory.CreateGitObjectFactory(TestRootPath);

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -113,14 +113,13 @@ namespace UnitTests
             TestTreeListener.AddCheckedNode(node);
         }
 
-        protected override TestTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, TestTreeData? treeData, bool isContainer)
+        protected override TestTreeNode CreateTreeNode(string path, string label, int level, bool isFolder, bool isActive, bool isHidden, bool isCollapsed, bool isChecked, TestTreeData? treeData)
         {
             if (traceLogging)
             {
                 Logger.Trace(
-                    "CreateTreeNode(path: {0}, label: {1}, level: {2}, isFolder: {3}, " +
-                    "isActive: {4}, isHidden: {5}, isCollapsed: {6}, isChecked: {7}, treeData: {8})", path, label,
-                    level, isFolder, isActive, isHidden, isCollapsed, isChecked, treeData?.ToString() ?? "[NULL]");
+                    "CreateTreeNode(path: {0}, label: {1}, level: {2}, isFolder: {3}, isActive: {4}, isHidden: {5}, isCollapsed: {6}, isChecked: {7}, treeData: {8})",
+                    path, label, level, isFolder, isActive, isHidden, isCollapsed, isChecked, treeData?.ToString() ?? "[NULL]");
             }
 
             TestTreeListener.CreateTreeNode(path, label, level, isFolder, isActive, isHidden, isCollapsed, isChecked,


### PR DESCRIPTION
Fixes #830 

- The functionality to create a nested tree depends on sorting, such that the meta file immediately follows the file it is tracking, if any.

While fixing thie functionality, I got distracted by TreeBase seemingly having an effect on "container-ship." TreeBase does not have the functionality to determine if a tree node is a "container" (i.e. parents of meta files). This property is only set form the `ChangesTreeView`

In order to fix this.
1. Use a custom `IComparer` to get the expected order.
2. Remove functions in TreeBase that purport to set that value when creating a `TreeNode`

Thanks to @profet23 for fixing my logic errors.