### PR TITLE
Use local zips when developing

### DIFF
--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -295,8 +295,25 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <Copy
+      SourceFiles="PlatformResources\linux\git-lfs.zip;PlatformResources\linux\git-lfs.json"
+      DestinationFolder="$(SolutionDir)\src\UnityExtension\Assets\Editor\GitHub.Unity\PlatformResources\linux"
+      SkipUnchangedFiles="true"
+      />
+
+    <Copy
+      SourceFiles="PlatformResources\mac\git-lfs.zip;PlatformResources\mac\git-lfs.json"
+      DestinationFolder="$(SolutionDir)\src\UnityExtension\Assets\Editor\GitHub.Unity\PlatformResources\mac"
+      SkipUnchangedFiles="true"
+      />
+
+    <Copy
+      SourceFiles="PlatformResources\windows\git.zip;PlatformResources\windows\git.json;PlatformResources\windows\git-lfs.zip;PlatformResources\windows\git-lfs.json"
+      DestinationFolder="$(SolutionDir)\src\UnityExtension\Assets\Editor\GitHub.Unity\PlatformResources\windows"
+      SkipUnchangedFiles="true"
+      />
+  </Target>
   <Import Project="..\..\common\build.targets" />
 </Project>

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -55,8 +55,14 @@ namespace GitHub.Unity
             }
 
             state = VerifyZipFiles(state);
+            // on developer builds, prefer local zips over downloading
+#if DEVELOPER_BUILD
+            state = GrabZipFromResourcesIfNeeded(state);
+            state = GetZipsIfNeeded(state);
+#else
             state = GetZipsIfNeeded(state);
             state = GrabZipFromResourcesIfNeeded(state);
+#endif
             state = ExtractGit(state);
 
             // if installing from zip failed (internet down maybe?), try to find a usable system git

--- a/src/UnityExtension/.gitignore
+++ b/src/UnityExtension/.gitignore
@@ -2,3 +2,6 @@
 UnityPackageManager
 JetBrains
 UnityExtension.sln
+Assets/**/*.zip
+Assets/**/*.md5
+Assets/**/*.json


### PR DESCRIPTION
When running developer builds, it's very likely that the git zips are going to be in the local path, so we can look there first instead of requiring the local web server to be running. The zips get copied to the `src/UnityExtension` part, so when prototyping in Unity directly in the source repo, the zips will be available, hopefully cutting down on the bootstrap time.