### PR TITLE
Cancelling invalidation of cache

### DIFF
--- a/src/GitHub.Api/Cache/CacheInterfaces.cs
+++ b/src/GitHub.Api/Cache/CacheInterfaces.cs
@@ -40,6 +40,7 @@ namespace GitHub.Unity
 
         bool ValidateData();
         void InvalidateData();
+        void ResetInvalidation();
 
         DateTimeOffset LastUpdatedAt { get; }
         CacheType CacheType { get; }
@@ -91,7 +92,7 @@ namespace GitHub.Unity
         ILocalConfigBranchDictionary LocalConfigBranches { get; }
         IRemoteConfigBranchDictionary RemoteConfigBranches { get; }
         IConfigRemoteDictionary ConfigRemotes { get; }
-        
+
         void SetRemotes(Dictionary<string, ConfigRemote> remoteConfigs, Dictionary<string, Dictionary<string, ConfigBranch>> configBranches, GitRemote[] gitRemotes, GitBranch[] gitBranches);
         void SetLocals(Dictionary<string, ConfigBranch> configBranches, GitBranch[] gitBranches);
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ApplicationCache.cs
@@ -213,12 +213,14 @@ namespace GitHub.Unity
 
         private void Invalidate()
         {
-            if (!isInvalidating)
-            {
-                isInvalidating = true;
-                LastUpdatedAt = DateTimeOffset.MinValue;
-                CacheInvalidated.SafeInvoke(CacheType);
-            }
+            isInvalidating = true;
+            LastUpdatedAt = DateTimeOffset.MinValue;
+            CacheInvalidated.SafeInvoke(CacheType);
+        }
+
+        public void ResetInvalidation()
+        {
+            isInvalidating = false;
         }
 
         protected void SaveData(DateTimeOffset now, bool isChanged)
@@ -463,25 +465,25 @@ namespace GitHub.Unity
                 isUpdated = true;
             }
 
-            if (forcedInvalidation ||!Nullable.Equals(currentGitBranch, data.CurrentGitBranch))
+            if (forcedInvalidation || !Nullable.Equals(currentGitBranch, data.CurrentGitBranch))
             {
                 currentGitBranch = data.CurrentGitBranch ?? GitBranch.Default;
                 isUpdated = true;
             }
 
-            if (forcedInvalidation ||!Nullable.Equals(currentConfigRemote, data.CurrentConfigRemote))
+            if (forcedInvalidation || !Nullable.Equals(currentConfigRemote, data.CurrentConfigRemote))
             {
                 currentConfigRemote = data.CurrentConfigRemote ?? ConfigRemote.Default;
                 isUpdated = true;
             }
 
-            if (forcedInvalidation ||!Nullable.Equals(currentConfigBranch, data.CurrentConfigBranch))
+            if (forcedInvalidation || !Nullable.Equals(currentConfigBranch, data.CurrentConfigBranch))
             {
                 currentConfigBranch = data.CurrentConfigBranch ?? ConfigBranch.Default;
                 isUpdated = true;
             }
 
-            if (forcedInvalidation ||!String.Equals(currentHead, data.CurrentHead))
+            if (forcedInvalidation || !String.Equals(currentHead, data.CurrentHead))
             {
                 currentHead = data.CurrentHead;
                 isUpdated = true;

--- a/src/tests/IntegrationTests/CachingClasses.cs
+++ b/src/tests/IntegrationTests/CachingClasses.cs
@@ -109,6 +109,7 @@ namespace IntegrationTests
         private DateTimeOffset? initializedAtValue;
 
         private bool isInvalidating;
+        protected bool forcedInvalidation;
 
         public event Action<CacheType> CacheInvalidated;
         public event Action<CacheType, DateTimeOffset> CacheUpdated;
@@ -134,13 +135,20 @@ namespace IntegrationTests
 
         public void InvalidateData()
         {
-            if (!isInvalidating)
-            {
-                Logger.Trace("Invalidate");
-                isInvalidating = true;
-                LastUpdatedAt = DateTimeOffset.MinValue;
-                CacheInvalidated.SafeInvoke(CacheType);
-            }
+            forcedInvalidation = true;
+            Invalidate();
+        }
+
+        private void Invalidate()
+        {
+            isInvalidating = true;
+            LastUpdatedAt = DateTimeOffset.MinValue;
+            CacheInvalidated.SafeInvoke(CacheType);
+        }
+
+        public void ResetInvalidation()
+        {
+            isInvalidating = false;
         }
 
         protected void SaveData(DateTimeOffset now, bool isChanged)


### PR DESCRIPTION
Under normal operation a user interface interaction will query the cache for data. If the data in the cache is out of date, the cache will be invalidated. after which the `RepositoryManager` and `User` objects respectively start the appropriate task(s) to refresh and update the cache. To prevent multiple calls to refresh and update the cache, a flag `isInvalidating`, is set. When the cache is refreshed, the user interface will receive an event indicating as much and will reload the display from the cache.

It is possible that an error occurs after the cache is invalidated and the process to refresh and update the cache fails. In that case a user will be "stuck", be cause the `isInvalidating` flag is never set to false. And further queries of the cache will not spur the actions to refresh it.

This pull request adds error handlers to the tasks initiated by `RepositoryManager` and `User` in order to "cancel" the invalidation process by setting the `isInvalidating` flag to false. Allowing further user interface actions to attempt to reload the data.

#### Depends on:
- [x] #921 being merged to `master`