### PR TITLE
fix: Better error logging when processes fail

### DIFF
--- a/src/GitHub.Api/Helpers/Constants.cs
+++ b/src/GitHub.Api/Helpers/Constants.cs
@@ -4,6 +4,7 @@ namespace GitHub.Unity
 {
     static class Constants
     {
+        // settings keys
         public const string GuidKey = "Guid";
         public const string MetricsKey = "MetricsEnabled";
         public const string UsageFile = "metrics.json";
@@ -11,6 +12,12 @@ namespace GitHub.Unity
         public const string TraceLoggingKey = "EnableTraceLogging";
         public const string WebTimeoutKey = "WebTimeout";
         public const string GitTimeoutKey = "GitTimeout";
+        public const string SkipVersionKey = "SkipVersion";
+        public const string GitInstallationState = "GitInstallationState";
+        public const string DisableGCMKey = "DisableGCM"; // don't let GCM prompt for credentials
+        public const string EnableGitAuthPromptsKey = "EnableGitAuthPrompts"; // let git prompt for credentials on the command line (might hang processes)
+        public const string DisableSetEnvironmentKey = "DisableSetEnvironment"; // don't set environment variables when spawning processes
+
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
         public static readonly string[] Iso8601Formats = {
@@ -32,8 +39,6 @@ namespace GitHub.Unity
             @"yyyy-MM-dd\THH\:mm\:ss.f\Z",
         };
         public const DateTimeStyles DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;
-        public const string SkipVersionKey = "SkipVersion";
-        public const string GitInstallationState = "GitInstallationState";
 
         public static readonly TheVersion MinimumGitVersion = TheVersion.Parse("2.0");
         public static readonly TheVersion MinimumGitLfsVersion = TheVersion.Parse("2.0");

--- a/src/GitHub.Api/Platform/ProcessEnvironment.cs
+++ b/src/GitHub.Api/Platform/ProcessEnvironment.cs
@@ -19,6 +19,11 @@ namespace GitHub.Unity
         public void Configure(ProcessStartInfo psi, NPath workingDirectory, bool dontSetupGit = false)
         {
             psi.WorkingDirectory = workingDirectory;
+            if (Environment.UserSettings.Get<bool>(Constants.DisableSetEnvironmentKey))
+            {
+                // don't do anything beyond setting the working directory;
+                return;
+            }
             psi.EnvironmentVariables["HOME"] = NPath.HomeDirectory;
             psi.EnvironmentVariables["TMP"] = psi.EnvironmentVariables["TEMP"] = NPath.SystemTemp;
 
@@ -109,6 +114,11 @@ namespace GitHub.Unity
             if (!String.IsNullOrEmpty(httpsProxy))
                 psi.EnvironmentVariables["HTTPS_PROXY"] = httpsProxy;
             psi.EnvironmentVariables["DISPLAY"] = "0";
+            if (!Environment.UserSettings.Get<bool>(Constants.EnableGitAuthPromptsKey))
+                psi.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+
+            if (Environment.UserSettings.Get<bool>(Constants.DisableGCMKey))
+                psi.EnvironmentVariables["GCM_INTERACTIVE"] = "NEVER";
         }
     }
 }

--- a/src/GitHub.Api/Tasks/ProcessTask.cs
+++ b/src/GitHub.Api/Tasks/ProcessTask.cs
@@ -165,8 +165,10 @@ namespace GitHub.Unity
                             // process is done and we haven't seen output, we're done
                             done = !gotOutput.WaitOne(100);
                         }
