### PR TITLE
Publishing a new branch

### DIFF
--- a/src/GitHub.Api/Git/GitBranch.cs
+++ b/src/GitHub.Api/Git/GitBranch.cs
@@ -10,12 +10,12 @@ namespace GitHub.Unity
         public string name;
         public string tracking;
 
-        public GitBranch(string name, string tracking)
+        public GitBranch(string name, string tracking = null)
         {
             Guard.ArgumentNotNullOrWhiteSpace(name, "name");
 
             this.name = name;
-            this.tracking = tracking;
+            this.tracking = tracking ?? string.Empty;
         }
 
         public override int GetHashCode()
@@ -64,7 +64,8 @@ namespace GitHub.Unity
 
         public override string ToString()
         {
-            return $"{Name} Tracking? {Tracking}";
+            var s = Tracking ?? "[NULL]";
+            return $"{Name} Tracking? {s}";
         }
     }
 }

--- a/src/GitHub.Api/Git/GitBranch.cs
+++ b/src/GitHub.Api/Git/GitBranch.cs
@@ -64,8 +64,7 @@ namespace GitHub.Unity
 
         public override string ToString()
         {
-            var s = Tracking ?? "[NULL]";
-            return $"{Name} Tracking? {s}";
+            return $"{Name} Tracking? {Tracking ?? "[NULL]"}";
         }
     }
 }

