### PR TITLE
Sometimes .tiff images has .tif extension

### DIFF
--- a/src/GitHub.Api/Resources/.gitattributes
+++ b/src/GitHub.Api/Resources/.gitattributes
@@ -32,6 +32,7 @@
 *.bmp filter=lfs diff=lfs merge=lfs -text
 *.tga filter=lfs diff=lfs merge=lfs -text
 *.tiff filter=lfs diff=lfs merge=lfs -text
+*.tif filter=lfs diff=lfs merge=lfs -text
 *.iff filter=lfs diff=lfs merge=lfs -text
 *.pict filter=lfs diff=lfs merge=lfs -text
 *.dds filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
even on asset store

### Description of the Change
Adding .tif (alternative extension for .tiff) files to LFS at default

### Benefits
Others dose't do same mistake that I just did; commited over 2G non lfs git
