### PR TITLE
Show error when failed to switch branches

### DIFF
--- a/src/GitHub.Api/Localization.Designer.cs
+++ b/src/GitHub.Api/Localization.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub.Unity {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Localization {
@@ -619,7 +619,7 @@ namespace GitHub.Unity {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ok.
+        ///   Looks up a localized string similar to OK.
         /// </summary>
         public static string Ok {
             get {
@@ -880,7 +880,7 @@ namespace GitHub.Unity {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not switch to branch {0}.
+        ///   Looks up a localized string similar to Could not switch to branch {0}, reason: {1}.
         /// </summary>
         public static string SwitchBranchFailedDescription {
             get {

--- a/src/GitHub.Api/Localization.resx
+++ b/src/GitHub.Api/Localization.resx
@@ -286,7 +286,7 @@
     <value>Switch branch</value>
   </data>
   <data name="SwitchBranchFailedDescription" xml:space="preserve">
-    <value>Could not switch to branch {0}</value>
+    <value>Could not switch to branch {0}, reason: {1}</value>
   </data>
   <data name="GitLFSNotFound" xml:space="preserve">
     <value>We could not find Git in the system.</value>

--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/UI/BranchesView.cs
@@ -519,7 +519,7 @@ namespace GitHub.Unity
                         else
                         {
                             EditorUtility.DisplayDialog(Localization.SwitchBranchTitle,
-                                String.Format(Localization.SwitchBranchFailedDescription, branch), Localization.Ok);
+                                String.Format(Localization.SwitchBranchFailedDescription, branch, e.Message), Localization.Ok);
                         }
                     }).Start();
             }


### PR DESCRIPTION
### Description of the Change

Append the error message from git to the dialog message in Unity when failing to switch branches.

![unity](https://user-images.githubusercontent.com/3352626/67102053-1f721e00-f1c3-11e9-8421-98125e65aebf.PNG)

### Alternate Designs

No other alternatives were considered

### Benefits

The user now knows why switching branches failed

### Possible Drawbacks

The dialog message might become cluttered

### Applicable Issues

#846 
