### PR TITLE
Fix bug to check parent file when meta is checked

### DIFF
--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -332,7 +332,6 @@ namespace GitHub.Unity
             return results;
         }
 
-
         private void ToggleParentFoldersChecked(int idx, TNode node, bool isChecked)
         {
             while (true)

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -261,7 +261,7 @@ namespace GitHub.Unity
                 ToggleChildrenChecked(idx, node, isChecked);
             }
 
-            ToggleParentFolderAndContainersChecked(idx, node, isChecked);
+            ToggleParentFolderAndContainersChecked(idx, node, checkState);
         }
 
         private void ToggleChildrenChecked(int idx, TNode node, bool isChecked)
@@ -270,8 +270,7 @@ namespace GitHub.Unity
             {
                 var childNode = Nodes[i];
 
-                var wasChecked = childNode.CheckState == CheckState.Checked;
-                SetCheckStateOnNode(node, isChecked);
+                SetCheckStateOnNode(childNode, isChecked);
 
                 if (childNode.IsFolderOrContainer)
                 {
@@ -327,8 +326,9 @@ namespace GitHub.Unity
             }
         }
 
-        private void ToggleParentFolderAndContainersChecked(int idx, TNode node, bool isChecked)
+        private void ToggleParentFolderAndContainersChecked(int idx, TNode node, CheckState checkState)
         {
+            var isChecked = checkState != CheckState.Empty;
             while (true)
             {
                 if (node.Level > 0)
@@ -381,9 +381,7 @@ namespace GitHub.Unity
 
                     var parentNodeState =
                         siblingsInSameState
-                            ? isChecked
-                                ? CheckState.Checked
-                                : CheckState.Empty
+                            ? node.CheckState
                             : CheckState.Mixed;
 
                     SetCheckStateOnNode(parentNode, parentNodeState);

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -183,23 +183,9 @@ namespace GitHub.Unity
 
         public void SetCheckStateOnAll(bool isChecked)
         {
-            var nodeCheckState = isChecked ? CheckState.Checked : CheckState.Empty;
             foreach (var node in Nodes)
             {
-                var wasChecked = node.CheckState == CheckState.Checked;
-                node.CheckState = nodeCheckState;
-
-                if (!node.IsFolder)
-                {
-                    if (isChecked && !wasChecked)
-                    {
-                        AddCheckedNode(node);
-                    }
-                    else if (!isChecked && wasChecked)
-                    {
-                        RemoveCheckedNode(node);
-                    }
-                }
+                SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
             }
         }
 
@@ -250,39 +236,32 @@ namespace GitHub.Unity
 
         protected void ToggleNodeChecked(int idx, TNode node)
         {
+            CheckState checkState;
             var isChecked = false;
-
             switch (node.CheckState)
             {
                 case CheckState.Mixed:
                 case CheckState.Empty:
-                    node.CheckState = CheckState.Checked;
+                    checkState = CheckState.Checked;
                     isChecked = true;
                     break;
 
                 case CheckState.Checked:
-                    node.CheckState = CheckState.Empty;
+                    checkState = CheckState.Empty;
                     break;
+
+                default:
+                    throw new ArgumentOutOfRangeException("Unknown CheckState");
             }
 
-            if (!node.IsFolder)
-            {
-                if (isChecked)
-                {
-                    AddCheckedNode(node);
-                }
-                else
-                {
-                    RemoveCheckedNode(node);
-                }
-            }
+            SetCheckStateOnNode(node, checkState);
 
             if (node.IsFolderOrContainer)
             {
                 ToggleChildrenChecked(idx, node, isChecked);
             }
 
-            ToggleParentFoldersChecked(idx, node, isChecked);
+            ToggleParentFolderAndContainersChecked(idx, node, isChecked);
         }
 
         private void ToggleChildrenChecked(int idx, TNode node, bool isChecked)
@@ -290,20 +269,9 @@ namespace GitHub.Unity
             for (var i = idx + 1; i < Nodes.Count && node.Level < Nodes[i].Level; i++)
             {
                 var childNode = Nodes[i];
-                var wasChecked = childNode.CheckState == CheckState.Checked;
-                childNode.CheckState = isChecked ? CheckState.Checked : CheckState.Empty;
 
-                if (!childNode.IsFolder)
-                {
-                    if (isChecked && !wasChecked)
-                    {
-                        AddCheckedNode(childNode);
-                    }
-                    else if (!isChecked && wasChecked)
-                    {
-                        RemoveCheckedNode(childNode);
-                    }
-                }
+                var wasChecked = childNode.CheckState == CheckState.Checked;
+                SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
 
                 if (childNode.IsFolderOrContainer)
                 {
@@ -332,7 +300,29 @@ namespace GitHub.Unity
             return results;
         }
 
-        private void ToggleParentFoldersChecked(int idx, TNode node, bool isChecked)
+        private void SetCheckStateOnNode(TNode node, CheckState nodeCheckState)
+        {
+            var isChecked = nodeCheckState == CheckState.Checked
+                || nodeCheckState == CheckState.Mixed;
+
+            var wasChecked = node.CheckState == CheckState.Checked;
+
+            node.CheckState = nodeCheckState;
+
+            if (!node.IsFolder)
+            {
+                if (isChecked && !wasChecked)
+                {
+                    AddCheckedNode(node);
+                }
+                else if (!isChecked && wasChecked)
+                {
+                    RemoveCheckedNode(node);
+                }
+            }
+        }
+
+        private void ToggleParentFolderAndContainersChecked(int idx, TNode node, bool isChecked)
         {
             while (true)
             {
@@ -383,14 +373,15 @@ namespace GitHub.Unity
 
                     var parentIndex = firstSiblingIndex - 1;
                     var parentNode = Nodes[parentIndex];
-                    if (siblingsInSameState)
-                    {
-                        parentNode.CheckState = isChecked ? CheckState.Checked : CheckState.Empty;
-                    }
-                    else
-                    {
-                        parentNode.CheckState = CheckState.Mixed;
-                    }
+
+                    var parentNodeState =
+                        siblingsInSameState
+                            ? isChecked
+                                ? CheckState.Checked
+                                : CheckState.Empty
+                            : CheckState.Mixed;
+
+                    SetCheckStateOnNode(parentNode, parentNodeState);
 
                     idx = parentIndex;
                     node = parentNode;

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -300,19 +300,19 @@ namespace GitHub.Unity
             return results;
         }
 
-        private void SetCheckStateOnNode(TNode node, bool isChecked)
+        private void SetCheckStateOnNode(TNode node, bool setChecked)
         {
-            SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
+            SetCheckStateOnNode(node, setChecked ? CheckState.Checked : CheckState.Empty);
         }
 
-        private void SetCheckStateOnNode(TNode node, CheckState nodeCheckState)
+        private void SetCheckStateOnNode(TNode node, CheckState setCheckState)
         {
-            var isChecked = nodeCheckState == CheckState.Checked
-                || nodeCheckState == CheckState.Mixed;
+            var isChecked = setCheckState == CheckState.Checked
+                || setCheckState == CheckState.Mixed;
 
             var wasChecked = node.CheckState == CheckState.Checked;
 
-            node.CheckState = nodeCheckState;
+            node.CheckState = setCheckState;
 
             if (!node.IsFolder)
             {

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -185,7 +185,7 @@ namespace GitHub.Unity
         {
             foreach (var node in Nodes)
             {
-                SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
+                SetCheckStateOnNode(node, isChecked);
             }
         }
 
@@ -271,7 +271,7 @@ namespace GitHub.Unity
                 var childNode = Nodes[i];
 
                 var wasChecked = childNode.CheckState == CheckState.Checked;
-                SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
+                SetCheckStateOnNode(node, isChecked);
 
                 if (childNode.IsFolderOrContainer)
                 {
@@ -298,6 +298,11 @@ namespace GitHub.Unity
                 }
             }
             return results;
+        }
+
+        private void SetCheckStateOnNode(TNode node, bool isChecked)
+        {
+            SetCheckStateOnNode(node, isChecked ? CheckState.Checked : CheckState.Empty);
         }
 
         private void SetCheckStateOnNode(TNode node, CheckState nodeCheckState)

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -671,6 +671,9 @@ namespace UnitTests
             var sceneNode = testTree.CreatedTreeNodes[2];
             var sceneMetaNode = testTree.CreatedTreeNodes[3];
 
+            Assert.AreEqual(CheckState.Empty, sceneNode.CheckState);
+            Assert.AreEqual(CheckState.Empty, sceneMetaNode.CheckState);
+
             testTree.ToggleNodeChecked(3, sceneMetaNode);
 
             Assert.AreEqual(CheckState.Checked, sceneNode.CheckState);

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -799,6 +799,21 @@ namespace UnitTests
 
             testTreeListener.Received(1).AddCheckedNode(Arg.Any<TestTreeNode>());
             testTreeListener.ClearReceivedCalls();
+
+            // Unchecked a.txt b.txt and c.txt, everything checked
+
+            testTree.ToggleNodeChecked(3, aNode);
+            testTree.ToggleNodeChecked(4, bNode);
+            testTree.ToggleNodeChecked(5, cNode);
+
+            Assert.AreEqual(CheckState.Empty, rootNode.CheckState);
+            Assert.AreEqual(CheckState.Empty, parentNode.CheckState);
+            Assert.AreEqual(CheckState.Empty, aNode.CheckState);
+            Assert.AreEqual(CheckState.Empty, bNode.CheckState);
+            Assert.AreEqual(CheckState.Empty, cNode.CheckState);
+
+            testTreeListener.Received(3).RemoveCheckedNode(Arg.Any<TestTreeNode>());
+            testTreeListener.ClearReceivedCalls();
         }
 
         [Test]

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -680,7 +680,7 @@ namespace UnitTests
         }
 
         [Test]
-        public void ShouldRippleUncheckCorrectly()
+        public void ShouldRippleChecksCorrectly()
         {
             var testTree = new TestTree(true);
             var testTreeListener = testTree.TestTreeListener;

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -753,6 +753,8 @@ namespace UnitTests
             var bNode = testTree.CreatedTreeNodes[4];
             var cNode = testTree.CreatedTreeNodes[5];
 
+            // Initial state, everything unchecked
+
             Assert.AreEqual(CheckState.Empty, rootNode.CheckState);
             Assert.AreEqual(CheckState.Empty, parentNode.CheckState);
             Assert.AreEqual(CheckState.Empty, aNode.CheckState);
@@ -760,6 +762,8 @@ namespace UnitTests
             Assert.AreEqual(CheckState.Empty, cNode.CheckState);
 
             testTree.ToggleNodeChecked(1, rootNode);
+
+            // Checked the root node, everything checked
 
             Assert.AreEqual(CheckState.Checked, rootNode.CheckState);
             Assert.AreEqual(CheckState.Checked, parentNode.CheckState);
@@ -769,6 +773,8 @@ namespace UnitTests
 
             testTreeListener.Received(3).AddCheckedNode(Arg.Any<TestTreeNode>());
             testTreeListener.ClearReceivedCalls();
+
+            // Unchecked c.txt, c.txt unchecked, parents mixed
 
             testTree.ToggleNodeChecked(5, cNode);
 
@@ -782,6 +788,8 @@ namespace UnitTests
             testTreeListener.ClearReceivedCalls();
 
             testTree.ToggleNodeChecked(5, cNode);
+
+            // Checked c.txt, everything checked
 
             Assert.AreEqual(CheckState.Checked, rootNode.CheckState);
             Assert.AreEqual(CheckState.Checked, parentNode.CheckState);

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -313,8 +313,6 @@ namespace UnitTests
                 return TestTreeListener.PromoteMetaFiles;
             }
         }
-
-
     }
 
     [TestFixture]
@@ -613,7 +611,6 @@ namespace UnitTests
                 }
             });
         }
-
 
         [Test]
         public void ShouldCheckParentOfMetaFile()


### PR DESCRIPTION
Fixes #913 

As a result of an item having it's check state changed in our tree lists, the check state of it's parents or children might need to be changed.

When performing this action from `TreeBase<TNode, TData>` we need to be sure to call `AddCheckedNode(...)` or `RemoveCheckedNode(...)` when those items are not folders. Those functions are overloaded and allow derived classes to set some additional state.

In order to do this cleanly, all nodes check states are now being changed through a central overloaded method.

https://github.com/github-for-unity/Unity/blob/d8d92c990278df1306754c22ed90de05193686ae/src/GitHub.Api/UI/TreeBase.cs#L303-L328

