### PR TITLE
It is not safe to instantiate scriptable objects in attribute constructors in 2018.3

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ScriptObjectSingleton.cs
@@ -10,20 +10,34 @@ namespace GitHub.Unity
     sealed class LocationAttribute : Attribute
     {
         public enum Location { PreferencesFolder, ProjectFolder, LibraryFolder, UserFolder }
-        public string filepath { get; set; }
+
+        private string relativePath;
+        private Location location;
+
+        private string filePath;
+        public string FilePath {
+            get {
+                if (filePath != null) return filePath;
+
+                if (relativePath[0] == '/')
+                    relativePath = relativePath.Substring(1);
+
+                if (location == Location.PreferencesFolder)
+                    filePath = InternalEditorUtility.unityPreferencesFolder + "/" + relativePath;
+                else if (location == Location.UserFolder)
+                    filePath = EntryPoint.ApplicationManager.Environment.UserCachePath.Combine(relativePath).ToString(SlashMode.Forward);
+                else if (location == Location.LibraryFolder)
+                    filePath = EntryPoint.ApplicationManager.Environment.UnityProjectPath.Combine("Library", "gfu", relativePath);
+
+                return filePath;
+            }
+        }
+
         public LocationAttribute(string relativePath, Location location)
         {
             Guard.ArgumentNotNullOrWhiteSpace(relativePath, "relativePath");
-
-            if (relativePath[0] == '/')
-                relativePath = relativePath.Substring(1);
-
-            if (location == Location.PreferencesFolder)
-                filepath = InternalEditorUtility.unityPreferencesFolder + "/" + relativePath;
-            else if (location == Location.UserFolder)
-                filepath = EntryPoint.ApplicationManager.Environment.UserCachePath.Combine(relativePath).ToString(SlashMode.Forward);
-            else if (location == Location.LibraryFolder)
-                filepath = EntryPoint.ApplicationManager.Environment.UnityProjectPath.Combine("Library", "gfu", relativePath);
+            this.relativePath = relativePath;
+            this.location = location;
         }
     }
 
@@ -99,7 +113,7 @@ namespace GitHub.Unity
             
             if (attr == null)
                 return null;
-            return attr.filepath.ToNPath();
+            return attr.FilePath.ToNPath();
         }
     }
 }


### PR DESCRIPTION
Fixes #990, until Unity fixes their broken stuff.