### PR TITLE
Adding Commitizen Support

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -11,6 +11,7 @@ namespace GitHub.Unity
         public const string TraceLoggingKey = "EnableTraceLogging";
         public const string WebTimeoutKey = "WebTimeout";
         public const string GitTimeoutKey = "GitTimeout";
+        public const string CommitizenKey = "Commitizen";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
         public static readonly string[] Iso8601Formats = {

--- a/src/GitHub.Logging/LogHelper.cs
+++ b/src/GitHub.Logging/LogHelper.cs
@@ -23,6 +23,23 @@ namespace GitHub.Logging
             }
         }
 
+        private static bool commitizenEnabled;
+        public static bool CommitizenEnabled
+        {
+            get
+            {
+                return commitizenEnabled;
+            }
+            set
+            {
+                if (commitizenEnabled != value)
+                {
+                    commitizenEnabled = value;
+                    Instance.Info("Commitizen " + (value ? "Enabled" : "Disabled"));
+                }
+            }
+        }
+
         private static LogAdapterBase logAdapter = nullLogAdapter;
 
         public static LogAdapterBase LogAdapter

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -34,6 +34,24 @@ namespace GitHub.Unity
         private const string ScopeLabel = "Scope";
         private const string FooterLabel = "Commit Footer";
 
+        private static Dictionary<CommitType, string> TypeDescription = new Dictionary<CommitType, string>()
+        {
+            {CommitType.Feat, "A new feature"},
+            {CommitType.Fix, "A bug fix"},
+            {CommitType.Doc, "Documentation only changes"},
+            {
+                CommitType.Style,
+                "Changes that do not affect the meaning of the code(white-space, formatting, missing semi-colons, etc)"
+            },
+            {CommitType.Refactor, "A code change that neither fixes a bug or add a feature"},
+            {CommitType.Perf, "A code change that improves performance"},
+            {CommitType.Test, "Adding missing tests"},
+            {
+                CommitType.Chore,
+                "Changes to the build process or auxiliary tools and libraries such as documentation generation"
+            }
+        };
+
         [SerializeField] private bool currentBranchHasUpdate;
         [SerializeField] private bool currentStatusEntriesHasUpdate;
         [SerializeField] private bool currentLocksHasUpdate;
@@ -508,7 +526,7 @@ namespace GitHub.Unity
                 GUILayout.BeginVertical();
                 {
                     GUILayout.Space(Styles.CommitAreaPadding);
-
+                    EditorGUILayout.HelpBox(TypeDescription[commitType], MessageType.Info);
                     GUILayout.BeginHorizontal();
                     {
                         commitType = (CommitType)EditorGUILayout.EnumPopup(TypeLabel, commitType);
@@ -578,7 +596,7 @@ namespace GitHub.Unity
             {
                 scope = scope != "" ? string.Format("({0})", scope) : "";
                 footer = footer != "" ? string.Format("({0})", footer) : "";
-                commitMessage = string.Format("{0}{1}:{2}{3}", commitType, scope, commitMessage, footer);
+                commitMessage = string.Format("{0}{1}:{2} {3}", commitType, scope, commitMessage, footer);
             }
 
             if (files.Count == gitStatusEntries.Count)
@@ -599,6 +617,9 @@ namespace GitHub.Unity
 
                             commitMessage = "";
                             commitBody = "";
+                            scope = "";
+                            footer = "";
+                            commitType = CommitType.Feat;
                         }
                         isBusy = false;
                     }).Start();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -6,6 +6,18 @@ using UnityEngine;
 
 namespace GitHub.Unity
 {
+    enum CommitType
+    {
+        Feat,
+        Fix,
+        Doc,
+        Style,
+        Refactor,
+        Perf,
+        Test,
+        Chore
+    }
+
     [Serializable]
     class ChangesView : Subview
     {
@@ -18,9 +30,23 @@ namespace GitHub.Unity
         private const string OneChangedFileLabel = "1 changed file";
         private const string NoChangedFilesLabel = "No changed files";
 
+        private const string TypeLabel = "Type";
+        private const string ScopeLabel = "Scope";
+        private const string SubjectLabel = "Subject";
+        private const string BodytLabel = "Body";
+        private const string FooterLabel = "Footer";
+
         [SerializeField] private bool currentBranchHasUpdate;
         [SerializeField] private bool currentStatusEntriesHasUpdate;
         [SerializeField] private bool currentLocksHasUpdate;
+
+        private bool useCommitizen
+        {
+            get
+            {
+                return Manager.UserSettings.Get(Constants.CommitizenKey, true);
+            }
+        }
 
         [NonSerialized] private GUIContent discardGuiContent;
         [NonSerialized] private bool isBusy;
@@ -28,6 +54,10 @@ namespace GitHub.Unity
         [SerializeField] private string commitBody = "";
         [SerializeField] private string commitMessage = "";
         [SerializeField] private string currentBranch = "[unknown]";
+
+        [SerializeField] private CommitType commitType = CommitType.Feat;
+        [SerializeField] private string scope = "";
+        [SerializeField] private string footer = "";
 
         [SerializeField] private Vector2 treeScroll;
         [SerializeField] private ChangesTree treeChanges = new ChangesTree { DisplayRootNode = false, IsCheckable = true, IsUsingGlobalSelection = true };
@@ -95,7 +125,15 @@ namespace GitHub.Unity
             DoProgressGUI();
 
             // Do the commit details area
-            DoCommitGUI();
+            if (useCommitizen)
+            {
+                DoCommitizenGUI();
+            }
+            else
+            {
+                DoCommitGUI();
+            }
+
             EditorGUI.EndDisabledGroup();
         }
 
@@ -463,6 +501,65 @@ namespace GitHub.Unity
             GUILayout.EndHorizontal();
         }
 
