### PR TITLE
configure: UnityYamlMerge as a merge tool

### DIFF
--- a/src/GitHub.Api/Application/ApplicationManagerBase.cs
+++ b/src/GitHub.Api/Application/ApplicationManagerBase.cs
@@ -288,12 +288,12 @@ namespace GitHub.Unity
                 ? $@"'{unityYamlMergeExec}' merge -p ""$BASE"" ""$REMOTE"" ""$LOCAL"" ""$MERGED"""
                 : $@"'{unityYamlMergeExec}' merge -p '$BASE' '$REMOTE' '$LOCAL' '$MERGED'";
 
-            GitClient.SetConfig("merge.unityyamlmerge.cmd", yamlMergeCommand, GitConfigSource.Local).Catch(e => {
+            GitClient.SetConfig("mergetool.unityyamlmerge.cmd", yamlMergeCommand, GitConfigSource.Local).Catch(e => {
                 Logger.Error(e, "Error setting merge.unityyamlmerge.cmd");
                 return true;
             }).RunSynchronously();
 
-            GitClient.SetConfig("merge.unityyamlmerge.trustExitCode", "false", GitConfigSource.Local).Catch(e => {
+            GitClient.SetConfig("mergetool.unityyamlmerge.trustExitCode", "false", GitConfigSource.Local).Catch(e => {
                 Logger.Error(e, "Error setting merge.unityyamlmerge.trustExitCode");
                 return true;
             }).RunSynchronously();

--- a/src/GitHub.Api/Resources/.gitattributes
+++ b/src/GitHub.Api/Resources/.gitattributes
@@ -1,10 +1,10 @@
 * text=auto
 
 # Unity files
-*.meta -text merge=unityamlmerge diff
-*.unity -text merge=unityamlmerge diff
-*.asset -text merge=unityamlmerge diff
-*.prefab -text merge=unityamlmerge diff
+*.meta -text diff
+*.unity -text diff
+*.asset -text diff
+*.prefab -text diff
 
 # Image formats
 *.psd filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### Description of the Change

UnityYamlMerge is a merge tool which can help with conflict resolution.
However, currently we configure it using the merge section instead of
the mergetool section, meaning that it's not being used.  In addition,
we configure it in .gitattributes, even though that has no effect.

Configure this tool in the correct section of the Git config file and
skip inserting it into the gitattributes file.

This should fix #943.

Please note that I have not actually tested this change, as I don't have Unity or any of the tooling required to test this; it's merely been submitted to address a question that @StanleyGoldman brought to my attention.  Testing it before merge would be prudent.

### Alternate Designs

I considered whether to set this up as a merge driver instead, but it doesn't appear that that's a valid configuration for UnityYamlMerge.  If it turns out it is, it's easy to add in addition. 

### Benefits

UnityYamlMerge will be usable as a merge tool.

### Possible Drawbacks

There shouldn't be any.  The tool didn't work before, and it should work now.

I suppose users could be unhappy with the merge tool and wish to go back to the way things were before, but that's a risk with any change.

### Applicable Issues

#943