### PR TITLE
refresh asset database after revert

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -349,6 +349,7 @@ namespace GitHub.Unity
                             EditorUtility.DisplayDialog(dialogTitle,
                                 "Error reverting commit: " + e.Message, Localization.Cancel);
                         }
+                        AssetDatabase.Refresh();
                     })
                     .Start();
             }


### PR DESCRIPTION
### Description of the Change

Refresh asset database after reverting.  This is necessary to make sure Unity is looking at the most up-to-date files.  I didn't see that this was happening in this case so it's a pretty simple change.

### Benefits

Users see accurate versions of file in Unity

### Possible Drawbacks

It is possible it is a redundant call, but not from what I could tell.
