### PR TITLE
Handling file names that look like they are a drive letter

### DIFF
--- a/src/GitHub.Api/IO/NiceIO.cs
+++ b/src/GitHub.Api/IO/NiceIO.cs
@@ -113,7 +113,7 @@ namespace GitHub.Unity
 
         private static string ParseDriveLetter(string path, out string driveLetter)
         {
-            if (path.Length >= 2 && path[1] == ':')
+            if (path.Length >= 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\'))
             {
                 driveLetter = path[0].ToString();
                 return path.Substring(2);

--- a/src/tests/UnitTests/IO/GitObjectFactoryTests.cs
+++ b/src/tests/UnitTests/IO/GitObjectFactoryTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests
                 CurrentDirectory = @"c:\Projects\UnityProject"
             });
 
-            var environment = NSubstitute.Substitute.For<IEnvironment>();
+            var environment = Substitute.For<IEnvironment>();
             environment.RepositoryPath.Returns(@"c:\Projects\UnityProject".ToNPath());
             environment.UnityProjectPath.Returns(@"c:\Projects\UnityProject".ToNPath());
 
@@ -37,7 +37,7 @@ namespace UnitTests
                 CurrentDirectory = @"c:\Projects\UnityProject"
             });
 
-            var environment = NSubstitute.Substitute.For<IEnvironment>();
+            var environment = Substitute.For<IEnvironment>();
             environment.RepositoryPath.Returns(@"c:\Projects\UnityProject".ToNPath());
             environment.UnityProjectPath.Returns(@"c:\Projects\UnityProject".ToNPath());
 

--- a/src/tests/UnitTests/IO/GitObjectFactoryTests.cs
+++ b/src/tests/UnitTests/IO/GitObjectFactoryTests.cs
@@ -1,0 +1,50 @@
+using GitHub.Unity;
+using NCrunch.Framework;
+using NSubstitute;
+using NUnit.Framework;
+using TestUtils;
+
+namespace UnitTests
+{
+    [TestFixture, Isolated]
+    class GitObjectFactoryTests
+    {
+        private static readonly SubstituteFactory SubstituteFactory = new SubstituteFactory();
+
+        [Test]
+        public void ShouldParseNormalFile()
+        {
+            NPath.FileSystem = SubstituteFactory.CreateFileSystem(new CreateFileSystemOptions() {
+                CurrentDirectory = @"c:\Projects\UnityProject"
+            });
+
+            var environment = NSubstitute.Substitute.For<IEnvironment>();
+            environment.RepositoryPath.Returns(@"c:\Projects\UnityProject".ToNPath());
+            environment.UnityProjectPath.Returns(@"c:\Projects\UnityProject".ToNPath());
+
+            var gitObjectFactory = new GitObjectFactory(environment);
+            var gitStatusEntry = gitObjectFactory.CreateGitStatusEntry("hello.txt", GitFileStatus.Deleted);
+
+            Assert.AreEqual(@"c:\Projects\UnityProject\hello.txt", gitStatusEntry.FullPath);
+        }
+
+
+        [Test]
+        public void ShouldParseOddFile()
+        {
+            NPath.FileSystem = SubstituteFactory.CreateFileSystem(new CreateFileSystemOptions()
+            {
+                CurrentDirectory = @"c:\Projects\UnityProject"
+            });
+
+            var environment = NSubstitute.Substitute.For<IEnvironment>();
+            environment.RepositoryPath.Returns(@"c:\Projects\UnityProject".ToNPath());
+            environment.UnityProjectPath.Returns(@"c:\Projects\UnityProject".ToNPath());
+
+            var gitObjectFactory = new GitObjectFactory(environment);
+            var gitStatusEntry = gitObjectFactory.CreateGitStatusEntry("c:UsersOculusGoVideo.mp4", GitFileStatus.Deleted);
+
+            Assert.AreEqual(@"c:\Projects\UnityProject\c:UsersOculusGoVideo.mp4", gitStatusEntry.FullPath);
+        }
+    }
+}

--- a/src/tests/UnitTests/UnitTests.csproj
+++ b/src/tests/UnitTests/UnitTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Git\GitConfigTests.cs" />
     <Compile Include="IO\BranchListOutputProcessorTests.cs" />
     <Compile Include="Extensions\EnvironmentExtensionTests.cs" />
+    <Compile Include="IO\GitObjectFactoryTests.cs" />
     <Compile Include="IO\LfsVersionOutputProcessorTests.cs" />
     <Compile Include="IO\LinuxDiskUsageOutputProcessorTests.cs" />
     <Compile Include="IO\LockOutputProcessorTests.cs" />


### PR DESCRIPTION
In a user's repo the file `c:UsersOculusGoVideo.mp4` exists in history and trips up the log parsing process. The fix is being made in NPath (our IO library).

https://github.com/github-for-unity/Unity/blob/3a9593c3766e76dd3d6d7ec6d3b4aceac8441202/src/GitHub.Api/IO/NiceIO.cs#L114-L124

Tests have been added to verify this case works.

Fixes: #922
Related to #899 - https://github.com/github-for-unity/Unity/issues/899#issuecomment-426667124