### PR TITLE
Refreshing the asset database differently

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -514,6 +514,7 @@ namespace GitHub.Unity
                         {
                             UsageTracker.IncrementBranchesViewButtonCheckoutLocalBranch();
                             Redraw();
+                            AssetDatabase.Refresh();
                         }
                         else
                         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -67,7 +67,6 @@ namespace GitHub.Unity
             if (!lastRepositoryStatusChangedEvent.Equals(cacheUpdateEvent))
             {
                 lastRepositoryStatusChangedEvent = cacheUpdateEvent;
-                AssetDatabase.Refresh();
                 entries.Clear();
                 entries.AddRange(Repository.CurrentChanges);
                 OnStatusUpdate();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Window.cs
@@ -757,6 +757,8 @@ namespace GitHub.Unity
                             EditorUtility.DisplayDialog(Localization.PullActionTitle,
                                 String.Format(Localization.PullSuccessDescription, currentRemoteName),
                             Localization.Ok);
+
+                            AssetDatabase.Refresh();
                         }
                         else
                         {


### PR DESCRIPTION
Fixes #936 

Being more direct about when we refresh the asset database.
I'm not happy with this solution, but making a derived class of Repository or RepositoryManager feels wasteful for just this purpose.