### PR TITLE
Fix unitypackage creation

### DIFF
--- a/create-unitypackage.sh
+++ b/create-unitypackage.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eu
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+version=$(sed -En 's,.*Version = "(.*)".*,\1,p' common/SolutionInfo.cs)
+commitcount=$(git rev-list  --count HEAD)
+commit=$(git log -n1 --pretty=format:%h)
+version="${version}.${commitcount}-${commit}"
+
+$DIR/submodules/packaging/unitypackage/run.sh --path $DIR/unity/PackageProject --out $DIR --file github-for-unity-$version


### PR DESCRIPTION
There were a few things missing in the unitypackage tar file that Unity needs in order to process a package, this pulls in the submodule fixes for that and adds a shell script to create packages from the command line.