### PR TITLE
fix asmdef files giving errors on 2018.3

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "ExtensionLoader",
-    "references": ["../../build/GitHub.UnityShim.dll"],
+    "precompiledReferences": ["../../build/GitHub.UnityShim.dll"],
     "includePlatforms": [
         "Editor"
     ],

--- a/src/UnityExtension/Assets/Editor/UnityTests/UnityTests.asmdef
+++ b/src/UnityExtension/Assets/Editor/UnityTests/UnityTests.asmdef
@@ -3,8 +3,16 @@
     "references": [
         "GitHub.Unity"
     ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }


### PR DESCRIPTION
### Description of the Change

I've updated the .asmdef files so that you can do the quick debugging workflow using Unity 2018.3.  Discussed this with Shana on Discord.

### Benefits

This allows developers the quick iteration of loading the GUI code directly in Unity

### Possible Drawbacks

Older versions of Unity will be broken
