### PR TITLE
Add .xcf (gimp) file to lfs at default

### DIFF
--- a/src/GitHub.Api/Resources/.gitattributes
+++ b/src/GitHub.Api/Resources/.gitattributes
@@ -17,6 +17,7 @@
 *.iff filter=lfs diff=lfs merge=lfs -text
 *.pict filter=lfs diff=lfs merge=lfs -text
 *.dds filter=lfs diff=lfs merge=lfs -text
+*.xcf filter=lfs diff=lfs merge=lfs -text
 
 # Audio formats
 *.mp3 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### Description of the Change

At default settings Gimp .xcf filles are not included to lfs, this changes default .gitattributes to do so.

### Benefits

.psd is on list, but all users dosen't use Photoshop