-                        else if (token.IsCancellationRequested || (taskName.Contains("git lfs") && lastOutput.AddMilliseconds(ApplicationConfiguration.DefaultGitTimeout) < DateTimeOffset.UtcNow))
-                        // if we're exiting or we haven't had output for a while
+                        else if (token.IsCancellationRequested || (taskName.Contains("git lfs") &&
+                                lastOutput.AddMilliseconds(ApplicationConfiguration.DefaultGitTimeout) <
+                                DateTimeOffset.UtcNow))
+                            // if we're exiting or we haven't had output for a while
                         {
                             Stop(true);
                             token.ThrowIfCancellationRequested();
@@ -199,14 +201,12 @@ namespace GitHub.Unity
                     sb.AppendLine($"'{Process.StartInfo.FileName} {Process.StartInfo.Arguments}'");
                 if (errorCode == 2)
                     sb.AppendLine("The system cannot find the file specified.");
-                foreach (string env in Process.StartInfo.EnvironmentVariables.Keys)
-                {
-                    if (!traceEnvKeys.Contains(env.ToUpperInvariant())) continue;
-                    sb.AppendFormat($"{env}:{Process.StartInfo.EnvironmentVariables[env]}");
-                    sb.AppendLine();
-                }
 
-                thrownException = new ProcessException(errorCode, sb.ToString(),  ex);
+                thrownException = new ProcessException(errorCode, sb.ToString(), ex) {
+                    EnvironmentVariables = Process.StartInfo.EnvironmentVariables.Keys.Cast<string>()
+                                                  .Where(x => traceEnvKeys.Contains(x)).Select(x =>
+                                                      $"{x}={Process.StartInfo.EnvironmentVariables[x]}").ToArray()
+                };
             }
 
             if (thrownException != null || errors.Count > 0)

--- a/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
+++ b/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
@@ -27,11 +27,11 @@ namespace GitHub.Unity
 
         protected ProcessException() : base()
         { }
-        public ProcessException(int errorCode, string message) : base(String.Format("Error code:{0} {1}", errorCode, message))
+        public ProcessException(int errorCode, string message) : base(message)
         {
             ErrorCode = errorCode;
         }
-        public ProcessException(int errorCode, string message, Exception innerException) : base(String.Format("Error code:{0} {1}", errorCode, message), innerException)
+        public ProcessException(int errorCode, string message, Exception innerException) : base(message, innerException)
         {
             ErrorCode = errorCode;
         }

--- a/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
+++ b/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
@@ -19,30 +19,4 @@ namespace GitHub.Unity
         public DependentTaskFailedException(ITask task, Exception ex) : this(ex.InnerException != null ? ex.InnerException.Message : ex.Message, ex.InnerException ?? ex)
         {}
     }
-
-    [Serializable]
-    class ProcessException : TaskCanceledException
-    {
-        public int ErrorCode { get; }
-
-        protected ProcessException() : base()
-        { }
-        public ProcessException(int errorCode, string message) : base(message)
-        {
-            ErrorCode = errorCode;
-        }
-        public ProcessException(int errorCode, string message, Exception innerException) : base(message, innerException)
-        {
-            ErrorCode = errorCode;
-        }
-        public ProcessException(string message) : base(message)
-        { }
-        public ProcessException(string message, Exception innerException) : base(message, innerException)
-        { }
-        protected ProcessException(SerializationInfo info, StreamingContext context) : base(info, context)
-        { }
-
-        public ProcessException(ITask process) : this(process.Errors)
-        { }
-    }
 }

--- a/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
+++ b/src/GitHub.Api/Tasks/TaskCanceledExceptions.cs
@@ -27,11 +27,11 @@ namespace GitHub.Unity
 
         protected ProcessException() : base()
         { }
-        public ProcessException(int errorCode, string message) : base(message)
+        public ProcessException(int errorCode, string message) : base(String.Format("Error code:{0} {1}", errorCode, message))
         {
             ErrorCode = errorCode;
         }
-        public ProcessException(int errorCode, string message, Exception innerException) : base(message, innerException)
+        public ProcessException(int errorCode, string message, Exception innerException) : base(String.Format("Error code:{0} {1}", errorCode, message), innerException)
         {
             ErrorCode = errorCode;
         }

--- a/src/GitHub.Logging/Extensions/ExceptionExtensions.cs
+++ b/src/GitHub.Logging/Extensions/ExceptionExtensions.cs
@@ -1,17 +1,30 @@
 using System;
 using System.Linq;