+        private void DoCommitizenGUI()
+        {
+            GUILayout.BeginHorizontal();
+            {
+                GUILayout.Space(Styles.CommitAreaPadding);
+
+                GUILayout.BeginVertical();
+                {
+                    GUILayout.Space(Styles.CommitAreaPadding);
+
+                    GUILayout.BeginHorizontal();
+                    {
+                        commitType = (CommitType)EditorGUILayout.EnumPopup(TypeLabel, commitType);
+                        GUILayout.Label(ScopeLabel);
+                        scope = EditorGUILayout.TextField(scope, Styles.TextFieldStyle);
+                    }
+                    GUILayout.EndHorizontal();
+
+                    GUILayout.Label(SubjectLabel);
+                    commitMessage = EditorGUILayout.TextField(commitMessage, Styles.TextFieldStyle);
+                    GUILayout.Space(Styles.CommitAreaPadding * 2);
+
+                    GUILayout.Label(DescriptionLabel);
+                    commitBody = EditorGUILayout.TextArea(commitBody, Styles.CommitDescriptionFieldStyle, GUILayout.Height(6 * 15f));
+
+                    GUILayout.Space(Styles.CommitAreaPadding);
+
+                    GUILayout.Label(FooterLabel);
+                    footer = EditorGUILayout.TextField(footer, Styles.TextFieldStyle);
+
+                    GUILayout.Space(Styles.CommitAreaPadding);
+
+                    // Disable committing when already committing or if we don't have all the data needed
+                    //Debug.LogFormat("IsBusy:{0} string.IsNullOrEmpty(commitMessage): {1} treeChanges.GetCheckedFiles().Any(): {2}", 
+                    //    IsBusy, string.IsNullOrEmpty(commitMessage), treeChanges.GetCheckedFiles().Any());
+                    EditorGUI.BeginDisabledGroup(IsBusy || string.IsNullOrEmpty(commitMessage) || !treeChanges.GetCheckedFiles().Any());
+                    {
+                        GUILayout.BeginHorizontal();
+                        {
+                            GUILayout.FlexibleSpace();
+                            if (GUILayout.Button(String.Format(CommitButton, currentBranch), Styles.CommitButtonStyle))
+                            {
+                                GUI.FocusControl(null);
+                                Commit();
+                            }
+                        }
+                        GUILayout.EndHorizontal();
+                    }
+                    EditorGUI.EndDisabledGroup();
+
+                    GUILayout.Space(Styles.CommitAreaPadding);
+                }
+                GUILayout.EndVertical();
+
+                GUILayout.Space(Styles.CommitAreaPadding);
+            }
+            GUILayout.EndHorizontal();
+        }
+
         private void SelectAll()
         {
             this.treeChanges.SetCheckStateOnAll(true);
@@ -478,6 +575,13 @@ namespace GitHub.Unity
             isBusy = true;
             var files = treeChanges.GetCheckedFiles().ToList();
             ITask addTask;
+
+            if (useCommitizen)
+            {
+                scope = scope != "" ? string.Format("({0})", scope) : "";
+                footer = footer != "" ? string.Format("({0})", footer) : "";
+                commitMessage = string.Format("{0}{1}:{2}{3}", commitType, scope, commitMessage, footer);
+            }
 
             if (files.Count == gitStatusEntries.Count)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -30,11 +30,9 @@ namespace GitHub.Unity
         private const string OneChangedFileLabel = "1 changed file";
         private const string NoChangedFilesLabel = "No changed files";
 
-        private const string TypeLabel = "Type";
+        private const string TypeLabel = "Commit Type";
         private const string ScopeLabel = "Scope";
-        private const string SubjectLabel = "Subject";
-        private const string BodytLabel = "Body";
-        private const string FooterLabel = "Footer";
+        private const string FooterLabel = "Commit Footer";
 
         [SerializeField] private bool currentBranchHasUpdate;
         [SerializeField] private bool currentStatusEntriesHasUpdate;
@@ -519,7 +517,7 @@ namespace GitHub.Unity
                     }
                     GUILayout.EndHorizontal();
 
