### PR TITLE
Revising StatusOutputPathComparer sorting algorithm because of edge case failure.

### DIFF
--- a/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/StatusOutputProcessor.cs
@@ -224,30 +224,21 @@ namespace GitHub.Unity
                 Guard.ArgumentNotNull(x, nameof(x));
                 Guard.ArgumentNotNull(y, nameof(y));
 
-                var metaString = ".meta";
-                var xIsMeta = x.EndsWith(metaString);
-                var yIsMeta = y.EndsWith(metaString);
+                const string meta = ".meta";
+                var xHasMeta = x.EndsWith(meta);
+                var yHasMeta = y.EndsWith(meta);
 
-                if (xIsMeta || yIsMeta)
+                if(!xHasMeta && !yHasMeta) return StringComparer.InvariantCulture.Compare(x, y);
+
+                var xPure = xHasMeta ? x.Substring(0, x.Length - meta.Length) : x;
+                var yPure = yHasMeta ? y.Substring(0, y.Length - meta.Length) : y;
+
+                if (xHasMeta)
                 {
-                    var compareX = !xIsMeta ? x : x.Substring(0, x.Length - 5);
-                    var compareY = !yIsMeta ? y : y.Substring(0, y.Length - 5);
-
-                    var comparisonResult = StringComparer.InvariantCultureIgnoreCase.Compare(compareX, compareY);
-                    if (comparisonResult != 0)
-                    {
-                        return comparisonResult;
-                    }
-
-                    if (xIsMeta)
-                    {
-                        return 1;
-                    }
-
-                    return -1;
+                    return xPure.Equals(y) ? 1 : StringComparer.InvariantCulture.Compare(xPure, yPure);
                 }
 
-                return StringComparer.InvariantCultureIgnoreCase.Compare(x, y);
+                return yPure.Equals(x) ? -1 : StringComparer.InvariantCulture.Compare(xPure, yPure);
             }
         }
     }

--- a/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
+++ b/src/tests/UnitTests/IO/StatusOutputProcessorTests.cs
@@ -303,6 +303,45 @@ namespace UnitTests
             });
         }
 
+        public void ShouldSortOutputCorrectly3()
+        {
+            var output = new[]
+            {
+                "## master",
+                "?? Assets/Assets.Test.dll",
+                "?? Assets/Assets.Test.dll.meta",
+                "?? Plugins/GitHub.Unity.dll",
+                "?? Plugins/GitHub.Unity.dll.mdb",
+                "?? Plugins/GitHub.Unity.dll.mdb.meta",
+                "?? Plugins/GitHub.Unity2.dll",
+                "?? Plugins/GitHub.Unity2.dll.mdb",
+                "?? Plugins/GitHub.Unity2.dll.mdb.meta",
+                "?? Plugins/GitHub.Unity2.dll.meta",
+                "?? Plugins/GitHub.Unity.dll.meta",
+                "?? blah.txt",
+                null
+            };
+
+            AssertProcessOutput(output, new GitStatus
+            {
+                LocalBranch = "master",
+                Entries = new List<GitStatusEntry>
+                {
+                    new GitStatusEntry(@"Assets/Assets.Test.dll", TestRootPath + @"\Assets/Assets.Test.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Assets/Assets.Test.dll.meta", TestRootPath + @"\Assets/Assets.Test.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"blah.txt", TestRootPath + @"\blah.txt", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll", TestRootPath + @"\Plugins/GitHub.Unity.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity.dll.mdb.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll", TestRootPath + @"\Plugins/GitHub.Unity2.dll", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.meta", TestRootPath + @"\Plugins/GitHub.Unity2.dll.meta", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.mdb", TestRootPath + @"\Plugins/GitHub.Unity2.dll.mdb", null, GitFileStatus.Untracked),
+                    new GitStatusEntry(@"Plugins/GitHub.Unity2.dll.mdb.meta", TestRootPath + @"\Plugins/GitHub.Unity2.dll.mdb.meta", null, GitFileStatus.Untracked),
+                }
+            });
+        }
+
         private void AssertProcessOutput(IEnumerable<string> lines, GitStatus expected)
         {
             var gitObjectFactory = SubstituteFactory.CreateGitObjectFactory(TestRootPath);


### PR DESCRIPTION
### Description of the Change

`StatusOutputPathComparer` sort fails on some edge cases. This enables support for such cases.

### Alternate Designs

Existing design had a bug, this is a small change to resolve the bug.

### Benefits

Sorting will work properly for the StatusOutputPathComparer usage.

### Possible Drawbacks

None known.

### Applicable Issues