+using GitHub.Unity;
 
 namespace GitHub.Logging
 {
     public static class ExceptionExtensions
     {
-        public static string GetExceptionMessage(this Exception ex)
+        public static string GetExceptionMessage(this Exception ex, bool includeEnvironment = false)
         {
             var message = ex.ToString();
+
+            var processException = ex as ProcessException;
+            if (includeEnvironment && processException != null)
+            {
+                message += Environment.NewLine + String.Join(Environment.NewLine, ((ProcessException)ex).EnvironmentVariables);
+            }
+
             var inner = ex.InnerException;
             while (inner != null)
             {
                 message += Environment.NewLine + inner.ToString();
+                processException = inner as ProcessException;
+                if (includeEnvironment && processException != null)
+                {
+                    message += Environment.NewLine + String.Join(Environment.NewLine, processException.EnvironmentVariables);
+                }
                 inner = inner.InnerException;
             }
             var caller = Environment.StackTrace;

--- a/src/GitHub.Logging/Extensions/ProcessExceptions.cs
+++ b/src/GitHub.Logging/Extensions/ProcessExceptions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace GitHub.Unity
+{
+    [Serializable]
+    class ProcessException : OperationCanceledException
+    {
+        public int ErrorCode { get; }
+        public string[] EnvironmentVariables { get; set; }
+
+        public ProcessException(int errorCode, string message) : base(message)
+        {
+            ErrorCode = errorCode;
+        }
+        public ProcessException(int errorCode, string message, Exception innerException) : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+        }
+        public ProcessException(string message, Exception innerException) : base(message, innerException)
+        { }
+        protected ProcessException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
+}

--- a/src/GitHub.Logging/GitHub.Logging.csproj
+++ b/src/GitHub.Logging/GitHub.Logging.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\ExceptionExtensions.cs" />
+    <Compile Include="Extensions\ProcessExceptions.cs" />
     <Compile Include="FileLogAdapter.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ILogging.cs" />

--- a/src/GitHub.Logging/LogFacade.cs
+++ b/src/GitHub.Logging/LogFacade.cs
@@ -87,8 +87,7 @@ namespace GitHub.Logging
         public void Trace(Exception ex, string message)
         {
             if (!LogHelper.TracingEnabled) return;
-
-            Trace(String.Concat(message, Environment.NewLine, ex.GetExceptionMessage()));
+            Trace(String.IsNullOrEmpty(message) ? ex.GetExceptionMessage() : String.Concat(message, Environment.NewLine, ex.GetExceptionMessage()));
         }
 
         public void Trace(Exception ex)

--- a/src/GitHub.Logging/LogFacade.cs
+++ b/src/GitHub.Logging/LogFacade.cs
@@ -59,7 +59,7 @@ namespace GitHub.Logging
         public void Debug(Exception ex, string message)
         {
 #if DEBUG
-            Debug(String.Concat(message, Environment.NewLine, ex.GetExceptionMessage()));
+            Debug(String.Concat(message, Environment.NewLine, ex.GetExceptionMessage(true)));
 #endif
         }
 
@@ -87,7 +87,7 @@ namespace GitHub.Logging
         public void Trace(Exception ex, string message)
         {
             if (!LogHelper.TracingEnabled) return;
-            Trace(String.IsNullOrEmpty(message) ? ex.GetExceptionMessage() : String.Concat(message, Environment.NewLine, ex.GetExceptionMessage()));
+            Trace(String.IsNullOrEmpty(message) ? ex.GetExceptionMessage(true) : String.Concat(message, Environment.NewLine, ex.GetExceptionMessage(true)));
         }
 
         public void Trace(Exception ex)

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Styles.cs
@@ -220,6 +220,36 @@ namespace GitHub.Unity
             }
         }
 
+        private static GUIStyle toggle;
+        public static GUIStyle Toggle
+        {
+            get
+            {
+                if (toggle == null)
+                {
+                    toggle = new GUIStyle(GUI.skin.toggle);
+                    toggle.name = "CustomToggle";
+                    toggle.wordWrap = true;
+                }
+                return toggle;
+            }
+        }
+
+        private static GUIStyle toggleNoWrap;
+        public static GUIStyle ToggleNoWrap
+        {
+            get
+            {
+                if (toggleNoWrap == null)
+                {
+                    toggleNoWrap = new GUIStyle(GUI.skin.toggle);
+                    toggleNoWrap.name = "CustomToggleNoWrap";
+                    toggleNoWrap.wordWrap = false;
+                }
+                return toggleNoWrap;
+            }
+        }
+
         public static GUIStyle LabelNoWrap
         {
             get
@@ -1134,6 +1164,20 @@ namespace GitHub.Unity
                 }
 
                 return lockMetaDataStyle;
+            }
+        }
+
+        private static GUIStyle horizontalLine;
+        public static GUIStyle HorizontalLine {
+            get {
+                if (horizontalLine == null)
+                {
+                    horizontalLine = new GUIStyle(GUI.skin.box);
+                    horizontalLine.border.top = horizontalLine.border.bottom = 1;
+                    horizontalLine.margin.top = horizontalLine.margin.bottom = 0;
+                    horizontalLine.padding.top = horizontalLine.padding.bottom = 0;
+                }
+                return horizontalLine;
             }
         }
     }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -352,10 +352,10 @@ namespace GitHub.Unity
             Refresh(CacheType.GitAheadBehind);
         }
 