--- a/src/GitHub.Api/Git/Repository.cs
+++ b/src/GitHub.Api/Git/Repository.cs
@@ -247,7 +247,7 @@ namespace GitHub.Unity
             {
                 var data = new RepositoryInfoCacheData();
                 data.CurrentConfigBranch = branch;
-                data.CurrentGitBranch = branch.HasValue ? (GitBranch?)GetLocalGitBranch(branch.Value.name, branch.Value) : null;
+                data.CurrentGitBranch = branch.HasValue ? (GitBranch?)GetLocalGitBranch(branch.Value) : null;
                 data.CurrentConfigRemote = remote;
                 data.CurrentGitRemote = remote.HasValue ? (GitRemote?)GetGitRemote(remote.Value) : null;
                 data.CurrentHead = head;
@@ -303,15 +303,15 @@ namespace GitHub.Unity
         private void RepositoryManagerOnLocalBranchesUpdated(Dictionary<string, ConfigBranch> localConfigBranchDictionary)
         {
             taskManager.RunInUI(() => {
-                var gitLocalBranches = localConfigBranchDictionary.Values.Select(x => GetLocalGitBranch(CurrentBranchName, x)).ToArray();
+                var gitLocalBranches = localConfigBranchDictionary.Values.Select(x => GetLocalGitBranch(x)).ToArray();
                 cacheContainer.BranchCache.SetLocals(localConfigBranchDictionary, gitLocalBranches);
             });
         }
 
-        private static GitBranch GetLocalGitBranch(string currentBranchName, ConfigBranch x)
+        private static GitBranch GetLocalGitBranch(ConfigBranch x)
         {
             var branchName = x.Name;
-            var trackingName = x.IsTracking ? x.Remote.Value.Name + "/" + branchName : "[None]";
+            var trackingName = x.IsTracking ? x.Remote.Value.Name + "/" + branchName : null;
             return new GitBranch(branchName, trackingName);
         }
 

--- a/src/GitHub.Api/OutputProcessors/BranchListOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/BranchListOutputProcessor.cs
@@ -37,6 +37,11 @@ namespace GitHub.Unity
                 if (tracking)
                 {
                     trackingName = proc.ReadChunk('[', ']');
+                    var indexOf = trackingName.IndexOf(':');
+                    if (indexOf != -1)
+                    {
+                        trackingName = trackingName.Substring(0, indexOf);
+                    }
                 }
 
                 var branch = new GitBranch(name, trackingName);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -40,6 +40,7 @@ namespace GitHub.Unity
         [SerializeField] private int statusAhead;
         [SerializeField] private int statusBehind;
         [SerializeField] private bool hasItemsToCommit;
+        [SerializeField] private bool isTrackingRemoteBranch;
         [SerializeField] private GUIContent currentBranchContent;
         [SerializeField] private GUIContent currentRemoteUrlContent;
         [SerializeField] private CacheUpdateEvent lastCurrentBranchAndRemoteChangedEvent;
@@ -279,7 +280,17 @@ namespace GitHub.Unity
                     currentBranchAndRemoteHasUpdate = false;
 
                     var repositoryCurrentBranch = Repository.CurrentBranch;
-                    var updatedRepoBranch = repositoryCurrentBranch.HasValue ? repositoryCurrentBranch.Value.Name : null;
+                    string updatedRepoBranch;
+                    if (repositoryCurrentBranch.HasValue)
+                    {
+                        updatedRepoBranch = repositoryCurrentBranch.Value.Name;
+                        isTrackingRemoteBranch = !string.IsNullOrEmpty(repositoryCurrentBranch.Value.Tracking);
+                    }
+                    else
+                    {
+                        updatedRepoBranch = null;
+                        isTrackingRemoteBranch = false;
+                    }
 
                     var repositoryCurrentRemote = Repository.CurrentRemote;
                     if (repositoryCurrentRemote.HasValue)
@@ -313,6 +324,8 @@ namespace GitHub.Unity
             }
             else
             {
+                isTrackingRemoteBranch = false;
+
                 if (currentRemoteName != null)
                 {
                     currentRemoteName = null;
@@ -591,7 +604,7 @@ namespace GitHub.Unity
                     EditorGUI.EndDisabledGroup();
 
                     // Push button
-                    EditorGUI.BeginDisabledGroup(currentRemoteName == null || statusAhead == 0);
+                    EditorGUI.BeginDisabledGroup(currentRemoteName == null || isTrackingRemoteBranch && statusAhead == 0);
                     {
                         var pushButtonText = statusAhead > 0 ? new GUIContent(String.Format(Localization.PushButtonCount, statusAhead)) : pushButtonContent;
                         var pushClicked = GUILayout.Button(pushButtonText, Styles.ToolbarButtonStyle);

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -294,7 +294,7 @@ namespace GitHub.Unity
 
                     if (currentRemoteName != updatedRepoRemote)
                     {
-                        currentRemoteName = updatedRepoBranch;
+                        currentRemoteName = updatedRepoRemote;
                         shouldUpdateContentFields = true;
                     }
 

--- a/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
+++ b/src/tests/IntegrationTests/Process/ProcessManagerIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace IntegrationTests
                 .StartAsAsync();
 
             gitBranches.Should().BeEquivalentTo(
-                new GitBranch("master", "origin/master: behind 1"),
+                new GitBranch("master", "origin/master"),
                 new GitBranch("feature/document", "origin/feature/document"));
         }
 

--- a/src/tests/UnitTests/IO/BranchListOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/BranchListOutputProcessorTests.cs
@@ -15,14 +15,20 @@ namespace UnitTests
             {
                 "* master                          ef7ecf9 [origin/master] Some project master",
                 "  feature/feature-1               f47d41b Untracked Feature 1",
-                "  bugfixes/bugfix-1               e1b7f22 [origin/bugfixes/bugfix-1] Tracked Local Bugfix"
+                "  bugfixes/bugfix-1               e1b7f22 [origin/bugfixes/bugfix-1] Tracked Local Bugfix",
+                "  bugfixes/bugfix-2               e1b7f22 [origin/bugfixes/bugfix-2: ahead 3] Ahead with some changes",
+                "  bugfixes/bugfix-3               e1b7f22 [origin/bugfixes/bugfix-3: ahead 3, behind 116] Ahead and Behind",
+                "  bugfixes/bugfix-4               e1b7f22 [origin/bugfixes/bugfix-4: gone] No longer on server",
             };
 
             AssertProcessOutput(output, new[]
             {
                 new GitBranch("master", "origin/master"),
-                new GitBranch("feature/feature-1", ""),
+                new GitBranch("feature/feature-1"),
                 new GitBranch("bugfixes/bugfix-1", "origin/bugfixes/bugfix-1"),
+                new GitBranch("bugfixes/bugfix-2", "origin/bugfixes/bugfix-2"),
+                new GitBranch("bugfixes/bugfix-3", "origin/bugfixes/bugfix-3"),
+                new GitBranch("bugfixes/bugfix-4", "origin/bugfixes/bugfix-4"),
             });
         }
 


### PR DESCRIPTION
In addition to the problems mentioned in #839 

1. The `trackingName` field of `GitBranch` is used oddly. In some scenarios `[None]` was set in the field. I believe the field was previously used for user output.
2. `git branch -vv` would output more than the tracking branch name. It also outputs the ahead/behind, and pruned status of the remote branch.

In order to fix these issues.
1. `trackingName` field will be set to empty string if the branch does not track a remote.
2. Fixed the output processor
3. Updating the "Push" button to remain enabled if the branch is not tracking a remote

Fixes #839 