### PR TITLE
Show staged status of files, and don't commit any files that aren't checked

### DIFF
--- a/src/GitHub.Api/Git/TreeData.cs
+++ b/src/GitHub.Api/Git/TreeData.cs
@@ -7,6 +7,7 @@ namespace GitHub.Unity
     {
         string Path { get; }
         bool IsActive { get; }
+        bool IsChecked { get; }
     }
 
     [Serializable]
@@ -64,6 +65,7 @@ namespace GitHub.Unity
 
         public string Path => GitBranch.Name;
         public bool IsActive => isActive;
+        public bool IsChecked => false;
     }
 
     [Serializable]
@@ -73,11 +75,13 @@ namespace GitHub.Unity
 
         public GitStatusEntry gitStatusEntry;
         public bool isLocked;
+        public bool isChecked;
 
         public GitStatusEntryTreeData(GitStatusEntry gitStatusEntry, bool isLocked = false)
         {
             this.isLocked = isLocked;
             this.gitStatusEntry = gitStatusEntry;
+            isChecked = gitStatusEntry.Staged;
         }
 
         public override int GetHashCode()
@@ -127,5 +131,6 @@ namespace GitHub.Unity
         public GitStatusEntry GitStatusEntry => gitStatusEntry;
         public GitFileStatus FileStatus => gitStatusEntry.Status;
         public bool IsLocked => isLocked;
+        public bool IsChecked => isChecked;
     }
 }

--- a/src/GitHub.Api/UI/TreeBase.cs
+++ b/src/GitHub.Api/UI/TreeBase.cs
@@ -118,7 +118,7 @@ namespace GitHub.Unity
                         {
                             isActive = treeData.IsActive;
                             treeNodeTreeData = treeData;
-                            isChecked = isCheckable && checkedFiles.Contains(nodePath);
+                            isChecked = isCheckable && (checkedFiles.Contains(nodePath) || treeData.IsChecked);
                         }
 
                         isSelected = selectedNodePath != null && nodePath == selectedNodePath;

--- a/src/tests/UnitTests/UI/TreeBaseTests.cs
+++ b/src/tests/UnitTests/UI/TreeBaseTests.cs
@@ -35,6 +35,7 @@ namespace UnitTests
 
         public string Path { get; set; }
         public bool IsActive { get; set; }
+        public bool IsChecked { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
If a file is staged outside of Unity, this makes sure the check box is checked automatically when listing changed files. If the user unchecks a file that has been staged for commit outside of Unity, we remove the file from the index right before commiting all the (other) checked files, to make sure WICIWIC (What Is Checked Is What Is Commited)