-        public override void OnDataUpdate()
+        public override void OnDataUpdate(bool first)
         {
-            base.OnDataUpdate();
-            MaybeUpdateData();
+            base.OnDataUpdate(first);
+            MaybeUpdateData(first);
         }
 
         public override void OnFocusChanged()
@@ -369,7 +369,7 @@ namespace GitHub.Unity
             }
         }
 
-        public override void OnGUI()
+        public override void OnUI()
         {
             var rect = GUILayoutUtility.GetLastRect();
             if (historyControl != null)
@@ -391,7 +391,7 @@ namespace GitHub.Unity
                     Redraw();
             }
 
-            DoProgressGUI();
+            DoProgressUI();
 
             if (!selectedEntry.Equals(GitLogEntry.Default))
             {
@@ -543,7 +543,7 @@ namespace GitHub.Unity
             repository.CheckAndRaiseEventsIfCacheNewer(CacheType.GitAheadBehind, lastTrackingStatusChangedEvent);
         }
 
-        private void MaybeUpdateData()
+        private void MaybeUpdateData(bool first)
         {
             if (Repository == null)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/IView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/IView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -21,20 +22,20 @@ namespace GitHub.Unity
         IUser User { get; }
         bool HasUser { get; }
         IApplicationManager Manager { get; }
-        bool IsBusy { get; }
+        bool IsBusy { get; set; }
         bool IsRefreshing { get; }
         bool HasFocus { get; }
-        Dictionary<CacheType, int> RefreshEvents { get; }
+        HashSet<CacheType> RefreshEvents { get; }
     }
 
     interface IUIEmpty
     {
-        void DoEmptyGUI();
+        void DoEmptyUI();
     }
 
     interface IUIProgress
     {
-        void DoProgressGUI();
+        void DoProgressUI();
         void UpdateProgress(IProgress progress);
     }
 }

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/InitProjectView.cs
@@ -39,7 +39,7 @@ namespace GitHub.Unity
             DetachHandlers();
         }
 
-        public override void OnGUI()
+        public override void OnUI()
         {
             GUILayout.BeginVertical(Styles.GenericBoxStyle);
             {
@@ -85,10 +85,10 @@ namespace GitHub.Unity
             GUILayout.EndVertical();
         }
 
-        public override void OnDataUpdate()
+        public override void OnDataUpdate(bool first)
         {
-            base.OnDataUpdate();
-            MaybeUpdateData();
+            base.OnDataUpdate(first);
+            MaybeUpdateData(first);
         }
 
         private void AttachHandlers()
@@ -111,7 +111,7 @@ namespace GitHub.Unity
             User.Changed -= UserOnChanged;
         }
 
