### PR TITLE
Add missing YAML files to .gitattributes

### DIFF
--- a/src/GitHub.Api/Resources/.gitattributes
+++ b/src/GitHub.Api/Resources/.gitattributes
@@ -6,6 +6,23 @@
 *.asset -text merge=unityyamlmerge diff
 *.prefab -text merge=unityyamlmerge diff
 *.mat -text merge=unityyamlmerge diff
+*.anim -text merge=unityyamlmerge diff
+*.controller -text merge=unityyamlmerge diff
+*.overrideController -text merge=unityyamlmerge diff
+*.physicMaterial -text merge=unityyamlmerge diff
+*.physicsMaterial2D -text merge=unityyamlmerge diff
+*.playable -text merge=unityyamlmerge diff
+*.mask -text merge=unityyamlmerge diff
+*.brush -text merge=unityyamlmerge diff
+*.flare -text merge=unityyamlmerge diff
+*.fontsettings -text merge=unityyamlmerge diff
+*.guiskin -text merge=unityyamlmerge diff
+*.giparams -text merge=unityyamlmerge diff
+*.renderTexture -text merge=unityyamlmerge diff
+*.spriteatlas -text merge=unityyamlmerge diff
+*.terrainlayer -text merge=unityyamlmerge diff
+*.mixer -text merge=unityyamlmerge diff
+*.shadervariants -text merge=unityyamlmerge diff
 
 # Image formats
 *.psd filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Fixes #847 

(The generated) .gitattributes file was missing some other YAML files besides `.prefab`, `.unity`, etc.

I created an empty project and created almost everything under `Assets`/`Create`. Here are the files: https://i.imgur.com/QODfnOr.png

While I'm not familiar with a lot of these extensions, Unity supports them, so they should be in .gitattributes.