### PR TITLE
fix asmdef files giving errors on 2018.3

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
@@ -1,8 +1,15 @@
 {
     "name": "ExtensionLoader",
-    "precompiledReferences": ["../../build/GitHub.UnityShim.dll"],
+    "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "GitHub.UnityShim.dll"
+    ],
+    "autoReferenced": true
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/ExtensionLoader/ExtensionLoader.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "ExtensionLoader",
-    "references": ["../../build/GitHub.UnityShim.dll"],
+    "precompiledReferences": ["../../build/GitHub.UnityShim.dll"],
     "includePlatforms": [
         "Editor"
     ],

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -37,15 +37,13 @@ namespace GitHub.Unity
             Texture2D texture2D = null;
 
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("GitHub.Unity.IconsAndLogos." + filename);
-            if (stream != null)
+            if (stream == null)
             {
-                texture2D = stream.ToTexture2D();
+                stream = new MemoryStream(Application.dataPath.ToNPath().Combine("Editor/GitHub.Unity/IconsAndLogos/", filename).ReadAllBytes());
             }
-            else
-            {
-                var iconPath = "Assets/Editor/GitHub.Unity/IconsAndLogos/" + filename;
-                texture2D = AssetDatabase.LoadAssetAtPath<Texture2D>(iconPath);
-            }
+
+            texture2D = stream.ToTexture2D();
+            stream.Dispose();
 
             if (texture2D != null)
             {

--- a/src/UnityExtension/Assets/Editor/UnityTests/UnityTests.asmdef
+++ b/src/UnityExtension/Assets/Editor/UnityTests/UnityTests.asmdef
@@ -3,8 +3,16 @@
     "references": [
         "GitHub.Unity"
     ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }

--- a/src/UnityExtension/ProjectSettings/ProjectVersion.txt
+++ b/src/UnityExtension/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,1 @@
+m_EditorVersion: 2018.3.2f1


### PR DESCRIPTION
Pulling in #1000 and adding some additional fixes. Dark mode was broken (because Unity is importing icons differently from the filesystem I guess?), and I let Unity regenerate the asmdef file, which changed it subtly. This is on 2018.3.0, so I want to do it on 2018.3.1 as well and then add the ProjectVersion.txt file to signal what version the project is actually on (because it's kinda important).