-        private void MaybeUpdateData()
+        private void MaybeUpdateData(bool first)
         {
             if (userHasChanges)
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LoadingView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/LoadingView.cs
@@ -16,7 +16,7 @@ namespace GitHub.Unity
             Size = MinViewSize;
         }
 
-        public override void OnGUI()
+        public override void OnUI()
         {
             GUILayout.BeginVertical();
             {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/PopupWindow.cs
@@ -21,6 +21,7 @@ namespace GitHub.Unity
         [SerializeField] private LoadingView loadingView;
         [SerializeField] private PublishView publishView;
         [SerializeField] private bool shouldCloseOnFinish;
+        [NonSerialized] private bool firstForThisView = true;
 
         public event Action<bool> OnClose;
 
@@ -44,14 +45,11 @@ namespace GitHub.Unity
             publishView.InitializeView(this);
             authenticationView.InitializeView(this);
             loadingView.InitializeView(this);
-
-            titleContent = new GUIContent(ActiveView.Title, Styles.SmallLogo);
         }
 
         public override void OnEnable()
         {
             base.OnEnable();
-            minSize = maxSize = ActiveView.Size;
             ActiveView.OnEnable();
         }
 
@@ -61,24 +59,26 @@ namespace GitHub.Unity
             ActiveView.OnDisable();
         }
 
-        public override void OnDataUpdate()
+        public override void OnDataUpdate(bool first)
         {
-            base.OnDataUpdate();
-            if (titleContent.image == null)
+            base.OnDataUpdate(first);
+            ActiveView.OnDataUpdate(first);
+            if (first || firstForThisView)
                 titleContent = new GUIContent(ActiveView.Title, Styles.SmallLogo);
-            ActiveView.OnDataUpdate();
+            minSize = maxSize = ActiveView.Size;
+            firstForThisView = false;
         }
 
         public override void OnUI()
         {
             base.OnUI();
-            ActiveView.OnGUI();
+            ActiveView.OnUI();
         }
 
         public override void Refresh()
         {
-            base.Refresh();
             ActiveView.Refresh();
+            base.Refresh();
         }
 
         public override void OnSelectionChange()
@@ -181,7 +181,7 @@ namespace GitHub.Unity
             if (fromView != null)
                 fromView.OnDisable();
             toView.OnEnable();
