### PR TITLE
Disable the extension loader if the extension is disabled

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.cs
@@ -32,6 +32,10 @@ namespace GitHub.Unity
 
         static ExtensionLoader()
         {
+            if (Environment.GetEnvironmentVariable("GITHUB_UNITY_DISABLE") == "1")
+            {
+                return;
+            }
             EditorApplication.update += Initialize;
         }
 


### PR DESCRIPTION
When we're packaging it's important that the extension not be running or changed in any way, and that's done by setting the `GITHUB_UNITY_DISABLE` environment variable to `1`. The extension loader should also not do anything if the env var is set.