### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ section below to understand how to contribute your feedback.
 
 This repository is LFS-enabled. To clone it, you should use a git client that supports git LFS 2.x and submodules.
 
-Please read the [How to Build](https://raw.githubusercontent.com/github-for-unity/Unity/master/docs/contributing/how-to-build.md) document for information on how to build GitHub for Unity.
+Please read the [How to Build](./docs/contributing/how-to-build.md) document for information on how to build GitHub for Unity.
 
 ### Reporting Bugs
 


### PR DESCRIPTION
### Summary

Fixes link to "How to Build" document. Previously led to the [raw](https://raw.githubusercontent.com/github-for-unity/Unity/master/docs/contributing/how-to-build.md) markdown document. Now, the link leads to the more readable version of it, rendered by Github.