-            titleContent = new GUIContent(ActiveView.Title, Styles.SmallLogo);
+            firstForThisView = true;
 
             // this triggers a repaint
             Repaint();

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/Subview.cs
@@ -1,3 +1,4 @@
+using System;
 using GitHub.Logging;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,10 +9,6 @@ namespace GitHub.Unity
     abstract class Subview : IView
     {
         private const string NullParentError = "Subview parent is null";
-
-        public Subview()
-        {
-        }
 
         public virtual void InitializeView(IView parent)
         {
@@ -25,10 +22,10 @@ namespace GitHub.Unity
         public virtual void OnDisable()
         {}
 
-        public virtual void OnDataUpdate()
+        public virtual void OnDataUpdate(bool first)
         {}
 
-        public virtual void OnGUI()
+        public virtual void OnUI()
         {}
 
         public virtual void OnSelectionChange()
@@ -50,14 +47,14 @@ namespace GitHub.Unity
             Parent.Finish(result);
         }
 
-        public void DoEmptyGUI()
+        public void DoEmptyUI()
         {
-            Parent.DoEmptyGUI();
+            Parent.DoEmptyUI();
         }
 
-        public void DoProgressGUI()
+        public void DoProgressUI()
         {
-            Parent.DoProgressGUI();
+            Parent.DoProgressUI();
         }
 
         public void UpdateProgress(IProgress progress)
@@ -97,13 +94,14 @@ namespace GitHub.Unity
         public bool HasFocus { get { return Parent != null && Parent.HasFocus; } }
         public virtual bool IsBusy
         {
-            get { return (Manager != null && Manager.IsBusy) || (Repository != null && Repository.IsBusy); }
+            get { return Parent.IsBusy; }
+            set { Parent.IsBusy = value; }
         }
 
         public Rect Position { get { return Parent.Position; } }
         public string Title { get; protected set; }
         public Vector2 Size { get; protected set; }
-        public Dictionary<CacheType, int> RefreshEvents { get { return Parent.RefreshEvents; } }
+        public HashSet<CacheType> RefreshEvents { get { return Parent.RefreshEvents; } }
         public bool IsRefreshing { get { return Parent.IsRefreshing; } }
 
         private ILogging logger;

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/TreeControl.cs
@@ -557,7 +557,7 @@ namespace GitHub.Unity
         [SerializeField] public bool isCheckable = false;
         [SerializeField] private List<TreeNode> nodes = new List<TreeNode>();
         [SerializeField] private TreeNode selectedNode = null;
-        [NonSerialized] private bool viewFocus;
+        [SerializeField] private bool viewFocus;
 
         public override string Title
         {

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UpdateCheck.cs
@@ -140,10 +140,10 @@ namespace GitHub.Unity
             this.InitializeWindow(manager, requiresRedraw);
         }
 
-        public override void OnDataUpdate()
+        public override void OnDataUpdate(bool first)
         {
-            base.OnDataUpdate();
-            LoadContents();
+            base.OnDataUpdate(first);
+            LoadContents(first);
         }
 
         public override void OnUI()
@@ -211,13 +211,13 @@ namespace GitHub.Unity
             EditorGUILayout.EndVertical();
         }
 
-        private void LoadContents()
+        private void LoadContents(bool first)
         {
-            if (guiLogo != null)
-                return;
+            if (!first) return;
 
             guiLogo = new GUIContent(Styles.BigLogo);
-            guiNewUpdate = new GUIContent(String.Format(newUpdateMessage, currentVersion, package.Package.Version.ToString()));
+            guiNewUpdate = new GUIContent(String.Format(newUpdateMessage, currentVersion,
+                package.Package.Version.ToString()));
             guiSkipThisVersion = new GUIContent(skipThisVersionMessage);
             guiDownloadNewVersion = new GUIContent(downloadNewVersionMessage);
             guiBrowseReleaseNotes = new GUIContent(browseReleaseNotes);

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -194,10 +194,12 @@ namespace IntegrationTests
             Assert.IsFalse(success);
             CollectionAssert.AreEqual(expectedOutput, output);
             Assert.IsNotNull(thrown);
-            var expected = @"Error code -1
-kaboom
-'CommandLine.exe -e kaboom -r -1'";
-            Assert.IsTrue(thrown.Message.StartsWith(expected));
+//            var expected = @"Error code -1
+//kaboom
+//'CommandLine.exe -e kaboom -r -1'";
+//            Assert.IsTrue(thrown.Message.StartsWith(expected));
+
+            Logger.Error(thrown);
         }
 
         [Test]

--- a/src/tests/TaskSystemIntegrationTests/Tests.cs
+++ b/src/tests/TaskSystemIntegrationTests/Tests.cs
@@ -194,7 +194,10 @@ namespace IntegrationTests
             Assert.IsFalse(success);
             CollectionAssert.AreEqual(expectedOutput, output);
             Assert.IsNotNull(thrown);
-            Assert.AreEqual("kaboom", thrown.Message);
+            var expected = @"Error code -1
+kaboom
+'CommandLine.exe -e kaboom -r -1'";
+            Assert.IsTrue(thrown.Message.StartsWith(expected));
         }
 
         [Test]


### PR DESCRIPTION
We were throwing away some important information when a spawned process failed, but we're also recording way too much environment information that we don't need, so clean all of that up for better error logging.