### PR TITLE
Correcting progress updating

### DIFF
--- a/src/GitHub.Api/Helpers/Progress.cs
+++ b/src/GitHub.Api/Helpers/Progress.cs
@@ -72,8 +72,7 @@ namespace GitHub.Unity
             float fTotal = Total;
             float fValue = Value;
             Percentage = fValue / fTotal;
-            float delta = fValue / fTotal - previousValue / fTotal;
-            delta = delta * 100f / fTotal;
+            var delta = (fValue / fTotal - previousValue / fTotal) * 100f;
 
             if (Value != previousValue && (fValue == 0f || delta > 1f || fValue == fTotal))
             { // signal progress in 1% increments or if we don't know what the total is


### PR DESCRIPTION
Fixes #854

A simple math error caused the computation of the progress delta to be infinitesimally small.