### PR TITLE
Changing how zip extracted resources are moved to their destination

### DIFF
--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -317,6 +317,7 @@ namespace GitHub.Unity
                     source.Delete();
 
                     state.GitIsValid = true;
+
                     state.IsCustomGitPath = state.GitExecutablePath != installDetails.GitExecutablePath;
                 }
             }
@@ -339,12 +340,15 @@ namespace GitHub.Unity
                 {
                     Logger.Info("Moving GitLFS source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    target.DeleteIfExists();
-                    target.EnsureParentDirectoryExists();
+                    Logger.Info("DeleteContents target:{0}", target.ToString());
+                    target.DeleteContents();
 
-                    Logger.Info("GitLFS target Exists: {0}", target.Exists());
+                    Logger.Info("MoveFiles fromPath: {0} toPath:{1}", source.ToString(), target.ToString());
+                    source.MoveFiles(target, true);
 
-                    source.Move(target);
+                    Logger.Info("Delete source:{0}", source.ToString());
+                    source.Delete();
+
                     state.GitLfsIsValid = true;
                 }
             }

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -307,12 +307,15 @@ namespace GitHub.Unity
                 {
                     Logger.Info("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    target.DeleteIfExists();
-                    target.EnsureParentDirectoryExists();
+                    Logger.Info("DeleteContents target:{0}", target.ToString());
+                    target.DeleteContents();
 
-                    Logger.Info("target Exists: {0}", target.Exists());
+                    Logger.Info("MoveFiles fromPath: {0} toPath:{1}", source.ToString(), target.ToString());
+                    source.MoveFiles(target, true);
 
-                    source.Move(target);
+                    Logger.Info("Delete source:{0}", source.ToString());
+                    source.Delete();
+
                     state.GitIsValid = true;
                     state.IsCustomGitPath = state.GitExecutablePath != installDetails.GitExecutablePath;
                 }
@@ -334,12 +337,12 @@ namespace GitHub.Unity
                 var target = state.GitLfsInstallationPath;
                 if (unzipTask.Successful)
                 {
-                    Logger.Info("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
+                    Logger.Info("Moving GitLFS source:{0} target:{1}", source.ToString(), target.ToString());
 
                     target.DeleteIfExists();
                     target.EnsureParentDirectoryExists();
 
-                    Logger.Info("target Exists: {0}", target.Exists());
+                    Logger.Info("GitLFS target Exists: {0}", target.Exists());
 
                     source.Move(target);
                     state.GitLfsIsValid = true;

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -301,13 +301,17 @@ namespace GitHub.Unity
                         return true;
                     });
                 unzipTask.Progress(p => Progress.UpdateProgress(40 + (long)(20 * p.Percentage), 100, unzipTask.Message));
-                var path = unzipTask.RunSynchronously();
+                var source = unzipTask.RunSynchronously();
                 var target = state.GitInstallationPath;
                 if (unzipTask.Successful)
                 {
-                    var source = path;
+                    Logger.Info("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
+
                     target.DeleteIfExists();
                     target.EnsureParentDirectoryExists();
+
+                    Logger.Info("target Exists: {0}", target.Exists());
+
                     source.Move(target);
                     state.GitIsValid = true;
                     state.IsCustomGitPath = state.GitExecutablePath != installDetails.GitExecutablePath;
@@ -326,13 +330,17 @@ namespace GitHub.Unity
                         return true;
                     });
                 unzipTask.Progress(p => Progress.UpdateProgress(60 + (long)(20 * p.Percentage), 100, unzipTask.Message));
-                var path = unzipTask.RunSynchronously();
+                var source = unzipTask.RunSynchronously();
                 var target = state.GitLfsInstallationPath;
                 if (unzipTask.Successful)
                 {
-                    var source = path;
+                    Logger.Info("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
+
                     target.DeleteIfExists();
                     target.EnsureParentDirectoryExists();
+
+                    Logger.Info("target Exists: {0}", target.Exists());
+
                     source.Move(target);
                     state.GitLfsIsValid = true;
                 }

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -305,16 +305,11 @@ namespace GitHub.Unity
                 var target = state.GitInstallationPath;
                 if (unzipTask.Successful)
                 {
-                    Logger.Info("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
+                    Logger.Trace("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    Logger.Info("DeleteContents target:{0}", target.ToString());
                     target.DeleteContents();
-
-                    Logger.Info("MoveFiles fromPath: {0} toPath:{1}", source.ToString(), target.ToString());
                     source.MoveFiles(target, true);
-
-                    Logger.Info("Delete source:{0}", source.ToString());
-                    source.Delete();
+                    source.Parent.Delete();
 
                     state.GitIsValid = true;
 
@@ -338,16 +333,11 @@ namespace GitHub.Unity
                 var target = state.GitLfsInstallationPath;
                 if (unzipTask.Successful)
                 {
-                    Logger.Info("Moving GitLFS source:{0} target:{1}", source.ToString(), target.ToString());
+                    Logger.Trace("Moving GitLFS source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    Logger.Info("DeleteContents target:{0}", target.ToString());
                     target.DeleteContents();
-
-                    Logger.Info("MoveFiles fromPath: {0} toPath:{1}", source.ToString(), target.ToString());
                     source.MoveFiles(target, true);
-
-                    Logger.Info("Delete source:{0}", source.ToString());
-                    source.Delete();
+                    source.Parent.Delete();
 
                     state.GitLfsIsValid = true;
                 }

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -61,7 +61,7 @@ namespace GitHub.Unity
             Logger.Info("MoveFiles fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
             fromPath.MoveFiles(toPath, true);
 
-            Logger.Info("Delete fromPath:{0}", fromPath.ToString());
+            Logger.Info("Delete fromPath.Parent:{0}", fromPath.Parent.ToString());
             fromPath.Parent.Delete();
 
             return installDetails.ExecutablePath;

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -52,8 +52,14 @@ namespace GitHub.Unity
         private NPath MoveOctorun(NPath fromPath)
         {
             var toPath = installDetails.InstallationPath;
+
+            Logger.Info("MoveOctorun fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
+
             toPath.DeleteIfExists();
             toPath.EnsureParentDirectoryExists();
+
+            Logger.Info("toPath Exists: {0}", toPath.Exists());
+
             fromPath.Move(toPath);
             fromPath.Parent.Delete();
             return installDetails.ExecutablePath;

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -53,15 +53,10 @@ namespace GitHub.Unity
         {
             var toPath = installDetails.InstallationPath;
 
-            Logger.Info("MoveOctorun fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
+            Logger.Trace("MoveOctorun fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
 
-            Logger.Info("DeleteContents toPath:{0}", toPath.ToString());
             toPath.DeleteContents();
-
-            Logger.Info("MoveFiles fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
             fromPath.MoveFiles(toPath, true);
-
-            Logger.Info("Delete fromPath.Parent:{0}", fromPath.Parent.ToString());
             fromPath.Parent.Delete();
 
             return installDetails.ExecutablePath;

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -55,13 +55,15 @@ namespace GitHub.Unity
 
             Logger.Info("MoveOctorun fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
 
-            toPath.DeleteIfExists();
-            toPath.EnsureParentDirectoryExists();
+            Logger.Info("DeleteContents toPath:{0}", toPath.ToString());
+            toPath.DeleteContents();
 
-            Logger.Info("toPath Exists: {0}", toPath.Exists());
+            Logger.Info("MoveFiles fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
+            fromPath.MoveFiles(toPath, true);
 
-            fromPath.Move(toPath);
+            Logger.Info("Delete fromPath:{0}", fromPath.ToString());
             fromPath.Parent.Delete();
+
             return installDetails.ExecutablePath;
         }
 


### PR DESCRIPTION
Fixes #898 
Fixes #836

This bug has appeared before in the past and we were never sure of the cause, but it seems to be a common enough setup for people to locate their "Temp" folder on something other than their user profile. When that is the case we cannot move the folder from one location to another, we have to actually create the folder and move the contents therein. I'm not able to reproduce this on my machine, but extensive user testing in #836 has resulted in this fix.