### PR TITLE
Refresh after discard

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -244,9 +244,7 @@ namespace GitHub.Unity
                 }
 
                 Repository.DiscardChanges(discardEntries)
-                          .ThenInUI(() => {
-                              AssetDatabase.Refresh();
-                          })
+                          .ThenInUI(AssetDatabase.Refresh)
                           .Start();
             });
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ChangesView.cs
@@ -244,6 +244,9 @@ namespace GitHub.Unity
                 }
 
                 Repository.DiscardChanges(discardEntries)
+                          .ThenInUI(() => {
+                              AssetDatabase.Refresh();
+                          })
                           .Start();
             });
 

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/ProjectWindowInterface.cs
@@ -291,7 +291,7 @@ namespace GitHub.Unity
                 guids.Add(guid);
             }
 
-            EditorApplication.RepaintProjectWindow();
+            AssetDatabase.Refresh();
         }
 
         private static void OnProjectWindowItemGUI(string guid, Rect itemRect)


### PR DESCRIPTION
Fixes #952 
Fixes #960 

Calling `AssetDatabase.Refresh();` from the status handler in the `ProjectWindowInterface` is particularly important because it is definitely after all git checkout operations have completed.