### PR TITLE
Case insensitive usernames

### DIFF
--- a/src/GitHub.Api/Application/ApiClient.cs
+++ b/src/GitHub.Api/Application/ApiClient.cs
@@ -255,7 +255,7 @@ namespace GitHub.Unity
                 {
                     var login = ret.Output[1];
 
-                    if (login != keychainConnection.Username)
+                    if (!string.Equals(login, keychainConnection.Username, StringComparison.InvariantCultureIgnoreCase))
                     {
                         logger.Trace("LoadKeychainInternal: Api username does not match");
                         throw new TokenUsernameMismatchException(keychainConnection.Username, login);

--- a/src/GitHub.Api/Authentication/LoginManager.cs
+++ b/src/GitHub.Api/Authentication/LoginManager.cs
@@ -73,7 +73,7 @@ namespace GitHub.Unity
 
                     if (loginResultData.Code == LoginResultCodes.Success)
                     {
-                        username = RetrieveUsername(loginResultData, username);
+                        username = RetrieveUsername();
                         keychainAdapter.Update(loginResultData.Token, username);
                         keychain.SaveToSystem(host);
                     }
@@ -113,7 +113,7 @@ namespace GitHub.Unity
                     }
 
                     keychainAdapter.Update(loginResultData.Token, username);
-                    username = RetrieveUsername(loginResultData, username);
+                    username = RetrieveUsername();
                     keychainAdapter.Update(loginResultData.Token, username);
                     keychain.SaveToSystem(host);
 
@@ -180,13 +180,8 @@ namespace GitHub.Unity
             return new LoginResultData(LoginResultCodes.Failed, ret.GetApiErrorMessage() ?? "Failed.", host);
         }
 
-        private string RetrieveUsername(LoginResultData loginResultData, string username)
+        private string RetrieveUsername()
         {
-            if (!username.Contains("@"))
-            {
-                return username;
-            }
-
             var octorunTask = new OctorunTask(taskManager.Token, keychain, environment, "validate")
                 .Configure(processManager);
 


### PR DESCRIPTION
Fixes #957 

- Always use what the server replies for the username instead of what the user entered
- Use a case insensitive match when comparing against the username for authentication