### PR TITLE
Fix typo: not->now

### DIFF
--- a/docs/using/working-with-changes.md
+++ b/docs/using/working-with-changes.md
@@ -9,7 +9,7 @@ All changes made to a repository will show up under the **Changes** view.
 3. Click the button `Commit to [branch name]`.
 <img src="images/changes-view.png" alt="Changes view"/>
 
-The commit will not be shown under the **History** view. On the top bar the button `Push (1)` indicates that there is 1 commit to push.
+The commit will now be shown under the **History** view. On the top bar the button `Push (1)` indicates that there is 1 commit to push.
 
 <img src="images/post-commit-view.png" alt="Post commit view"/>
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Corrected documentation to match actual behavior. The documentation used to say that after pressing the button to commit changes, "The commit will not be shown under the History view." I've changed this to match the actual behavior that "The commit will now be shown under the History view."

### Alternate Designs

This section could have been rewritten in several different ways, but as this was a single character change and I believe what the original author intended as this is a common typo, I went with this.

### Benefits

New users will more clearly be able to understand how to use this software.

### Possible Drawbacks

I can think of no drawbacks to this change.

### Applicable Issues

I didn't find any issue associated with this and the change seemed so simple and obvious that I didn't feel it was necessary to create one.