### PR TITLE
File history revert

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/HistoryView.cs
@@ -349,6 +349,7 @@ namespace GitHub.Unity
                             EditorUtility.DisplayDialog(dialogTitle,
                                 "Error reverting commit: " + e.Message, Localization.Cancel);
                         }
+                        AssetDatabase.Refresh();
                     })
                     .Start();
             }


### PR DESCRIPTION
### Description of the Change

The main change is that this allows you to revert an individual file to a specific point in time.

This PR also has some changes in it that allow the UI to survive domain reloads (previously, the title and icon would disappear but the history view would persist).

### Alternate Designs

Many ways to do this; happy to make changes if I'm breaking any sorts of conventions.

### Benefits

Users are prompted if the file they are reverting is changed locally (so it's safe).  Perhaps an even better fix would be to move the existing file into the recycle bin so they could restore it if necessary?  This also allows the UI to survive domain reloads

### Possible Drawbacks

I don't see much use of the GitClient in the UI layer so I'm not sure if I'm violating some convention..

### Applicable Issues

none