### PR TITLE
Avoid throwing when the first ongui pass is not a layout pass

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LocksView.cs
@@ -119,7 +119,7 @@ namespace GitHub.Unity
                         visibleItems[entry.GitLock.ID] = shouldRenderEntry;
                     }
 
-                    if (visibleItems[entry.GitLock.ID])
+                    if (visibleItems.ContainsKey(entry.GitLock.ID) && visibleItems[entry.GitLock.ID])
                     {
                         entryRect = RenderEntry(entryRect, entry);
                     }


### PR DESCRIPTION
Getting an exception every now and then when refreshing assets Unity quickly, as the dictionary might not have the entries we expect if the layout pass hasn't actually happened (I don't know how it happens, but it's happening), so added a guard to prevent it from throwing.