### PR TITLE
CopyMethod changes

### DIFF
--- a/src/GitHub.Api/GitHub.Api.45.csproj
+++ b/src/GitHub.Api/GitHub.Api.45.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Application\ApplicationManagerBase.cs" />
     <Compile Include="Helpers\Constants.cs" />
     <Compile Include="Helpers\Validation.cs" />
+    <Compile Include="Installer\CopyHelper.cs" />
     <Compile Include="Installer\GitInstaller.cs" />
     <Compile Include="Installer\OctorunInstaller.cs" />
     <Compile Include="Installer\UnzipTask.cs" />

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Application\ApplicationManagerBase.cs" />
     <Compile Include="Helpers\Constants.cs" />
     <Compile Include="Helpers\Validation.cs" />
+    <Compile Include="Installer\CopyHelper.cs" />
     <Compile Include="Installer\GitInstaller.cs" />
     <Compile Include="Installer\OctorunInstaller.cs" />
     <Compile Include="Installer\UnzipTask.cs" />

--- a/src/GitHub.Api/Installer/CopyHelper.cs
+++ b/src/GitHub.Api/Installer/CopyHelper.cs
@@ -31,6 +31,10 @@ namespace GitHub.Unity
                     throw;
                 }
             }
+            finally
+            {
+                fromPath.DeleteIfExists();
+            }
         }
         public static void CopyFolder(NPath fromPath, NPath toPath)
         {
@@ -38,7 +42,6 @@ namespace GitHub.Unity
 
             toPath.EnsureParentDirectoryExists();
             fromPath.Move(toPath);
-            fromPath.Delete();
         }
 
         public static void CopyFolderContents(NPath fromPath, NPath toPath)
@@ -47,7 +50,6 @@ namespace GitHub.Unity
 
             toPath.DeleteContents();
             fromPath.MoveFiles(toPath, true);
-            fromPath.Delete();
         }
     }
 }

--- a/src/GitHub.Api/Installer/CopyHelper.cs
+++ b/src/GitHub.Api/Installer/CopyHelper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GitHub.Logging;
+
+namespace GitHub.Unity
+{
+    public static class CopyHelper
+    {
+        private static readonly ILogging Logger = LogHelper.GetLogger(typeof(CopyHelper));
+
+        public static void Copy(NPath fromPath, NPath toPath)
+        {
+            try
+            {
+
+                CopyFolder(fromPath, toPath);
+            }
+            catch (Exception ex1)
+            {
+                Logger.Warning(ex1, "Error copying from " + fromPath + " to " + toPath + ". Attempting to copy contents.");
+
+                try
+                {
+                    CopyFolderContents(fromPath, toPath);
+                }
+                catch (Exception ex2)
+                {
+                    Logger.Error(ex2, "Error copying from " + fromPath + " to " + toPath + ".");
+                    throw;
+                }
+            }
+        }
+        public static void CopyFolder(NPath fromPath, NPath toPath)
+        {
+            Logger.Trace("CopyFolder fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
+
+            toPath.EnsureParentDirectoryExists();
+            fromPath.Move(toPath);
+            fromPath.Delete();
+        }
+
+        public static void CopyFolderContents(NPath fromPath, NPath toPath)
+        {
+            Logger.Trace("CopyFolderContents fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
+
+            toPath.DeleteContents();
+            fromPath.MoveFiles(toPath, true);
+            fromPath.Delete();
+        }
+    }
+}

--- a/src/GitHub.Api/Installer/GitInstaller.cs
+++ b/src/GitHub.Api/Installer/GitInstaller.cs
@@ -307,9 +307,7 @@ namespace GitHub.Unity
                 {
                     Logger.Trace("Moving Git source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    target.DeleteContents();
-                    source.MoveFiles(target, true);
-                    source.Parent.Delete();
+                    CopyHelper.Copy(source, target);
 
                     state.GitIsValid = true;
 
@@ -335,9 +333,7 @@ namespace GitHub.Unity
                 {
                     Logger.Trace("Moving GitLFS source:{0} target:{1}", source.ToString(), target.ToString());
 
-                    target.DeleteContents();
-                    source.MoveFiles(target, true);
-                    source.Parent.Delete();
+                    CopyHelper.Copy(source, target);
 
                     state.GitLfsIsValid = true;
                 }

--- a/src/GitHub.Api/Installer/OctorunInstaller.cs
+++ b/src/GitHub.Api/Installer/OctorunInstaller.cs
@@ -55,9 +55,7 @@ namespace GitHub.Unity
 
             Logger.Trace("MoveOctorun fromPath: {0} toPath:{1}", fromPath.ToString(), toPath.ToString());
 
-            toPath.DeleteContents();
-            fromPath.MoveFiles(toPath, true);
-            fromPath.Parent.Delete();
+            CopyHelper.Copy(fromPath, toPath);
 
             return installDetails.ExecutablePath;
         }


### PR DESCRIPTION
Fixes #930 

As a fix i'm restoring the original copy method as something to be tried first.
The second copy method will be tried if the original fails.
Then an error will throw.

Macs should work with the original copy method.