### PR TITLE
Update octorun packager to also update the version file

### DIFF
--- a/create-octorun-zip.sh
+++ b/create-octorun-zip.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 DIR=$(pwd)
-submodules/packaging/octorun/run.sh --path $DIR/octorun --out $DIR/src/GitHub.Api/Resources
+submodules/packaging/octorun/run.sh --path $DIR/octorun --out $DIR/src/GitHub.Api/Resources --source $DIR/src/GitHub.Api/Installer


### PR DESCRIPTION
This makes the octorun packager script update `version` file with the latest commit that touched the `octorun` directory. It also takes that commit hash and changes the `OctorunInstaller.cs` file with it, so that everything is in sync.