### PR TITLE
Downloader hangs when executed with no items

### DIFF
--- a/src/GitHub.Api/Tasks/ActionTask.cs
+++ b/src/GitHub.Api/Tasks/ActionTask.cs
@@ -31,16 +31,30 @@ namespace GitHub.Unity
 
         public override void RunSynchronously()
         {
-            foreach (var task in queuedTasks)
-                task.Start();
-            base.RunSynchronously();
+            if (queuedTasks.Any())
+            {
+                foreach (var task in queuedTasks)
+                    task.Start();
+                base.RunSynchronously();
+            }
+            else
+            {
+                aggregateTask.TrySetResult(true);
+            }
         }
 
         protected override void Schedule()
         {
-            foreach (var task in queuedTasks)
-                task.Start();
-            base.Schedule();
+            if (queuedTasks.Any())
+            {
+                foreach (var task in queuedTasks)
+                    task.Start();
+                base.Schedule();
+            }
+            else
+            {
+                aggregateTask.TrySetResult(true);
+            }
         }
 
         private void InvokeFinishOnlyOnSuccess(ITask task, bool success, Exception ex)
@@ -115,16 +129,29 @@ namespace GitHub.Unity
 
         public override List<TResult> RunSynchronously()
         {
-            foreach (var task in queuedTasks)
+            if (queuedTasks.Any())
+            {
+                foreach (var task in queuedTasks)
                 task.Start();
-            return base.RunSynchronously();
+                return base.RunSynchronously();
+            }
+
+            aggregateTask.TrySetResult(new List<TResult>());
+            return Result;
         }
 
         protected override void Schedule()
         {
-            foreach (var task in queuedTasks)
+            if (queuedTasks.Any())
+            {
+                foreach (var task in queuedTasks)
                 task.Start();
-            base.Schedule();
+                base.Schedule();
+            }
+            else
+            {
+                aggregateTask.TrySetResult(new List<TResult>());
+            }
         }
 
         private void InvokeFinishOnlyOnSuccess(ITask<TTaskResult> task, TTaskResult result, bool success, Exception ex)

--- a/src/GitHub.Api/Tasks/ActionTask.cs
+++ b/src/GitHub.Api/Tasks/ActionTask.cs
@@ -35,12 +35,13 @@ namespace GitHub.Unity
             {
                 foreach (var task in queuedTasks)
                     task.Start();
-                base.RunSynchronously();
             }
             else
             {
                 aggregateTask.TrySetResult(true);
             }
+
+            base.RunSynchronously();
         }
 
         protected override void Schedule()
@@ -49,12 +50,13 @@ namespace GitHub.Unity
             {
                 foreach (var task in queuedTasks)
                     task.Start();
-                base.Schedule();
             }
             else
             {
                 aggregateTask.TrySetResult(true);
             }
+
+            base.Schedule();
         }
 
         private void InvokeFinishOnlyOnSuccess(ITask task, bool success, Exception ex)
@@ -132,12 +134,14 @@ namespace GitHub.Unity
             if (queuedTasks.Any())
             {
                 foreach (var task in queuedTasks)
-                task.Start();
-                return base.RunSynchronously();
+                    task.Start();
+            }
+            else
+            {
+                aggregateTask.TrySetResult(new List<TResult>());
             }
 
-            aggregateTask.TrySetResult(new List<TResult>());
-            return Result;
+            return base.RunSynchronously();
         }
 
         protected override void Schedule()
@@ -145,13 +149,14 @@ namespace GitHub.Unity
             if (queuedTasks.Any())
             {
                 foreach (var task in queuedTasks)
-                task.Start();
-                base.Schedule();
+                    task.Start();
             }
             else
             {
                 aggregateTask.TrySetResult(new List<TResult>());
             }
+
+            base.Schedule();
         }
 
         private void InvokeFinishOnlyOnSuccess(ITask<TTaskResult> task, TTaskResult result, bool success, Exception ex)


### PR DESCRIPTION
Might be related to: #841 

Depends on:
- [x] #879 

Testing local builds, where the conditions for downloading resources are slightly different.
I found an issue where the `Downloader` will hang when `RunSynchronously` is called with no items in the queue.

https://github.com/github-for-unity/Unity/blob/675714afdabd86a0ccbcf51837d36705ee9425c8/src/GitHub.Api/Installer/GitInstaller.cs#L260-L264

It hangs because `TrySetResult`/`TrySetException` is never called.