### PR TITLE
Make sure the correct environment variables are being read

### DIFF
--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -135,7 +135,7 @@ namespace GitHub.Unity
         private static string GetEnvironmentVariableKeyInternal(string name)
         {
             return Environment.GetEnvironmentVariables().Keys.Cast<string>()
-                                 .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0);
+                                 .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0) ?? name;
         }
 
         public NPath LogPath { get; }

--- a/src/GitHub.Api/Platform/DefaultEnvironment.cs
+++ b/src/GitHub.Api/Platform/DefaultEnvironment.cs
@@ -1,5 +1,6 @@
 using GitHub.Logging;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -116,12 +117,25 @@ namespace GitHub.Unity
 
         public string ExpandEnvironmentVariables(string name)
         {
-            return Environment.ExpandEnvironmentVariables(name);
+            var key = GetEnvironmentVariableKey(name);
+            return Environment.ExpandEnvironmentVariables(key);
         }
 
-        public string GetEnvironmentVariable(string variable)
+        public string GetEnvironmentVariable(string name)
         {
-            return Environment.GetEnvironmentVariable(variable);
+            var key = GetEnvironmentVariableKey(name);
+            return Environment.GetEnvironmentVariable(key);
+        }
+
+        public string GetEnvironmentVariableKey(string name)
+        {
+            return GetEnvironmentVariableKeyInternal(name);
+        }
+
+        private static string GetEnvironmentVariableKeyInternal(string name)
+        {
+            return Environment.GetEnvironmentVariables().Keys.Cast<string>()
+                                 .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0);
         }
 
         public NPath LogPath { get; }
@@ -134,7 +148,7 @@ namespace GitHub.Unity
         public NPath ExtensionInstallPath { get; set; }
         public NPath UserCachePath { get; set; }
         public NPath SystemCachePath { get; set; }
-        public string Path { get; set; } = Environment.GetEnvironmentVariable("PATH");
+        public string Path { get; set; } = Environment.GetEnvironmentVariable(GetEnvironmentVariableKeyInternal("PATH"));
 
         public string NewLine => Environment.NewLine;
         public NPath OctorunScriptPath

--- a/src/GitHub.Api/Platform/IEnvironment.cs
+++ b/src/GitHub.Api/Platform/IEnvironment.cs
@@ -41,5 +41,6 @@ namespace GitHub.Unity
         ISettings LocalSettings { get; }
         ISettings SystemSettings { get; }
         ISettings UserSettings { get; }
+        string GetEnvironmentVariableKey(string name);
     }
 }

--- a/src/GitHub.Api/Platform/ProcessEnvironment.cs
+++ b/src/GitHub.Api/Platform/ProcessEnvironment.cs
@@ -1,5 +1,4 @@
 using GitHub.Logging;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -24,11 +23,12 @@ namespace GitHub.Unity
 
             var path = Environment.Path;
             psi.EnvironmentVariables["GHU_WORKINGDIR"] = workingDirectory;
+            var pathEnvVarKey = Environment.GetEnvironmentVariableKey("PATH");
 
             if (dontSetupGit)
             {
                 psi.EnvironmentVariables["GHU_FULLPATH"] = path;
-                psi.EnvironmentVariables["PATH"] = path;
+                psi.EnvironmentVariables[pathEnvVarKey] = path;
                 return;
             }
 
@@ -87,10 +87,10 @@ namespace GitHub.Unity
 
             pathEntries.Add("END");
 
-            path = String.Join(separator, pathEntries.ToArray()) + separator + path;
+            path = string.Join(separator, pathEntries.ToArray()) + separator + path;
 
             psi.EnvironmentVariables["GHU_FULLPATH"] = path;
-            psi.EnvironmentVariables["PATH"] = path;
+            psi.EnvironmentVariables[pathEnvVarKey] = path;
 
             //TODO: Remove with Git LFS Locking becomes standard
             psi.EnvironmentVariables["GITLFSLOCKSENABLED"] = "1";
@@ -102,11 +102,11 @@ namespace GitHub.Unity
             }
 
             var httpProxy = Environment.GetEnvironmentVariable("HTTP_PROXY");
-            if (!String.IsNullOrEmpty(httpProxy))
+            if (!string.IsNullOrEmpty(httpProxy))
                 psi.EnvironmentVariables["HTTP_PROXY"] = httpProxy;
 
             var httpsProxy = Environment.GetEnvironmentVariable("HTTPS_PROXY");
-            if (!String.IsNullOrEmpty(httpsProxy))
+            if (!string.IsNullOrEmpty(httpsProxy))
                 psi.EnvironmentVariables["HTTPS_PROXY"] = httpsProxy;
             psi.EnvironmentVariables["DISPLAY"] = "0";
         }

--- a/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
@@ -77,13 +77,13 @@ namespace IntegrationTests
 
         public string GetEnvironmentVariableKey(string name)
         {
-            return GetEnvironmentVariableKeyInternal(name);
+            return defaultEnvironment.GetEnvironmentVariableKey(name);
         }
 
         private static string GetEnvironmentVariableKeyInternal(string name)
         {
             return Environment.GetEnvironmentVariables().Keys.Cast<string>()
-                              .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0);
+                              .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0) ?? name;
         }
 
         public string GetSpecialFolder(Environment.SpecialFolder folder)

--- a/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
+++ b/src/tests/IntegrationTests/IntegrationTestEnvironment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using GitHub.Unity;
 using GitHub.Logging;
 
@@ -60,7 +61,7 @@ namespace IntegrationTests
 
         public string ExpandEnvironmentVariables(string name)
         {
-            return name;
+            return defaultEnvironment.ExpandEnvironmentVariables(name);
         }
 
         public string GetEnvironmentVariable(string v)
@@ -71,6 +72,18 @@ namespace IntegrationTests
                 logger.Trace("GetEnvironmentVariable: {0}={1}", v, environmentVariable);
             }
             return environmentVariable;
+        }
+
+
+        public string GetEnvironmentVariableKey(string name)
+        {
+            return GetEnvironmentVariableKeyInternal(name);
+        }
+
+        private static string GetEnvironmentVariableKeyInternal(string name)
+        {
+            return Environment.GetEnvironmentVariables().Keys.Cast<string>()
+                              .FirstOrDefault(k => string.Compare(name, k, true, CultureInfo.InvariantCulture) == 0);
         }
 
         public string GetSpecialFolder(Environment.SpecialFolder folder)
@@ -88,7 +101,7 @@ namespace IntegrationTests
 
         public string UserProfilePath => UserCachePath.Parent.CreateDirectory("user profile path");
 
-        public string Path { get; set; } = Environment.GetEnvironmentVariable("PATH").ToNPath();
+        public string Path { get; set; } = Environment.GetEnvironmentVariable(GetEnvironmentVariableKeyInternal("PATH"));
 
         public string NewLine => Environment.NewLine;
         public string UnityVersion => "5.6";


### PR DESCRIPTION
~Possible~ Confirmed fix for the wrong git being picked up in some cases. Fixes #1044 

Even though environment variable keys are case-insensitive, they're exposed via a hashset that is case-sensitive. This means that in some cases, for eg when the environment variable is named `Path`, setting `PATH=something` causes an additional `PATH` env var to be created, and the actual original environment variable `Path` that the system reads is not updated. WTF.

This change looks up environment variables by a case insensitive search. It might fix #1044, since that problem is being caused by the wrong git being used in some operations, so I'm going to take a wild guess that maybe in those cases the wrong environment variable is getting read.