### PR TITLE
Making the standalone api nicer to use

### DIFF
--- a/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
+++ b/src/GitHub.Api/OutputProcessors/LogEntryOutputProcessor.cs
@@ -143,7 +143,6 @@ namespace GitHub.Unity
                         }
 
                         summary = line;
-                        descriptionLines.Add(line);
                         phase++;
                         // there's no description so skip it
                         if (oneliner)

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -83,7 +83,7 @@ namespace GitHub.Unity
             Guard.NotNull(this, FileSystem, nameof(FileSystem));
 
             NPath expectedRepositoryPath;
-            if (!RepositoryPath.IsInitialized)
+            if (!RepositoryPath.IsInitialized || (repositoryPath != null && RepositoryPath != repositoryPath.Value))
             {
                 Guard.NotNull(this, UnityProjectPath, nameof(UnityProjectPath));
 

--- a/src/GitHub.Api/Tasks/ActionTask.cs
+++ b/src/GitHub.Api/Tasks/ActionTask.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
-    class TaskQueue : TPLTask
+    public class TaskQueue : TPLTask
     {
         private TaskCompletionSource<bool> aggregateTask = new TaskCompletionSource<bool>();
         private readonly List<ITask> queuedTasks = new List<ITask>();
@@ -85,7 +85,7 @@ namespace GitHub.Unity
         }
     }
 
-    class TaskQueue<TTaskResult, TResult> : TPLTask<List<TResult>>
+    public class TaskQueue<TTaskResult, TResult> : TPLTask<List<TResult>>
     {
         private TaskCompletionSource<List<TResult>> aggregateTask = new TaskCompletionSource<List<TResult>>();
         private readonly List<ITask<TTaskResult>> queuedTasks = new List<ITask<TTaskResult>>();
@@ -190,7 +190,7 @@ namespace GitHub.Unity
         }
     }
 
-    class TPLTask : TaskBase
+    public class TPLTask : TaskBase
     {
         private Task task;
 
@@ -235,7 +235,7 @@ namespace GitHub.Unity
         }
     }
 
-    class TPLTask<T> : TaskBase<T>
+    public class TPLTask<T> : TaskBase<T>
     {
         private Task<T> task;
 
@@ -280,7 +280,7 @@ namespace GitHub.Unity
         }
     }
 
-    class ActionTask : TaskBase
+    public class ActionTask : TaskBase
     {
         protected Action<bool> Callback { get; }
         protected Action<bool, Exception> CallbackWithException { get; }
@@ -329,7 +329,7 @@ namespace GitHub.Unity
         }
     }
 
-    class ActionTask<T> : TaskBase
+    public class ActionTask<T> : TaskBase
     {
         private readonly Func<T> getPreviousResult;
 
@@ -415,7 +415,7 @@ namespace GitHub.Unity
         public T PreviousResult { get; set; } = default(T);
     }
 
-    class FuncTask<T> : TaskBase<T>
+    public class FuncTask<T> : TaskBase<T>
     {
         protected Func<bool, T> Callback { get; }
         protected Func<bool, Exception, T> CallbackWithException { get; }
@@ -468,7 +468,7 @@ namespace GitHub.Unity
         }
     }
 
-    class FuncTask<T, TResult> : TaskBase<T, TResult>
+    public class FuncTask<T, TResult> : TaskBase<T, TResult>
     {
         protected Func<bool, T, TResult> Callback { get; }
         protected Func<bool, Exception, T, TResult> CallbackWithException { get; }
@@ -513,7 +513,7 @@ namespace GitHub.Unity
         }
     }
 
-    class FuncListTask<T> : DataTaskBase<T, List<T>>
+    public class FuncListTask<T> : DataTaskBase<T, List<T>>
     {
         protected Func<bool, List<T>> Callback { get; }
         protected Func<bool, FuncListTask<T>, List<T>> CallbackWithSelf { get; }
@@ -573,7 +573,7 @@ namespace GitHub.Unity
         }
     }
 
-    class FuncListTask<T, TData, TResult> : DataTaskBase<T, TData, List<TResult>>
+    public class FuncListTask<T, TData, TResult> : DataTaskBase<T, TData, List<TResult>>
     {
         protected Func<bool, T, List<TResult>> Callback { get; }
         protected Func<bool, Exception, T, List<TResult>> CallbackWithException { get; }

--- a/src/GitHub.Api/Tasks/TaskBase.cs
+++ b/src/GitHub.Api/Tasks/TaskBase.cs
@@ -547,7 +547,7 @@ namespace GitHub.Unity
         public virtual string Message { get; set; }
     }
 
-    abstract class TaskBase<TResult> : TaskBase, ITask<TResult>
+    public abstract class TaskBase<TResult> : TaskBase, ITask<TResult>
     {
         private event Action<bool, TResult> finallyHandler;
 
@@ -723,7 +723,7 @@ namespace GitHub.Unity
         public TResult Result { get { return result; } }
     }
 
-    abstract class TaskBase<T, TResult> : TaskBase<TResult>
+    public abstract class TaskBase<T, TResult> : TaskBase<TResult>
     {
         private readonly Func<T> getPreviousResult;
 
@@ -770,7 +770,7 @@ namespace GitHub.Unity
         public T PreviousResult { get; set; } = default(T);
     }
 
-    abstract class DataTaskBase<TData, TResult> : TaskBase<TResult>, ITask<TData, TResult>
+    public abstract class DataTaskBase<TData, TResult> : TaskBase<TResult>, ITask<TData, TResult>
     {
         public DataTaskBase(CancellationToken token)
             : base(token)
@@ -783,7 +783,7 @@ namespace GitHub.Unity
         }
     }
 
-    abstract class DataTaskBase<T, TData, TResult> : TaskBase<T, TResult>, ITask<TData, TResult>
+    public abstract class DataTaskBase<T, TData, TResult> : TaskBase<T, TResult>, ITask<TData, TResult>
     {
         public DataTaskBase(CancellationToken token)
             : base(token)

--- a/src/GitHub.Api/Tasks/TaskExtensions.cs
+++ b/src/GitHub.Api/Tasks/TaskExtensions.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace GitHub.Unity
 {
-    static class TaskExtensions
+    public static class TaskExtensions
     {
         public static async Task StartAwait(this ITask source, Action<Exception> handler = null)
         {


### PR DESCRIPTION
I did a little app (https://github.com/shana/unity-runtime-git) to test using the api at runtime, and I had to do some tweaks to make it nicer to use. These are those tweaks:

- When parsing the history log, the first line of the commit was being added to the description. This makes it annoying to show entries when showing both the first line (summary) and the body (description), as the first line would appear duplicated. I kinda wanna treat these as email subject and body (because that's what they were meant to be originally in git anyways), so took out the duplication.
- calling `InitializeRepository(path to repository)` on `DefaultEnvironment` does the useful thing of setting the base path on the FileSystem object, which means any shell commands and path manipulations are going to assume that path to repository as the base for all relative paths and working directory paths. Which is handy! Only the logic that we currently have makes it impossible to call `InitializeRepository` twice (it just ignores it), so it's not easy to switch these paths.
- The task classes should be public, they're useful!