### PR TITLE
Support git-worktree on History

### DIFF
--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -69,6 +69,7 @@ namespace GitHub.Unity
             RepositoryPath = repositoryPath;
 
             DotGitPath = repositoryPath.Combine(".git");
+            NPath CommonPath;
             if (DotGitPath.FileExists())
             {
                 DotGitPath =
@@ -76,13 +77,28 @@ namespace GitHub.Unity
                               .Where(x => x.StartsWith("gitdir:"))
                               .Select(x => x.Substring(7).Trim().ToNPath())
                               .First();
+                if (DotGitPath.Combine("commondir").FileExists())
+                {
+                    CommonPath = DotGitPath.Combine("commondir").ReadAllLines()
+                        .Select(x => x.Trim().ToNPath())
+                        .First();
+                    CommonPath = DotGitPath.Combine(CommonPath);
+                }
+                else
+                {
+                    CommonPath = DotGitPath;
+                }
+            }
+            else
+            {
+                CommonPath = DotGitPath;
             }
 
-            BranchesPath = DotGitPath.Combine("refs", "heads");
-            RemotesPath = DotGitPath.Combine("refs", "remotes");
+            BranchesPath = CommonPath.Combine("refs", "heads");
+            RemotesPath = CommonPath.Combine("refs", "remotes");
             DotGitIndex = DotGitPath.Combine("index");
             DotGitHead = DotGitPath.Combine("HEAD");
-            DotGitConfig = DotGitPath.Combine("config");
+            DotGitConfig = CommonPath.Combine("config");
             DotGitCommitEditMsg = DotGitPath.Combine("COMMIT_EDITMSG");
         }
 

--- a/src/GitHub.Api/Git/RepositoryManager.cs
+++ b/src/GitHub.Api/Git/RepositoryManager.cs
@@ -60,6 +60,8 @@ namespace GitHub.Unity
         NPath DotGitIndex { get; }
         NPath DotGitHead { get; }
         NPath DotGitConfig { get; }
+        NPath WorktreeDotGitPath { get; }
+        bool IsWorktree { get; }
     }
 
     class RepositoryPathConfiguration : IRepositoryPathConfiguration
@@ -67,9 +69,10 @@ namespace GitHub.Unity
         public RepositoryPathConfiguration(NPath repositoryPath)
         {
             RepositoryPath = repositoryPath;
+            WorktreeDotGitPath = NPath.Default;
 
             DotGitPath = repositoryPath.Combine(".git");
-            NPath CommonPath;
+            NPath commonPath;
             if (DotGitPath.FileExists())
             {
                 DotGitPath =
@@ -79,30 +82,35 @@ namespace GitHub.Unity
                               .First();
                 if (DotGitPath.Combine("commondir").FileExists())
                 {
-                    CommonPath = DotGitPath.Combine("commondir").ReadAllLines()
+                    commonPath = DotGitPath.Combine("commondir").ReadAllLines()
                         .Select(x => x.Trim().ToNPath())
                         .First();
-                    CommonPath = DotGitPath.Combine(CommonPath);
+                    commonPath = DotGitPath.Combine(commonPath);
+
+                    IsWorktree = true;
+                    WorktreeDotGitPath = commonPath;
                 }
                 else
                 {
-                    CommonPath = DotGitPath;
+                    commonPath = DotGitPath;
                 }
             }
             else
             {
-                CommonPath = DotGitPath;
+                commonPath = DotGitPath;
             }
 
-            BranchesPath = CommonPath.Combine("refs", "heads");
-            RemotesPath = CommonPath.Combine("refs", "remotes");
+            BranchesPath = commonPath.Combine("refs", "heads");
+            RemotesPath = commonPath.Combine("refs", "remotes");
             DotGitIndex = DotGitPath.Combine("index");
             DotGitHead = DotGitPath.Combine("HEAD");
-            DotGitConfig = CommonPath.Combine("config");
+            DotGitConfig = commonPath.Combine("config");
             DotGitCommitEditMsg = DotGitPath.Combine("COMMIT_EDITMSG");
         }
 
+        public bool IsWorktree { get; }
         public NPath RepositoryPath { get; }
+        public NPath WorktreeDotGitPath { get; }
         public NPath DotGitPath { get; }
         public NPath BranchesPath { get; }
         public NPath RemotesPath { get; }

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -89,9 +89,9 @@ namespace GitHub.Unity
 
                 expectedRepositoryPath = repositoryPath != null ? repositoryPath.Value : UnityProjectPath;
 
-                if (!expectedRepositoryPath.DirectoryExists(".git"))
+                if (!expectedRepositoryPath.Exists(".git"))
                 {
-                    NPath reporoot = UnityProjectPath.RecursiveParents.FirstOrDefault(d => d.DirectoryExists(".git"));
+                    NPath reporoot = UnityProjectPath.RecursiveParents.FirstOrDefault(d => d.Exists(".git"));
                     if (reporoot.IsInitialized)
                         expectedRepositoryPath = reporoot;
                 }
@@ -102,7 +102,7 @@ namespace GitHub.Unity
             }
 
             FileSystem.SetCurrentDirectory(expectedRepositoryPath);
-            if (expectedRepositoryPath.DirectoryExists(".git"))
+            if (expectedRepositoryPath.Exists(".git"))
             {
                 RepositoryPath = expectedRepositoryPath;
                 Repository = new Repository(RepositoryPath, CacheContainer);


### PR DESCRIPTION
#865 You can display the history when opening working directory made with `git-worktree`.