-                    GUILayout.Label(SubjectLabel);
+                    GUILayout.Label(SummaryLabel);
                     commitMessage = EditorGUILayout.TextField(commitMessage, Styles.TextFieldStyle);
                     GUILayout.Space(Styles.CommitAreaPadding * 2);
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -22,10 +22,13 @@ namespace GitHub.Unity
         private const string EnableTraceLoggingLabel = "Enable Trace Logging";
         private const string MetricsOptInLabel = "Help us improve by sending anonymous usage data";
         private const string DefaultRepositoryRemoteName = "origin";
+        private const string CommitToolSettingTitle = "Commit Message Tool";
+        private const string UseCommitizenLabel = "Use Commitizen";
 
         [NonSerialized] private bool currentRemoteHasUpdate;
         [NonSerialized] private bool isBusy;
         [NonSerialized] private bool metricsHasChanged;
+        [NonSerialized] private bool commitizen;
 
         [SerializeField] private GitPathView gitPathView = new GitPathView();
         [SerializeField] private bool hasRemote;
@@ -104,6 +107,7 @@ namespace GitHub.Unity
                 OnPrivacyGui();
                 OnGeneralSettingsGui();
                 OnLoggingSettingsGui();
+                OnCommitMessageSettingGui();
             }
 
             GUILayout.EndScrollView();
@@ -266,6 +270,23 @@ namespace GitHub.Unity
             {
                 ApplicationConfiguration.GitTimeout = gitTimeout;
                 Manager.UserSettings.Set(Constants.GitTimeoutKey, gitTimeout);
+            }
+        }
+
+        private void OnCommitMessageSettingGui()
+        {
+            GUILayout.Label(CommitToolSettingTitle, EditorStyles.boldLabel);
+
+            commitizen = LogHelper.CommitizenEnabled;
+
+            EditorGUI.BeginChangeCheck();
+            {
+                commitizen = GUILayout.Toggle(commitizen, UseCommitizenLabel);
+            }
+            if (EditorGUI.EndChangeCheck())
+            {
+                LogHelper.CommitizenEnabled = commitizen;
+                Manager.UserSettings.Set(Constants.CommitizenKey, commitizen);
             }
         }
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/SettingsView.cs
@@ -28,12 +28,12 @@ namespace GitHub.Unity
         [NonSerialized] private bool currentRemoteHasUpdate;
         [NonSerialized] private bool isBusy;
         [NonSerialized] private bool metricsHasChanged;
-        [NonSerialized] private bool commitizen;
 
         [SerializeField] private GitPathView gitPathView = new GitPathView();
         [SerializeField] private bool hasRemote;
         [SerializeField] private CacheUpdateEvent lastCurrentRemoteChangedEvent;
         [SerializeField] private bool metricsEnabled;
+        [SerializeField] private bool commitizen;
         [SerializeField] private string newRepositoryRemoteUrl;
         [SerializeField] private string repositoryRemoteName;
         [SerializeField] private string repositoryRemoteUrl;


### PR DESCRIPTION
Hi, 

Dear Unity develop team, I've made a pull request which add a new way to write better commit message a in case of team-work.

This style of commit message is popular in NodeJS developers.

### Requirements

* No extra requirements required except codes in this pull request.

### Description of the Change

Reasonable commit message made easy. 

By enable this feature, you can add more standard field for your commit message.

This feature is always optional for user, they can still use the original way to write commit message.

Following extra field is included in each commit without extra requires. They will be formatted as standard git commit message.

+ `type`:   Your commit type, just choose from listed options (just like fix, doc, etc).
+ `scope`: How does your codes affecting the scope of the project.
+ `footer`: Extra info for your commit outside the description, please check commitizen to understand how it works.

This pull requests add a feature which allows user to write better commit message which is similar to [Commitizen](https://github.com/commitizen/cz-cli). 

This is the usage preview of original project: 
![ simple how to](https://raw.githubusercontent.com/commitizen/cz-cli/master/meta/screenshots/add-commit.png)

>  Get instant feedback on your commit message formatting and be prompted for required fields.


Finally, it generates commit message like:

```
 CommitType(scope): the commit title (footer)

the description

```


### Alternate Designs

This feature is optional, it counts while you are working in a team which requires reasonable commit message. 

### Benefits

+ Reasonable commit message made easy.
+ You can easily choose your commit-type by a simple click.
+ You could gain a lot from specify commit-type, 

### Possible Drawbacks

* Makes almost no affects on users since it's optional, just work in old way or use new way by a simple click.

### Applicable Issues

Almost no.

### Screenshots and References
[Commitizen](https://github.com/commitizen/cz-cli) is a commit message style tool.

#### Enable "commitizen" by checking the checkbox.
![image](https://user-images.githubusercontent.com/8806796/45584619-801c9080-b909-11e8-960f-037b7ef8ee86.png)

#### Write commit message in new way
![image](https://user-images.githubusercontent.com/8806796/45584625-9a566e80-b909-11e8-92ce-48d39a16fe29.png)

